### PR TITLE
Adding New Camera Speed Slider

### DIFF
--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -254,6 +254,10 @@ export class FPSCameraController implements CameraController {
         vec3.set(this.keyMovement, 0, 0, 0);
     }
 
+    public setKeyMoveSpeed(speed: number): void {
+        this.keyMoveSpeed = speed;
+    }
+
     public update(inputManager: InputManager, dt: number): boolean {
         const camera = this.camera;
         let updated = false;
@@ -264,7 +268,6 @@ export class FPSCameraController implements CameraController {
             updated = true;
         }
 
-        this.keyMoveSpeed += inputManager.dz;
         this.keyMoveSpeed = Math.max(this.keyMoveSpeed, 1);
 
         let keyMoveMult = 1;

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -215,6 +215,7 @@ export function computeScreenSpaceProjectionFromWorldSpaceAABB(screenSpaceProjec
 export interface CameraController {
     camera: Camera;
     forceUpdate: boolean;
+    setKeyMoveSpeed(speed: number): void;
     cameraUpdateForced(): void;
     update(inputManager: InputManager, dt: number): boolean;
 }
@@ -379,6 +380,9 @@ export class OrbitCameraController implements CameraController {
     }
 
     public deserialize(state: string): void {
+    }
+
+    public setKeyMoveSpeed(speed: number): void {
     }
 
     public update(inputManager: InputManager, dt: number): boolean {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1473,7 +1473,7 @@ class ViewerSettings extends Panel {
         this.camSpeedSlider = this.contents.querySelector('.CamSpeedSlider');
         this.camSpeedSlider.oninput = this.onCamSliderChange.bind(this);
         this.camSpeedSlider.value = '6'
-        addEventListener('wheel', this._onWheel.bind(this), { passive: false });
+        window.addEventListener('wheel', this._onWheel.bind(this), { passive: false });
 
         this.cameraControllerWASD = this.contents.querySelector('.CameraControllerWASD');
         this.cameraControllerWASD.onclick = () => {
@@ -1503,7 +1503,6 @@ class ViewerSettings extends Panel {
 
     private onCamSliderChange(e: UIEvent): void {
         const slider = (<HTMLInputElement> e.target);
-        const value = this._getSliderT(slider);
         this.updateCameraSpeed();
     }
 
@@ -1520,10 +1519,7 @@ class ViewerSettings extends Panel {
     }
 
     private updateCameraSpeed(): void {
-        const controller: FPSCameraController = (this.viewer.cameraController as FPSCameraController);
-        if(controller && controller.setKeyMoveSpeed) {
-            controller.setKeyMoveSpeed(Number(this.camSpeedSlider.value) * 10);
-        }
+        this.viewer.cameraController.setKeyMoveSpeed(Number(this.camSpeedSlider.value) * 10);
     }
 
     public cameraControllerSelected(cameraControllerClass: CameraControllerClass) {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1391,6 +1391,7 @@ const FRUSTUM_ICON = `<svg viewBox="0 0 100 100" height="20" fill="white"><polyg
 
 class ViewerSettings extends Panel {
     private fovSlider: HTMLInputElement;
+    private camSpeedSlider: HTMLInputElement;
     private cameraControllerWASD: HTMLElement;
     private cameraControllerOrbit: HTMLElement;
     private invertCheckbox: Checkbox;
@@ -1453,6 +1454,11 @@ class ViewerSettings extends Panel {
 <input class="Slider FoVSlider" type="range" min="1" max="100">
 </div>
 
+<div style="display: grid; grid-template-columns: 1fr 1fr; align-items: center;">
+<div class="SettingsHeader">Camera Speed</div>
+<input class="Slider CamSpeedSlider" type="range" min="0" max="100">
+</div>
+
 <div style="display: grid; grid-template-columns: 2fr 1fr 1fr; align-items: center;">
 <div class="SettingsHeader">Camera Controller</div>
 <div class="SettingsButton CameraControllerWASD">WASD</div><div class="SettingsButton CameraControllerOrbit">Orbit</div>
@@ -1463,6 +1469,11 @@ class ViewerSettings extends Panel {
         this.fovSlider = this.contents.querySelector('.FoVSlider');
         this.fovSlider.oninput = this.onFovSliderChange.bind(this);
         this.fovSlider.value = '25';
+
+        this.camSpeedSlider = this.contents.querySelector('.CamSpeedSlider');
+        this.camSpeedSlider.oninput = this.onCamSliderChange.bind(this);
+        this.camSpeedSlider.value = '6'
+        addEventListener('wheel', this._onWheel.bind(this), { passive: false });
 
         this.cameraControllerWASD = this.contents.querySelector('.CameraControllerWASD');
         this.cameraControllerWASD.onclick = () => {
@@ -1490,9 +1501,29 @@ class ViewerSettings extends Panel {
         this.viewer.fovY = value * (Math.PI * 0.995);
     }
 
+    private onCamSliderChange(e: UIEvent): void {
+        const slider = (<HTMLInputElement> e.target);
+        const value = this._getSliderT(slider);
+        this.updateCameraSpeed();
+    }
+
+    private _onWheel = (e: WheelEvent) => {
+        e.preventDefault();
+        this.camSpeedSlider.value = "" + ( Number(this.camSpeedSlider.value) - Math.sign(e.deltaY));
+        this.updateCameraSpeed();
+    };
+
     private setCameraControllerClass(cameraControllerClass: CameraControllerClass) {
         this.viewer.setCameraController(new cameraControllerClass());
         this.cameraControllerSelected(cameraControllerClass);
+        this.updateCameraSpeed();
+    }
+
+    private updateCameraSpeed(): void {
+        const controller: FPSCameraController = (this.viewer.cameraController as FPSCameraController);
+        if(controller && controller.setKeyMoveSpeed) {
+            controller.setKeyMoveSpeed(Number(this.camSpeedSlider.value) * 10);
+        }
     }
 
     public cameraControllerSelected(cameraControllerClass: CameraControllerClass) {


### PR DESCRIPTION
Adding a Camera Speed Slider to the viewer settings. I also hooked up
the slider to also update on the mouse wheel event, so that the camera
speed can still be set like it was previously, or by using this new
slider. Because of the addition of this slider, the max camera speed is
1000 normally, or 5000 if you are holding shift. Max speed could be adjusted if we want to make it higher or lower, but I felt like this was a pretty good balance.