### PR TITLE
Add support for Kingdom Hearts II Final Mix

### DIFF
--- a/src/kh2fm/map.ts
+++ b/src/kh2fm/map.ts
@@ -1,0 +1,659 @@
+import { vec2, vec3, vec4 } from "gl-matrix";
+import ArrayBufferSlice from "../ArrayBufferSlice";
+import { assert } from "../util";
+import { psmToString, gsMemoryMapReadImagePSMT8_PSMCT32, gsMemoryMapReadImagePSMT4_PSMCT32, gsMemoryMapUploadImage, GSRegisterBITBLTBUF, getGSRegisterBITBLTBUF, getGSRegisterTRXPOS, getGSRegisterTRXREG, GSRegister, GSMemoryMap, gsMemoryMapNew, GSRegisterTRXPOS, GSRegisterTRXREG, GSRegisterTEX0, GSRegisterCLAMP, getGSRegisterTEX0, getGSRegisterCLAMP, GSPixelStorageFormat, GSWrapMode, GSTextureColorComponent } from "../ps2/gs";
+
+export interface KingdomHeartsIIMap {
+    mapGroup: MapGroup;
+    sky0Group: MapGroup;
+    sky1Group: MapGroup;
+
+    // textureAnims : TextureAnim[];
+}
+
+export class MapGroup {
+    public meshes: MapMesh[] = [];
+    public textureBlocks: TextureBlock[] = [];
+    public uvScrollArray: Float32Array = new Float32Array(32);
+    // Texture index -> (TextureBlock, Texture)
+    public textureIndexMap: Map<number, [TextureBlock, Texture]> = new Map;
+}
+
+export class MapMesh {
+    public textureBlock: TextureBlock | null = null;
+    public texture: Texture | null = null;
+    public vtx: vec3[] = [];
+    public ind: number[] = [];
+    public vcol: vec4[] = [];
+    public uv: vec2[] = [];
+    public normal: vec3[] = [];
+    public layer = 0;
+    public translucent: boolean = false;
+    public uvScroll = vec2.fromValues(0, 0);
+}
+
+export class TextureBlock {
+    public textures: Texture[] = [];
+    public format: string;
+    public width = 0;
+    public height = 0;
+    public atlasX = 0;  // Set by renderer
+    public atlasY = 0;  // Set by renderer
+    public pixels: Uint8Array;
+}
+
+export class Texture {
+    public clipLeft = 0;
+    public clipRight = 0;
+    public clipTop = 0;
+    public clipBottom = 0;
+    public tiledU: boolean = false;
+    public tiledV: boolean = false;
+    public tex0: GSRegisterTEX0;
+    public textureAnim: TextureAnimation | null = null;
+
+    constructor(public index: number, public parent: TextureBlock) {}
+
+    public width(): number {
+        return this.clipRight - this.clipLeft + 1;
+    }
+
+    public height(): number {
+        return this.clipBottom - this.clipTop + 1;
+    }
+
+    public pixels(): Uint8Array {
+        if (!this.parent || !this.parent.pixels || this.parent.pixels.length === 0) {
+            return null;
+        }
+        const width = this.clipRight - this.clipLeft + 1;
+        const height = this.clipBottom - this.clipTop + 1;
+        if (width === this.parent.width && height === this.parent.height) {
+            return new Uint8Array(this.parent.pixels);
+        }
+        let clipped = new Uint8Array(width * height * 4);
+        for (let y = 0; y < height; y++) {
+            const src = ((y + this.clipTop) * this.parent.width + this.clipLeft) * 4;
+            const dst = y * width * 4;
+            clipped.set(this.parent.pixels.slice(src, src + width * 4), dst);
+        }
+        return clipped;
+    }
+}
+
+interface TextureAnimationFrame {
+    spriteIndex: number;
+    minLength: number;
+    maxLength: number;
+}
+
+export class TextureAnimation {
+    public sheetWidth: number;
+    public sheetHeight: number;
+    public pixels: Uint8Array;
+    public frames: TextureAnimationFrame[] = [];
+    public index: number = 0;  // Set by renderer
+
+    private spritesPerRow: number;
+    private spriteIndex = 0;
+
+    private frameIndex = 0;
+    private frameTimer = 0;
+
+    constructor(public spriteWidth: number, public spriteHeight: number, public spriteOffsetX: number, public spriteOffsetY: number, public numSprites: number) {
+        this.spritesPerRow = Math.ceil(Math.sqrt(numSprites));
+        this.sheetWidth = this.spritesPerRow * spriteWidth;
+        this.sheetHeight = Math.ceil(numSprites / this.spritesPerRow) * spriteHeight;
+        this.pixels = new Uint8Array(this.sheetWidth * this.sheetHeight * 4);
+    }
+
+    public addSprite(srcPixels: Uint8Array, srcX: number, srcY: number, srcWidth: number) {
+        assert(this.spriteIndex < this.numSprites, `Unexpected number of sprites added to TEXA: ${this.spriteIndex}`);
+        const dstX = (this.spriteIndex % this.spritesPerRow) * this.spriteWidth;
+        const dstY = Math.floor(this.spriteIndex / this.spritesPerRow) * this.spriteHeight;
+        for (let y = 0; y < this.spriteHeight; y++) {
+            for (let x = 0; x < this.spriteWidth; x++) {
+                const dstOffs = ((y + dstY) * this.sheetWidth + x + dstX) * 4;
+                const srcOffs = ((y + srcY) * srcWidth + x + srcX) * 4;
+                this.pixels[dstOffs] = srcPixels[srcOffs];
+                this.pixels[dstOffs + 1] = srcPixels[srcOffs + 1];
+                this.pixels[dstOffs + 2] = srcPixels[srcOffs + 2];
+                this.pixels[dstOffs + 3] = srcPixels[srcOffs + 3];
+            }
+        }
+        this.spriteIndex++;
+    }
+
+    public advanceTime(deltaTime: number) {
+        if (this.frames.length === 0) {
+            return;
+        }
+        this.frameTimer -= deltaTime / 1000;
+        if (this.frameTimer > 0) {
+            return;
+        }
+        this.frameIndex = (this.frameIndex + 1) % this.frames.length;
+        const minTime = this.frames[this.frameIndex].minLength / 60;
+        const maxTime = this.frames[this.frameIndex].maxLength / 60;
+        this.frameTimer += Math.random() * (maxTime - minTime) + minTime;
+    }
+
+    public fillUVOffset(uvOffset: vec2) {
+        if (this.frames.length === 0) {
+            return;
+        }
+        uvOffset[0] = (this.frames[this.frameIndex].spriteIndex % this.spritesPerRow) / this.spritesPerRow;
+        uvOffset[1] = Math.floor(this.frames[this.frameIndex].spriteIndex / this.spritesPerRow) * this.spriteHeight / this.sheetHeight;
+    }
+}
+
+class BarFileset {
+    public mapGeometry: BarFile;
+    public mapTextures: BarFile;
+    public sky0Geometry: BarFile;
+    public sky0Textures: BarFile;
+    public sky1Geometry: BarFile;
+    public sky1Textures: BarFile;
+    public mapDoct: BarFile;
+
+    public addFile(barFile: BarFile) {
+        if (barFile.filename === 0x50414D) {  // MAP
+            if (barFile.type === 0x4) {
+                this.mapGeometry = barFile;
+            } else if (barFile.type === 0x7) {
+                this.mapTextures = barFile;
+            }
+        } else if (barFile.filename === 0x304B53) {  // SK0
+            if (barFile.type === 0x4) {
+                this.sky0Geometry = barFile;
+            } else if (barFile.type === 0x7) {
+                this.sky0Textures = barFile;
+            }
+        } else if (barFile.filename === 0x314B53) {  // SK1
+            if (barFile.type === 0x4) {
+                this.sky1Geometry = barFile;
+            } else if (barFile.type === 0x7) {
+                this.sky1Textures = barFile;
+            }
+        } else if (barFile.type === 0x5) {
+            this.mapDoct = barFile;
+        }
+    }
+}
+
+interface BarFile {
+    type: number,
+    filename: number,
+    offset: number,
+    bytesize: number
+}
+
+export function parseMap(buffer: ArrayBufferSlice): KingdomHeartsIIMap {
+    if (buffer.byteLength < 0x80) {
+        return null;
+    }
+    const view = buffer.createDataView();
+
+    // Parse files in BAR header.
+    const numFiles = view.getUint32(0x4, true);
+    const barFileset = new BarFileset;
+    for (let i = 0; i < numFiles; i++) {
+        barFileset.addFile({
+            type: view.getUint32(i * 0x10 + 0x10, true),
+            filename: view.getUint32(i * 0x10 + 0x14, true),
+            offset: view.getUint32(i * 0x10 + 0x18, true),
+            bytesize: view.getUint32(i * 0x10 + 0x1C, true)
+        })
+    }
+
+    const gsMemoryMap: GSMemoryMap = gsMemoryMapNew();
+    let mapGroup = new MapGroup;
+    let sky0Group = new MapGroup;
+    let sky1Group = new MapGroup;
+    if (barFileset.mapGeometry && barFileset.mapTextures) {
+        parseMapGroup(buffer, barFileset.mapGeometry, barFileset.mapTextures, gsMemoryMap, mapGroup);
+        if (barFileset.mapDoct) {
+            parseDOCT(buffer, barFileset.mapDoct, barFileset.mapGeometry, mapGroup);
+        }
+    }
+    if (barFileset.sky0Geometry && barFileset.sky0Textures) {
+        parseMapGroup(buffer, barFileset.sky0Geometry, barFileset.sky0Textures, gsMemoryMap,sky0Group);
+    }
+    if (barFileset.sky1Geometry && barFileset.sky1Textures) {
+        parseMapGroup(buffer, barFileset.sky1Geometry, barFileset.sky1Textures, gsMemoryMap, sky1Group);
+    }
+    return {mapGroup, sky0Group, sky1Group};
+}
+
+function parseMapGroup(buffer: ArrayBufferSlice, geometryFile: BarFile, textureFile: BarFile, gsMemoryMap: GSMemoryMap, mapGroup: MapGroup) {
+    parseTextures(buffer, textureFile, gsMemoryMap, mapGroup);
+    parseTextureAnimTags(buffer, textureFile, gsMemoryMap, mapGroup);
+    parseGeometry(buffer, geometryFile, mapGroup);
+}
+
+function parseTextures(buffer: ArrayBufferSlice, textureFile: BarFile, gsMemoryMap: GSMemoryMap, mapGroup: MapGroup) {
+    const view = buffer.createDataView(textureFile.offset);
+
+    // Texture Block index -> [Texture index]
+    const textureBlockMap: Map<number, Array<number>> = new Map;
+    const numTextureBlocks = view.getUint32(0x08, true);
+    const numTextures = view.getUint32(0x0C, true);
+    const textureToBlockTableOffset = view.getUint32(0x10, true);
+
+    // Reserve first entry in block map for CLUT (first image transfer).
+    for (let i = 0; i < numTextureBlocks + 1; i++) {
+        textureBlockMap.set(i, []);
+    }
+    for (let i = 0; i < numTextures; i++) {
+        const blockIndex = view.getUint8(textureToBlockTableOffset + i) + 1;
+        textureBlockMap.get(blockIndex).push(i);
+    }
+
+    const gsWriteTableOffs = view.getUint32(0x14, true);
+    const gsReadTableOffs = view.getUint32(0x18, true);
+    for (const kv of textureBlockMap.entries()) {
+        const blockIndex = kv[0];
+        const blockOffs = gsWriteTableOffs + blockIndex * 0x90;
+        processTextureUpload(buffer, blockOffs, gsMemoryMap, textureFile);
+
+        let textureBlock: TextureBlock = null;
+        for (const textureIndex of kv[1]) {
+            const textureOffs = gsReadTableOffs + textureIndex * 0xA0;
+            // Parse GIFtag and GS data minimally for image read.
+            const nloop = view.getUint32(textureOffs + 0x10, true) & 0x3FFF;
+            const reg = view.getUint8(textureOffs + 0x18);
+            assert(nloop === 0x7, "Expected GIFtag with nloop 7 for texture read");
+            assert(reg === 0xE, "Expected A+E register in GIFtag for texture read");
+            let tex0: GSRegisterTEX0;
+            let clamp: GSRegisterCLAMP;
+            for (let i = 0; i < nloop; i++) {
+                const dataLower = view.getUint32(textureOffs + 0x10 * i + 0x20, true);
+                const dataUpper = view.getUint32(textureOffs + 0x10 * i + 0x24, true);
+                const gsReg = view.getUint8(textureOffs + 0x10 * i + 0x28);
+                if (gsReg === GSRegister.TEX0_1) {
+                    tex0 = getGSRegisterTEX0(dataLower, dataUpper);
+                } else if (gsReg === GSRegister.CLAMP_1) {
+                    clamp = getGSRegisterCLAMP(dataLower, dataUpper);
+                }
+            }
+            if (!textureBlock) {
+                textureBlock = new TextureBlock;
+                textureBlock.format = psmToString(tex0.psm);
+                textureBlock.width = 1 << tex0.tw;
+                textureBlock.height = 1 << tex0.th;
+                textureBlock.pixels = new Uint8Array(textureBlock.width * textureBlock.height * 4);
+                mapGroup.textureBlocks.push(textureBlock);
+            }
+            const texture = new Texture(textureIndex, textureBlock);
+            if (clamp.wms === GSWrapMode.REGION_REPEAT) {
+                texture.tiledU = true;
+                texture.clipLeft = clamp.maxu;
+                texture.clipRight = clamp.minu;
+            } else {
+                texture.clipLeft = clamp.minu;
+                texture.clipRight = clamp.maxu;
+            }
+            if (clamp.wmt === GSWrapMode.REGION_REPEAT) {
+                texture.tiledV = true;
+                texture.clipTop = clamp.maxv;
+                texture.clipBottom = clamp.minv;
+            } else {
+                texture.clipTop = clamp.minv;
+                texture.clipBottom = clamp.maxv;
+            }
+            textureBlock.textures.push(texture);
+            const pixels = new Uint8Array(textureBlock.pixels.length);
+            const alphaReg = tex0.tcc === GSTextureColorComponent.RGBA ? -1 : 0x80;
+            if (tex0.psm === GSPixelStorageFormat.PSMT8) {
+                gsMemoryMapReadImagePSMT8_PSMCT32(pixels, gsMemoryMap, tex0.tbp0, tex0.tbw, textureBlock.width, textureBlock.height, tex0.cbp, alphaReg);
+            } else if (tex0.psm === GSPixelStorageFormat.PSMT4) {
+                gsMemoryMapReadImagePSMT4_PSMCT32(pixels, gsMemoryMap, tex0.tbp0, tex0.tbw, textureBlock.width, textureBlock.height, tex0.cbp, tex0.csa, alphaReg);
+            }
+            texture.tex0 = tex0;
+            for (let y = texture.clipTop; y <= texture.clipBottom; y++) {
+                for (let x = texture.clipLeft; x <= texture.clipRight; x++) {
+                    const offs = (y * textureBlock.width + x) * 4;
+                    textureBlock.pixels[offs] = pixels[offs];
+                    textureBlock.pixels[offs + 1] = pixels[offs + 1];
+                    textureBlock.pixels[offs + 2] = pixels[offs + 2];
+                    textureBlock.pixels[offs + 3] = pixels[offs + 3];
+                }
+            }
+            mapGroup.textureIndexMap.set(textureIndex, [textureBlock, texture]);
+        }
+    }
+}
+
+function processTextureUpload(buffer: ArrayBufferSlice, offs: number, gsMemoryMap: GSMemoryMap, textureFile: BarFile) {
+    const view = buffer.createDataView(textureFile.offset);
+
+    // Parse GIFtags and GS data minimally for image upload.
+    const nloop = view.getUint32(offs + 0x10, true) & 0x3FFF;
+    const reg = view.getUint8(offs + 0x18);
+    assert(nloop === 0x4, "Expected GIFtag with nloop 4 for texture upload");
+    assert(reg === 0xE, "Expected A+E register in GIFtag for texture upload");
+    let bitbltbuf: GSRegisterBITBLTBUF;
+    let trxpos: GSRegisterTRXPOS;
+    let trxreg: GSRegisterTRXREG;
+    for (let i = 0; i < nloop; i++) {
+        const dataLower = view.getUint32(offs + 0x10 * i + 0x20, true);
+        const dataUpper = view.getUint32(offs + 0x10 * i + 0x24, true);
+        const gsReg = view.getUint8(offs + 0x10 * i + 0x28);
+        if (gsReg === GSRegister.BITBLTBUF) {
+            bitbltbuf = getGSRegisterBITBLTBUF(dataLower, dataUpper);
+        } else if (gsReg === GSRegister.TRXPOS) {
+            trxpos = getGSRegisterTRXPOS(dataLower, dataUpper);
+        } else if (gsReg === GSRegister.TRXREG) {
+            trxreg = getGSRegisterTRXREG(dataLower, dataUpper);
+        }
+    }
+    const imageOffs = textureFile.offset + view.getUint32(offs + 0x74, true);
+    let imageBytesize = (view.getUint32(offs + 0x70, true) & 0xFFFFFFF) * 0x10;
+    if (imageOffs + imageBytesize > buffer.byteLength) {
+        // Maps gm03.map, gm05.map, and gm08.map specify IMAGE transfers that overflow the map file.
+        const fillBuffer: Uint8Array = new Uint8Array(imageBytesize);
+        fillBuffer.set(buffer.createTypedArray(Uint8Array, imageOffs));
+        gsMemoryMapUploadImage(gsMemoryMap, bitbltbuf.dpsm, bitbltbuf.dbp, bitbltbuf.dbw, trxpos.dsax, trxpos.dsay, trxreg.rrw, trxreg.rrh, new ArrayBufferSlice(fillBuffer.buffer));
+        return;
+    }
+    gsMemoryMapUploadImage(gsMemoryMap, bitbltbuf.dpsm, bitbltbuf.dbp, bitbltbuf.dbw, trxpos.dsax, trxpos.dsay, trxreg.rrw, trxreg.rrh, buffer.subarray(imageOffs, imageBytesize));
+}
+
+function parseTextureAnimTags(buffer: ArrayBufferSlice, textureFile: BarFile, gsMemoryMap: GSMemoryMap, mapGroup: MapGroup) {
+    const view = buffer.createDataView(textureFile.offset);
+
+    let offs = view.getUint32(0x4, true) * 4 + view.getUint32(0x20, true);
+    while (offs < textureFile.bytesize) {
+        const tag = view.getUint32(offs, true);
+        const size = view.getUint32(offs + 4, true);
+        switch (tag) {
+            case 0x43535655: {  // UVSC
+                const index = view.getUint32(offs + 0x8, true);
+                mapGroup.uvScrollArray[index * 2] = view.getFloat32(offs + 0xC, true);
+                mapGroup.uvScrollArray[index * 2 + 1] = view.getFloat32(offs + 0x10, true);
+                break;
+            }
+            case 0x41584554: {  // TEXA
+                parseTextureAnimation(buffer, textureFile.offset + offs + 0x8, gsMemoryMap, mapGroup);
+                break;
+            }
+            case 0x594D445F:  // _DMY
+                break;
+            case 0x354E4B5F:  // _KN5
+                break;  // Done
+            default:
+                console.error(`Unknown texture data tag ${tag.toString(16)} at offset ${textureFile.offset + offs.toString(16)}`);
+                return;
+        }
+        offs += size + 0x8;
+    }
+}
+
+function parseTextureAnimation(buffer: ArrayBufferSlice, offs: number, gsMemoryMap: GSMemoryMap, mapGroup: MapGroup) {
+    const view = buffer.createDataView(offs);
+
+    const textureIndex = view.getUint16(0x2, true);
+    assert(mapGroup.textureIndexMap.has(textureIndex), `Failed to parse TEXA block due to missing texture index ${textureIndex}`);
+    const textureBlock = mapGroup.textureIndexMap.get(textureIndex)[0];
+    const texture = mapGroup.textureIndexMap.get(textureIndex)[1];
+    const numSprites = view.getUint16(0xE, true);
+    const dsax = view.getUint16(0x10, true);
+    const dsay = view.getUint16(0x12, true);
+    const rrw = view.getUint16(0x14, true);
+    const rrh = view.getUint16(0x16, true);
+    const unk = view.getUint16(0x0, true) * 0x100;
+    texture.textureAnim = new TextureAnimation(texture.width(), texture.height(), dsax, dsay, numSprites + 1);
+
+    // First sprite in the sheet is the original clipped texture.
+    texture.textureAnim.addSprite(textureBlock.pixels, texture.clipLeft, texture.clipTop, textureBlock.width);
+
+    const tex0: GSRegisterTEX0 = texture.tex0;
+    const spriteDataOffset = view.getUint32(0x20, true);
+    let spriteBytesize = rrw * rrh;
+    if (tex0.psm === GSPixelStorageFormat.PSMT4) {
+        spriteBytesize /= 2;
+    }
+    const alphaReg = tex0.tcc === GSTextureColorComponent.RGBA ? -1 : 0x80;
+    for (let i = 0; i < numSprites; i++) {
+        gsMemoryMapUploadImage(gsMemoryMap, tex0.psm, tex0.tbp0, tex0.tbw, dsax, dsay, rrw, rrh, buffer.subarray(offs + spriteDataOffset + i * spriteBytesize, spriteBytesize));
+        const pixels = new Uint8Array(textureBlock.width * textureBlock.height * 4);
+        if (tex0.psm === GSPixelStorageFormat.PSMT8) {
+            gsMemoryMapReadImagePSMT8_PSMCT32(pixels, gsMemoryMap, tex0.tbp0, tex0.tbw, textureBlock.width, textureBlock.height, tex0.cbp, alphaReg);
+        } else if (tex0.psm === GSPixelStorageFormat.PSMT4) {
+            gsMemoryMapReadImagePSMT4_PSMCT32(pixels, gsMemoryMap, tex0.tbp0, tex0.tbw, textureBlock.width, textureBlock.height, tex0.cbp, tex0.csa, alphaReg);
+        }
+        texture.textureAnim.addSprite(pixels, texture.clipLeft, texture.clipTop, textureBlock.width);
+    }
+
+    let frameOffs = view.getUint32(0x1C, true) + 0x4;
+    while (frameOffs < spriteDataOffset) {
+        const control = view.getInt16(frameOffs, true);
+        if (control < 0) {
+            break;
+        }
+        const minLength = view.getUint16(frameOffs + 0x2, true);
+        const maxLength = view.getUint16(frameOffs + 0x4, true);
+        const spriteIndex = view.getUint16(frameOffs + 0x6, true);
+        texture.textureAnim.frames.push({minLength, maxLength, spriteIndex: control > 0 ? 0 : spriteIndex + 1});
+        frameOffs += 0x8;
+    }
+}
+
+function parseGeometry(buffer: ArrayBufferSlice, geometryFile: BarFile, mapGroup: MapGroup) {
+    const view = buffer.createDataView(geometryFile.offset + 0x90);
+    const meshCount = view.getUint32(0x10, true);
+    for (let i = 0; i < meshCount; i++) {
+        const mesh = new MapMesh;
+        const offs = view.getUint32(i * 0x10 + 0x20, true);
+        const textureIndex = view.getUint16(i * 0x10 + 0x24, true);
+        if (mapGroup.textureIndexMap.has(textureIndex)) {
+            mesh.textureBlock = mapGroup.textureIndexMap.get(textureIndex)[0];
+            mesh.texture = mapGroup.textureIndexMap.get(textureIndex)[1];
+        }
+        mesh.translucent = view.getUint16(i * 0x10 + 0x2A, true) === 0x1;
+        const uvScrollIndex = (view.getUint16(i * 0x10 + 0x2C, true) >> 1) & 0xF;
+        if (uvScrollIndex > 0 && (mesh.texture.tiledU || mesh.texture.tiledV)) {
+            mesh.uvScroll = vec2.fromValues(
+                mapGroup.uvScrollArray[(uvScrollIndex - 1) * 2],
+                mapGroup.uvScrollArray[(uvScrollIndex - 1) * 2 + 1]
+            );
+        }
+        parseGeometryMesh(view, offs, mesh);
+        mapGroup.meshes.push(mesh);
+    }
+}
+
+class VUState {
+    public static a_modelType = 0x0;
+    public static a_uvIndFlagsCount = 0x4;
+    public static a_uvIndFlagsAddr = 0x5;
+    public static a_vertexColorCount = 0x8;
+    public static a_vertexColorAddr = 0x9;
+    public static a_vertexCount = 0xC;
+    public static a_vertexAddr = 0xD;
+    public static a_vertexNormalCount = 0x10;
+    public static a_vertexNormalAddr = 0x11;
+
+    public mask = 0;
+    public header: Uint32Array = new Uint32Array(20);
+
+    public flg: Uint8Array | null = null;
+    public ind: Uint8Array | null = null;
+
+    public reset() {
+        this.mask = 0;
+        this.header.fill(0);
+        this.flg = null;
+        this.ind = null;
+    }
+}
+
+function parseGeometryMesh(view: DataView, startOffset: number, mesh: MapMesh) {
+    // Parse VIF commands at a high level, extracting only the required vertex data
+    // directly from UNPACK commands. This reduces overall complexity of the parser
+    // since there is no need to accurately simulate VU memory to obtain this data.
+    let offs = startOffset;
+    let vuState = new VUState;
+    while (offs < view.byteLength) {
+        const imm = view.getUint16(offs, true);
+        const qwd = view.getUint8(offs + 0x2);
+        const cmd = view.getUint8(offs + 0x3) & 0x7F;
+        offs += 0x4;
+
+        if (cmd >> 5 === 0b11) {  // UNPACK
+            if (cmd === 0x60) {
+                break;  // Done
+            }
+            offs += handleVifUnpack(view, offs, imm, qwd, cmd, vuState, mesh);
+            continue;
+        }
+        switch (cmd) {
+            case 0b00100000:  // STMASK
+                vuState.mask = view.getUint32(offs, true);
+                offs += 0x4;
+                break;
+            case 0b00010111:  // MSCNT
+                vuState.reset();
+                break;
+            case 0b00110001:  // STCOL
+                // Used only to fill w = 1.0 for each vertex position
+                offs += 0x10;
+                break;
+            case 0b00000000:  // NOP
+            case 0b00000001:  // STCYCLE
+            case 0b00010000:  // FLUSHE
+            case 0b00010001:  // FLUSH
+            case 0b00010011:  // FLUSHA
+                break;
+            default:
+                console.error(`VIF parse error: Unhandled command ${cmd.toString(16)} at offset ${offs.toString(16)}`);
+                return;
+        }
+    }
+}
+
+function handleVifUnpack(view: DataView, offs: number, imm: number, qwd: number, cmd: number, vuState: VUState, mesh: MapMesh): number {
+    const m: boolean = (cmd & 0x10) > 0;
+    const addr = imm & 0x1FF;
+    const vnvl = cmd & 0xF;
+    switch (vnvl) {
+        case 0b1100: {  // V4-32
+            if (addr === 0 && !m) {
+                // Header
+                for (let i = 0; i < qwd * 0x4; i++) {
+                    vuState.header[i] = view.getUint32(offs + i * 0x4, true);
+                }
+            }
+            return qwd * 0x10;
+        }
+        case 0b1000: {  // V3-32
+            if (addr === vuState.header[VUState.a_vertexAddr] && m) {
+                handleVifUnpackVertexData(view, offs, vuState, mesh);
+            } else if (addr === vuState.header[VUState.a_vertexNormalAddr] && m) {
+                for (let i = 0; i < vuState.header[VUState.a_vertexNormalCount]; i++) {
+                    mesh.normal.push(vec3.fromValues(
+                        view.getFloat32(offs + i * 0xC, true),        // nx
+                        view.getFloat32(offs + i * 0xC + 0x4, true),  // ny
+                        view.getFloat32(offs + i * 0xC + 0x8, true)   // nz
+                    ));
+                }
+            }
+            return qwd * 0xC;
+        }
+        case 0b0010: {  // S-8
+            if (addr === vuState.header[VUState.a_uvIndFlagsAddr] && m) {
+                if (vuState.mask === 0xCFCFCFCF) {
+                    vuState.ind = new Uint8Array(qwd);
+                    for (let i = 0; i < qwd; i++) {
+                        vuState.ind[i] = view.getUint8(offs + i);
+                    }
+                } else if (vuState.mask === 0x3F3F3F3F) {
+                    vuState.flg = new Uint8Array(qwd);
+                    for (let i = 0; i < qwd; i++) {
+                        vuState.flg[i] = view.getUint8(offs + i);
+                    }
+                }
+            }
+            return Math.ceil(qwd / 4) * 0x4;
+        }
+        case 0b0101: {  // V2-16
+            if (addr === vuState.header[VUState.a_uvIndFlagsAddr] && !m) {
+                for (let i = 0; i < vuState.header[VUState.a_uvIndFlagsCount]; i++) {
+                    mesh.uv.push(vec2.fromValues(
+                        view.getInt16(offs + i * 0x4, true) / 4096,       // tu
+                        view.getInt16(offs + i * 0x4 + 0x2, true) / 4096  // tv
+                    ));
+                }
+            }
+            return qwd * 0x4;
+        }
+        case 0b1110: {  // V4-8
+            if (addr === vuState.header[VUState.a_vertexColorAddr]) {
+                for (let i = 0; i < vuState.header[VUState.a_vertexColorCount]; i++) {
+                    mesh.vcol.push(vec4.fromValues(
+                        view.getUint8(offs + i * 0x4) / 256,        // cr
+                        view.getUint8(offs + i * 0x4 + 0x1) / 256,  // cg
+                        view.getUint8(offs + i * 0x4 + 0x2) / 256,  // cb
+                        view.getUint8(offs + i * 0x4 + 0x3) / 128   // ca
+                    ));
+                }
+            }
+            return qwd * 0x4;
+        }
+        case 0b000:
+            break;
+        default:
+            console.error(`VIF parse error: Unhandled UNPACK vn/vl ${vnvl.toString(16)} at offset ${offs.toString(16)}`);
+    }
+    return qwd * 0x10;
+}
+
+function handleVifUnpackVertexData(view: DataView, offs: number, vuState: VUState, mesh: MapMesh) {
+    if (!vuState.ind || !vuState.flg) {
+        return;
+    }
+    const indStart = mesh.vtx.length;
+    for (let i = 0; i < vuState.header[VUState.a_uvIndFlagsCount]; i++) {
+        mesh.vtx.push(vec3.fromValues(
+            view.getFloat32(offs + vuState.ind[i] * 0xC, true),          // vx
+            view.getFloat32(offs + vuState.ind[i] * 0xC + 0x4, true),    // vy
+            view.getFloat32(offs + vuState.ind[i] * 0xC + 0x8, true)));  // vz
+        const f = vuState.flg[i] & 0x30;
+        if (f != 0x10) {
+            if (f === 0x20 || f === 0x0) {
+                mesh.ind.push(indStart + i - 2);  // t0
+                mesh.ind.push(indStart + i - 1);  // t1
+                mesh.ind.push(indStart + i);      // t2
+            }
+            if (f === 0x30 || f === 0x0) {
+                mesh.ind.push(indStart + i);      // t0
+                mesh.ind.push(indStart + i - 1);  // t1
+                mesh.ind.push(indStart + i - 2);  // t2
+            }
+        }
+    }
+}
+
+function parseDOCT(buffer: ArrayBufferSlice, doctFile: BarFile, geometryFile: BarFile, mapGroup: MapGroup) {
+    const geometryView = buffer.createDataView(geometryFile.offset + 0x90);
+    const doctView = buffer.createDataView(doctFile.offset);
+
+    const groupCount = geometryView.getUint16(0x16, true);
+    const groupTableOffset = geometryView.getUint32(0x18, true);
+    const metadataTableOffset = doctView.getUint32(0x1C, true);
+    for (let group = 0; group < groupCount; group++) {
+        const layer = doctView.getUint32(metadataTableOffset + group * 0x1C, true);
+        const groupOffset = geometryView.getUint32(groupTableOffset + group * 0x4, true);
+        let groupIndex = 0;
+        while (true) {
+            const meshIndex = geometryView.getUint16(groupOffset + groupIndex * 2, true);
+            if (meshIndex === 0xFFFF) {
+                break;
+            }
+            if (meshIndex < mapGroup.meshes.length) {
+                mapGroup.meshes[meshIndex].layer = layer;
+            }
+            groupIndex++;
+        }
+    }
+}

--- a/src/kh2fm/program.glsl
+++ b/src/kh2fm/program.glsl
@@ -1,0 +1,70 @@
+precision mediump float;
+
+// Expected to be constant across the entire scene.
+layout(row_major, std140) uniform ub_SceneParams {
+    Mat4x4 u_Projection;
+    float u_Time;
+};
+
+layout(row_major, std140) uniform ub_DrawParams {
+    Mat4x4 u_Model;
+    Mat4x3 u_View;
+    vec4 u_AnimOffset;
+};
+
+uniform sampler2D u_Texture;
+
+varying vec4 v_Color;
+varying vec2 v_TexCoord;
+varying vec4 v_TexClip;
+varying vec2 v_TexRepeat;
+varying vec4 v_TexScaleOffset;
+varying vec2 v_TexScroll;
+
+#ifdef VERT
+layout(location = 0) in vec3 a_Position;
+layout(location = 1) in vec4 a_Color;
+layout(location = 2) in vec2 a_TexCoord;
+layout(location = 3) in vec4 a_TexClip;
+layout(location = 4) in vec2 a_TexRepeat;
+layout(location = 5) in vec4 a_TexScaleOffset;
+layout(location = 6) in vec2 a_TexScroll;
+
+void main() {
+    gl_Position = Mul(u_Projection, Mul(_Mat4x4(u_View), Mul(u_Model, vec4(a_Position, 1.0))));
+    v_Color = a_Color;
+    v_TexCoord = a_TexCoord;
+    v_TexClip = a_TexClip;
+    v_TexRepeat = a_TexRepeat;
+    v_TexScaleOffset = a_TexScaleOffset;
+    v_TexScroll = a_TexScroll;
+}
+#endif
+
+#ifdef FRAG
+void main() {
+    vec4 t_Color = vec4(0.5, 0.5, 0.5, 1);
+
+#ifdef USE_TEXTURE
+    vec2 tc = v_TexCoord;
+    tc += v_TexScroll * u_Time * 2e-10f;
+    tc = fract(tc * v_TexRepeat) / v_TexRepeat;
+    tc = clamp(tc, v_TexClip.xz, v_TexClip.yw);
+    tc = tc * v_TexScaleOffset.xy + v_TexScaleOffset.zw + u_AnimOffset.xy;
+    t_Color = texture(u_Texture, tc);
+#endif
+
+#ifdef USE_VERTEX_COLOR
+    t_Color.rgb *= v_Color.rgb * 2.0f;
+    t_Color.a *= v_Color.a;
+#endif
+
+#ifdef USE_ALPHA_MASK
+    if (t_Color.a < 0.125) {
+        discard;
+    }
+#endif
+
+    gl_FragColor = t_Color;
+}
+#endif

--- a/src/kh2fm/render.ts
+++ b/src/kh2fm/render.ts
@@ -1,0 +1,673 @@
+import * as MAP from './map';
+import * as UI from '../ui';
+import * as Viewer from '../viewer';
+
+// @ts-ignore
+import { readFileSync } from 'fs';
+import { DeviceProgram } from "../Program";
+import { GfxProgram, GfxMegaStateDescriptor, GfxDevice, GfxCullMode, GfxBlendMode, GfxBlendFactor, GfxCompareMode, GfxTexture, GfxSampler, GfxBuffer, GfxBufferUsage, GfxInputLayout, GfxInputState, GfxHostAccessPass, GfxRenderPass, GfxTextureDimension, GfxFormat, GfxWrapMode, GfxTexFilterMode, GfxMipFilterMode, GfxVertexAttributeDescriptor, GfxVertexAttributeFrequency, GfxBindingLayoutDescriptor } from '../gfx/platform/GfxPlatform';
+import { mat4, vec2, vec4 } from 'gl-matrix';
+import { GfxRenderInstManager, executeOnPass } from '../gfx/render/GfxRenderer';
+import { BasicRenderTarget, transparentBlackFullClearRenderPassDescriptor } from '../gfx/helpers/RenderTargetHelpers';
+import { GfxRenderDynamicUniformBuffer } from '../gfx/render/GfxRenderDynamicUniformBuffer';
+import { TextureHolder, TextureMapping } from '../TextureHolder';
+import { reverseDepthForCompareMode } from '../gfx/helpers/ReversedDepthHelpers';
+import { nArray } from '../util';
+import { makeStaticDataBuffer } from '../gfx/helpers/BufferHelpers';
+import { fillMatrix4x4, fillMatrix4x3 } from '../gfx/helpers/UniformBufferHelpers';
+
+export function textureToCanvas(texture: MAP.Texture, baseName: string): Viewer.Texture {
+    const canvas = document.createElement("canvas");
+    const width = texture.width();
+    const height = texture.height();
+    const name = `${baseName}_tex_${("000" + texture.index).slice(-3)}`
+    canvas.width = width;
+    canvas.height = height;
+    canvas.title = name;
+
+    const context = canvas.getContext("2d");
+    const imgData = context.createImageData(canvas.width, canvas.height);
+    imgData.data.set(texture.pixels());
+    context.putImageData(imgData, 0, 0);
+    const surfaces = [canvas];
+    const extraInfo = new Map<string, string>();
+    extraInfo.set('Format', texture.parent.format);
+    return { name: name, surfaces, extraInfo };
+}
+
+export function textureAnimationToCanvas(textureAnim: MAP.TextureAnimation, parentTexture: MAP.Texture, baseName: string): Viewer.Texture {
+    const canvas = document.createElement("canvas");
+    const width = textureAnim.sheetWidth;
+    const height = textureAnim.sheetHeight;
+    const name = `${baseName}_tex_${("000" + parentTexture.index).slice(-3)}_texa`
+    canvas.width = width;
+    canvas.height = height;
+    canvas.title = name;
+
+    const context = canvas.getContext("2d");
+    const imgData = context.createImageData(canvas.width, canvas.height);
+    imgData.data.set(textureAnim.pixels);
+    context.putImageData(imgData, 0, 0);
+    const surfaces = [canvas];
+    const extraInfo = new Map<string, string>();
+    extraInfo.set('Format', parentTexture.parent.format);
+    extraInfo.set('Sprite Width', textureAnim.spriteWidth.toString());
+    extraInfo.set('Sprite Height', textureAnim.spriteHeight.toString());
+    extraInfo.set('Sprite Count', textureAnim.numSprites.toString());
+    return { name: name, surfaces, extraInfo };
+}
+
+class KingdomHeartsIIProgram extends DeviceProgram {
+    public static a_Position = 0;
+    public static a_Color = 1;
+    public static a_TexCoord = 2;
+    public static a_TexClip = 3;
+    public static a_TexRepeat = 4;
+    public static a_TexScaleOffs = 5;
+    public static a_TexScroll = 6;
+
+    public static ub_SceneParams = 0;
+    public static ub_DrawParams = 1;
+
+    private static program = readFileSync('src/kh2fm/program.glsl', { encoding: 'utf8' });
+    public both = KingdomHeartsIIProgram.program;
+}
+
+const enum RenderPass {
+    MAIN = 0x1
+}
+
+class Layer implements UI.Layer {
+    public visible: boolean = true;
+
+    constructor(public layerIndex: number, public name: string) {}
+
+    public setVisible(v: boolean) {
+        this.visible = v;
+    }
+}
+
+class DrawCall {
+    public firstIndex: number = 0;
+    public indexCount: number = 0;
+    public textureIndex: number = 0;
+    public textureAnim: MAP.TextureAnimation | null = null;
+
+    public translucent: boolean = false;
+    public cullBackfaces: boolean = true;
+    public layer: Layer | null = null;
+}
+
+const enum MeshGroup {
+    MAP = 0, SK0 = 1, SK1 = 2
+};
+
+interface MeshGroupPair {
+    mesh: MAP.MapMesh;
+    group: MeshGroup;
+};
+
+interface RenderBatchKey {
+    group: MeshGroup;
+    layerIndex: number;
+    textureIndex: number;
+};
+
+export class MapData {
+    public vertexBuffer: GfxBuffer;
+    public indexBuffer: GfxBuffer;
+    public inputLayout: GfxInputLayout;
+    public inputState: GfxInputState;
+
+    public layers: Layer[] = [];
+    public drawCalls: DrawCall[] = [];
+    public textureAnimations: MAP.TextureAnimation[] = [];
+
+    public textures: GfxTexture[] = [];
+    public sampler: GfxSampler;
+
+    private vertices = 0;
+    private indices = 0;
+    private atlasWidth = 0;
+    private atlasHeight = 0;
+
+    constructor(device: GfxDevice, map: MAP.KingdomHeartsIIMap) {
+        this.textures.push(this.buildTextureAtlas(device, map));
+        this.processTextureAnimations(device, map);
+        this.sampler = this.createSampler(device);
+
+        const meshesInDrawOrder: MAP.MapMesh[] = [];
+        this.createBatchedDrawCalls(map, meshesInDrawOrder);
+        this.buildBuffersAndInputState(device, meshesInDrawOrder);
+    }
+
+    private processTextureAnimations(device: GfxDevice, map: MAP.KingdomHeartsIIMap) {
+        let textureBlocks: MAP.TextureBlock[] = [];
+        textureBlocks = textureBlocks.concat(map.mapGroup.textureBlocks);
+        textureBlocks = textureBlocks.concat(map.sky0Group.textureBlocks);
+        textureBlocks = textureBlocks.concat(map.sky1Group.textureBlocks);
+        let index = 0;
+        for (const textureBlock of textureBlocks) {
+            for (const texture of textureBlock.textures) {
+                if (texture.textureAnim) {
+                    this.textures.push(this.translateTextureAnimation(device, texture.textureAnim));
+                    texture.textureAnim.index = index++;
+                    this.textureAnimations.push(texture.textureAnim);
+                }
+            }
+        }
+    }
+
+    private translateTextureAnimation(device: GfxDevice, textureAnim: MAP.TextureAnimation): GfxTexture {
+        const gfxTexture = device.createTexture({
+            dimension: GfxTextureDimension.n2D, pixelFormat: GfxFormat.U8_RGBA,
+            width: textureAnim.sheetWidth, height: textureAnim.sheetHeight, depth: 1, numLevels: 1
+        });
+        device.setResourceName(gfxTexture, `texa${textureAnim.index}`);
+        const hostAccessPass = device.createHostAccessPass();
+        hostAccessPass.uploadTextureData(gfxTexture, 0, [textureAnim.pixels]);
+        device.submitPass(hostAccessPass);
+        return gfxTexture;
+    }
+
+    private buildTextureAtlas(device: GfxDevice, map: MAP.KingdomHeartsIIMap): GfxTexture {
+        const textureBlocks: MAP.TextureBlock[] = [];
+        let area = 0;
+        for (const textureBlock of map.mapGroup.textureBlocks) {
+            textureBlocks.push(textureBlock);
+            area += textureBlock.width * textureBlock.height;
+        }
+        for (const textureBlock of map.sky0Group.textureBlocks) {
+            textureBlocks.push(textureBlock);
+            area += textureBlock.width * textureBlock.height;
+        }
+        for (const textureBlock of map.sky1Group.textureBlocks) {
+            textureBlocks.push(textureBlock);
+            area += textureBlock.width * textureBlock.height;
+        }
+        if (textureBlocks.length === 0) {
+            return null;
+        }
+
+        // Greedily place textures in order of decreasing height into row bins.
+        textureBlocks.sort(function(a: MAP.TextureBlock, b: MAP.TextureBlock): number {
+            if (a.height === b.height) {
+                if (a.width === b.width) {
+                    return a.textures[0].index < b.textures[0].index ? 1 : -1;
+                }
+                return a.width < b.width ? 1 : -1;
+            }
+            return a.height < b.height ? 1 : -1;
+        });
+        this.atlasWidth = Math.min(2048, 1 << Math.ceil(Math.log(Math.sqrt(area)) / Math.log(2)));
+        this.atlasHeight = textureBlocks[0].height;
+        let ax = 0;
+        let ay = 0;
+        for (const textureBlock of textureBlocks) {
+            if (textureBlock.width > this.atlasWidth - ax) {
+                ax = 0;
+                ay = this.atlasHeight;
+                this.atlasHeight += textureBlock.height;
+            }
+            textureBlock.atlasX = ax;
+            textureBlock.atlasY = ay;
+            ax += textureBlock.width;
+        }
+
+        // Finalize texture atlas after placing all textures.
+        const pixels = new Uint8Array(this.atlasWidth * this.atlasHeight * 4);
+        for (const textureBlock of textureBlocks) {
+            for (let y = 0; y < textureBlock.height; y++) {
+                for (let x = 0; x < textureBlock.width; x++) {
+                    const srcOffs = (y * textureBlock.width + x) * 4;
+                    const atlasOffs = ((y + textureBlock.atlasY) * this.atlasWidth + x + textureBlock.atlasX) * 4;
+                    pixels[atlasOffs] = textureBlock.pixels[srcOffs];
+                    pixels[atlasOffs + 1] = textureBlock.pixels[srcOffs + 1];
+                    pixels[atlasOffs + 2] = textureBlock.pixels[srcOffs + 2];
+                    pixels[atlasOffs + 3] = textureBlock.pixels[srcOffs + 3];
+                }
+            }
+        }
+        const gfxTexture = device.createTexture({
+            dimension: GfxTextureDimension.n2D, pixelFormat: GfxFormat.U8_RGBA,
+            width: this.atlasWidth, height: this.atlasHeight, depth: 1, numLevels: 1
+        });
+        device.setResourceName(gfxTexture, `textureAtlas`);
+        const hostAccessPass = device.createHostAccessPass();
+        hostAccessPass.uploadTextureData(gfxTexture, 0, [pixels]);
+        device.submitPass(hostAccessPass);
+        return gfxTexture;
+    }
+
+    private createBatchedDrawCalls(map: MAP.KingdomHeartsIIMap, meshesInDrawOrder: MAP.MapMesh[]) {
+        // Batch key -> Submesh[]
+        const opaqueMeshMap: Map<string, MAP.MapMesh[]> = new Map;
+        const translucentMeshes: Array<[string, MAP.MapMesh[]]> = [];
+
+        // Batch draw calls from all groups together since map and skyboxes will be rendered
+        // in a single pass. Rough draw order is SK0 -> SK1 -> MAP.
+        const meshPairs: MeshGroupPair[] = [];
+        for (const mesh of map.sky0Group.meshes) {
+            meshPairs.push({mesh, group: MeshGroup.SK0});
+        }
+        for (const mesh of map.sky1Group.meshes) {
+            meshPairs.push({mesh, group: MeshGroup.SK1});
+        }
+        for (const mesh of map.mapGroup.meshes) {
+            meshPairs.push({mesh, group: MeshGroup.MAP});
+        }
+
+        // Build layers for all groups.
+        // "<group>_<layerIndex>" -> Layer object
+        const layerMap: Map<string, Layer> = this.buildLayerMap(map);
+        layerMap.forEach((layer: Layer) => {
+            this.layers.push(layer);
+        });
+        this.layers.sort((a: Layer, b: Layer) => {
+            return a.layerIndex < b.layerIndex ? -1 : 1;
+        })
+
+        // Finalize draw order of meshes and build draw calls.
+        let lastIndex = -1;
+        for (const meshPair of meshPairs) {
+            const mesh = meshPair.mesh;
+            if (mesh.textureBlock === null) {
+                continue;
+            }
+            let textureIndex = 0;  // Use atlas by default
+            if (mesh.texture.textureAnim) {
+                textureIndex = mesh.texture.textureAnim.index + 1;
+            }
+            const batchKey: RenderBatchKey = {group: meshPair.group, layerIndex: mesh.layer, textureIndex};
+            const batchKeyStr = JSON.stringify(batchKey);
+            if (!mesh.translucent) {
+                if (!opaqueMeshMap.has(batchKeyStr)) {
+                    opaqueMeshMap.set(batchKeyStr, []);
+                }
+                opaqueMeshMap.get(batchKeyStr).push(mesh);
+            } else if (lastIndex >= 0 && translucentMeshes[lastIndex][0] === batchKeyStr) {
+                translucentMeshes[lastIndex][1].push(mesh);
+            } else {
+                translucentMeshes.push([batchKeyStr, [mesh]])
+                lastIndex++;
+            }
+        }
+        opaqueMeshMap.forEach((value: MAP.MapMesh[], key: string) => {
+            const batchKey: RenderBatchKey = JSON.parse(key);
+            const drawCall = this.createDrawCall(batchKey, /*translucent=*/false, layerMap);
+            drawCall.firstIndex = this.indices;
+            for (const mesh of value) {
+                meshesInDrawOrder.push(mesh);
+                this.vertices += mesh.vtx.length;
+                this.indices += mesh.ind.length;
+            }
+            drawCall.indexCount = this.indices - drawCall.firstIndex;
+            this.drawCalls.push(drawCall);
+        });
+        translucentMeshes.forEach((value: [string, MAP.MapMesh[]]) => {
+            const batchKey: RenderBatchKey = JSON.parse(value[0]);
+            const drawCall = this.createDrawCall(batchKey, /*translucent=*/true, layerMap);
+            drawCall.firstIndex = this.indices;
+            for (const mesh of value[1]) {
+                meshesInDrawOrder.push(mesh);
+                this.vertices += mesh.vtx.length;
+                this.indices += mesh.ind.length;
+            }
+            drawCall.indexCount = this.indices - drawCall.firstIndex;
+            this.drawCalls.push(drawCall);
+        });
+    }
+
+    private buildLayerMap(map: MAP.KingdomHeartsIIMap): Map<string, Layer> {
+        // "<group>_<layerIndex>" -> Layer object
+        const layerMap: Map<string, Layer> = new Map;
+        for (const mesh of map.mapGroup.meshes) {
+            if (!layerMap.has(`${MeshGroup.MAP}_${mesh.layer}`)) {
+                layerMap.set(`${MeshGroup.MAP}_${mesh.layer}`, new Layer(mesh.layer, `map_layer_${mesh.layer.toString(16)}`));
+            }
+        }
+        for (const mesh of map.sky0Group.meshes) {
+            if (!layerMap.has(`${MeshGroup.SK0}_${mesh.layer}`)) {
+                layerMap.set(`${MeshGroup.SK0}_${mesh.layer}`, new Layer(mesh.layer, `sky0_layer_${mesh.layer.toString(16)}`));
+            }
+        }
+        for (const mesh of map.sky1Group.meshes) {
+            if (!layerMap.has(`${MeshGroup.SK1}_${mesh.layer}`)) {
+                layerMap.set(`${MeshGroup.SK1}_${mesh.layer}`, new Layer(mesh.layer, `sky1_layer_${mesh.layer.toString(16)}`));
+            }
+        }
+        return layerMap;
+    }
+
+    private createDrawCall(batchKey: RenderBatchKey, translucent: boolean, layerMap: Map<string, Layer>): DrawCall {
+        const drawCall = new DrawCall;
+        if (layerMap.has(`${batchKey.group}_${batchKey.layerIndex}`)) {
+            drawCall.layer = layerMap.get(`${batchKey.group}_${batchKey.layerIndex}`);
+        }
+        drawCall.textureIndex = batchKey.textureIndex;
+        drawCall.translucent = translucent;
+        if (batchKey.textureIndex > 0) {
+            drawCall.textureAnim = this.textureAnimations[batchKey.textureIndex - 1];
+        }
+        return drawCall;
+    }
+
+    private createSampler(device: GfxDevice) {
+        return device.createSampler({
+            wrapS: GfxWrapMode.REPEAT,
+            wrapT: GfxWrapMode.REPEAT,
+            minFilter: GfxTexFilterMode.BILINEAR,
+            magFilter: GfxTexFilterMode.BILINEAR,
+            mipFilter: GfxMipFilterMode.NO_MIP,
+            minLOD: 0, maxLOD: 0,
+        });
+    }
+
+    private buildBuffersAndInputState(device: GfxDevice, meshesInDrawOrder: MAP.MapMesh[]) {
+        const vBuffer = new Float32Array(this.vertices * 21);
+        const iBuffer = new Uint32Array(this.indices);
+        let vBufferIndex = 0;
+        let iBufferIndex = 0;
+        let lastInd = 0;
+        for (const mesh of meshesInDrawOrder) {
+            if (!mesh.textureBlock) {
+                continue;
+            }
+            const texScaleOffs = vec4.create();
+            const texClip = vec4.create();
+            const texRepeat = vec2.create();
+            if (mesh.texture.textureAnim) {
+                texScaleOffs.set([
+                    mesh.textureBlock.width / mesh.texture.textureAnim.sheetWidth,
+                    mesh.textureBlock.height / mesh.texture.textureAnim.sheetHeight,
+                    -mesh.texture.clipLeft / mesh.texture.textureAnim.sheetWidth,
+                    -mesh.texture.clipTop / mesh.texture.textureAnim.sheetHeight
+                ]);
+            } else {
+                texScaleOffs.set([
+                    mesh.textureBlock.width / this.atlasWidth,
+                    mesh.textureBlock.height / this.atlasHeight,
+                    mesh.textureBlock.atlasX / this.atlasWidth,
+                    mesh.textureBlock.atlasY / this.atlasHeight
+                ]);
+            }
+            texClip.set([
+                (mesh.texture.clipLeft + 0.5) / mesh.textureBlock.width,
+                (mesh.texture.clipRight + 0.5) / mesh.textureBlock.width,
+                (mesh.texture.clipTop + 0.5) / mesh.textureBlock.height,
+                (mesh.texture.clipBottom + 0.5) / mesh.textureBlock.height
+            ]);
+            texRepeat.set([
+                mesh.texture.tiledU ? mesh.textureBlock.width / mesh.texture.width() : 0.5,
+                mesh.texture.tiledV ? mesh.textureBlock.height / mesh.texture.height() : 0.5
+            ]);
+            for (let i = 0; i < mesh.vtx.length; i++) {
+                vBuffer[vBufferIndex++] = mesh.vtx[i][0];
+                vBuffer[vBufferIndex++] = mesh.vtx[i][1];
+                vBuffer[vBufferIndex++] = mesh.vtx[i][2];
+                vBuffer[vBufferIndex++] = mesh.vcol[i][0];
+                vBuffer[vBufferIndex++] = mesh.vcol[i][1];
+                vBuffer[vBufferIndex++] = mesh.vcol[i][2];
+                vBuffer[vBufferIndex++] = mesh.vcol[i][3];
+                vBuffer[vBufferIndex++] = mesh.uv[i][0];
+                vBuffer[vBufferIndex++] = mesh.uv[i][1];
+                vBuffer[vBufferIndex++] = texClip[0];
+                vBuffer[vBufferIndex++] = texClip[1];
+                vBuffer[vBufferIndex++] = texClip[2];
+                vBuffer[vBufferIndex++] = texClip[3];
+                vBuffer[vBufferIndex++] = texRepeat[0];
+                vBuffer[vBufferIndex++] = texRepeat[1];
+                vBuffer[vBufferIndex++] = texScaleOffs[0];
+                vBuffer[vBufferIndex++] = texScaleOffs[1];
+                vBuffer[vBufferIndex++] = texScaleOffs[2];
+                vBuffer[vBufferIndex++] = texScaleOffs[3];
+                vBuffer[vBufferIndex++] = mesh.uvScroll[0];
+                vBuffer[vBufferIndex++] = mesh.uvScroll[1];
+            }
+            for (let i = 0; i < mesh.ind.length; i++) {
+                iBuffer[iBufferIndex++] = mesh.ind[i] + lastInd;
+            }
+            lastInd += mesh.vtx.length;
+        } 
+
+        this.vertexBuffer = makeStaticDataBuffer(device, GfxBufferUsage.VERTEX, vBuffer.buffer);
+        this.indexBuffer = makeStaticDataBuffer(device, GfxBufferUsage.INDEX, iBuffer.buffer);
+
+        const vertexAttributeDescriptors: GfxVertexAttributeDescriptor[] = [
+            { location: KingdomHeartsIIProgram.a_Position, bufferIndex: 0, format: GfxFormat.F32_RGB, bufferByteOffset: 0*0x04, frequency: GfxVertexAttributeFrequency.PER_VERTEX, },
+            { location: KingdomHeartsIIProgram.a_Color, bufferIndex: 0, format: GfxFormat.F32_RGBA, bufferByteOffset: 3*0x04, frequency: GfxVertexAttributeFrequency.PER_VERTEX, },
+            { location: KingdomHeartsIIProgram.a_TexCoord, bufferIndex: 0, format: GfxFormat.F32_RG, bufferByteOffset: 7*0x04, frequency: GfxVertexAttributeFrequency.PER_VERTEX, },
+            { location: KingdomHeartsIIProgram.a_TexClip, bufferIndex: 0, format: GfxFormat.F32_RGBA, bufferByteOffset: 9*0x04, frequency: GfxVertexAttributeFrequency.PER_VERTEX, },
+            { location: KingdomHeartsIIProgram.a_TexRepeat, bufferIndex: 0, format: GfxFormat.F32_RG, bufferByteOffset: 13*0x04, frequency: GfxVertexAttributeFrequency.PER_VERTEX, },
+            { location: KingdomHeartsIIProgram.a_TexScaleOffs, bufferIndex: 0, format: GfxFormat.F32_RGBA, bufferByteOffset: 15*0x04, frequency: GfxVertexAttributeFrequency.PER_VERTEX, },
+            { location: KingdomHeartsIIProgram.a_TexScroll, bufferIndex: 0, format: GfxFormat.F32_RG, bufferByteOffset: 19*0x04, frequency: GfxVertexAttributeFrequency.PER_VERTEX, },
+        ];
+        this.inputLayout = device.createInputLayout({
+            indexBufferFormat: GfxFormat.U32_R,
+            vertexAttributeDescriptors,
+        });
+        const buffers = [{ buffer: this.vertexBuffer, byteOffset: 0, byteStride: 21*4}];
+        const indexBuffer = { buffer: this.indexBuffer, byteOffset: 0, byteStride: 0 };
+        this.inputState = device.createInputState(this.inputLayout, buffers, indexBuffer);
+    }
+
+    public destroy(device: GfxDevice): void {
+        for (let i = 0; i < this.textures.length; i++) {
+            device.destroyTexture(this.textures[i]);
+        }
+        device.destroySampler(this.sampler);
+        device.destroyBuffer(this.indexBuffer);
+        device.destroyBuffer(this.vertexBuffer);
+        device.destroyInputLayout(this.inputLayout);
+        device.destroyInputState(this.inputState);
+    }
+}
+
+const uvAnimOffsetScratch = vec2.create();
+class DrawCallInstance {
+    private vertexColorsEnabled = true;
+    private texturesEnabled = true;
+    private textureMappings = nArray(1, () => new TextureMapping());
+    private program!: DeviceProgram;
+    private gfxProgram: GfxProgram | null = null;
+    private megaStateFlags: Partial<GfxMegaStateDescriptor>;
+
+    constructor(private mapData: MapData, private drawCall: DrawCall, private drawCallIndex: number) {
+        this.createProgram();
+
+        this.megaStateFlags = {};
+        if (!drawCall.cullBackfaces) {
+            this.megaStateFlags.cullMode = GfxCullMode.NONE;
+        }
+        if (drawCall.translucent) {
+            this.megaStateFlags.blendMode = GfxBlendMode.ADD;
+            this.megaStateFlags.depthWrite = false;
+        }
+
+        const textureMapping = this.textureMappings[0];
+        textureMapping.gfxTexture = mapData.textures[drawCall.textureIndex];
+        textureMapping.gfxSampler = mapData.sampler;
+    }
+
+    public prepareToRender(device: GfxDevice, renderInstManager: GfxRenderInstManager, modelMatrix: mat4, viewerInput: Viewer.ViewerRenderInput) {
+        if (!this.drawCall.layer.visible) {
+            return;
+        }
+        const renderInst = renderInstManager.pushRenderInst();
+        renderInst.setInputLayoutAndState(this.mapData.inputLayout, this.mapData.inputState);
+        renderInst.sortKey = this.drawCallIndex;
+        if (this.gfxProgram === null) {
+            this.gfxProgram = renderInstManager.gfxRenderCache.createProgram(device, this.program);
+        }
+        renderInst.setGfxProgram(this.gfxProgram);
+        renderInst.setMegaStateFlags(this.megaStateFlags);
+        renderInst.setSamplerBindingsFromTextureMappings(this.textureMappings);
+        renderInst.drawIndexes(this.drawCall.indexCount, this.drawCall.firstIndex);
+
+        let offs = renderInst.allocateUniformBuffer(KingdomHeartsIIProgram.ub_DrawParams, 32);
+        const mapped = renderInst.mapUniformBufferF32(KingdomHeartsIIProgram.ub_DrawParams);
+        offs += fillMatrix4x4(mapped, offs, modelMatrix);
+        offs += fillMatrix4x3(mapped, offs, viewerInput.camera.viewMatrix);
+        if (this.drawCall.textureAnim) {
+            this.drawCall.textureAnim.fillUVOffset(uvAnimOffsetScratch);
+            mapped[offs++] = uvAnimOffsetScratch[0];
+            mapped[offs++] = uvAnimOffsetScratch[1];
+        } else {
+            mapped[offs++] = 0;
+            mapped[offs++] = 0;
+        }
+    }
+
+    public setVertexColorsEnabled(v: boolean): void {
+        this.vertexColorsEnabled = v;
+        this.createProgram();
+    }
+
+    public setTexturesEnabled(v: boolean): void {
+        this.texturesEnabled = v;
+        this.createProgram();
+    }
+
+    private createProgram(): void {
+        const program = new KingdomHeartsIIProgram();
+        if (this.vertexColorsEnabled) {
+            program.defines.set('USE_VERTEX_COLOR', '1');
+        }
+        if (this.texturesEnabled) {
+            program.defines.set('USE_TEXTURE', '1');
+        }
+        if (!this.drawCall.translucent) {
+            program.defines.set(`USE_ALPHA_MASK`, '1');
+        }
+        this.gfxProgram = null;
+        this.program = program;
+    }
+}
+
+const bindingLayouts: GfxBindingLayoutDescriptor[] = [
+    { numUniformBuffers: 2, numSamplers: 1 },
+];
+
+class SceneRenderer {
+    private worldTransform: mat4;
+    private drawCallInstances: DrawCallInstance[] = [];
+    private megaStateFlags: Partial<GfxMegaStateDescriptor>;
+
+    constructor(device: GfxDevice, mapData: MapData, drawCalls: DrawCall[]) {
+        this.megaStateFlags = {
+            cullMode: GfxCullMode.BACK,
+            blendMode: GfxBlendMode.NONE,
+            blendSrcFactor: GfxBlendFactor.SRC_ALPHA,
+            blendDstFactor: GfxBlendFactor.ONE_MINUS_SRC_ALPHA,
+            depthWrite: true,
+            depthCompare: reverseDepthForCompareMode(GfxCompareMode.LEQUAL),
+        };
+
+        for (let i = 0; i < drawCalls.length; i++) {
+            this.drawCallInstances.push(new DrawCallInstance(mapData, drawCalls[i], i));
+        }
+
+        this.worldTransform = mat4.create();
+    }
+
+    public prepareToRender(device: GfxDevice, renderInstManager: GfxRenderInstManager, viewerInput: Viewer.ViewerRenderInput) {
+        const template = renderInstManager.pushTemplateRenderInst();
+        template.setBindingLayouts(bindingLayouts);
+        template.setMegaStateFlags(this.megaStateFlags);
+        template.filterKey = RenderPass.MAIN;
+
+        viewerInput.camera.setClipPlanes(/*n=*/20, /*f=*/500000);
+
+        let offs = template.allocateUniformBuffer(KingdomHeartsIIProgram.ub_SceneParams, 20);
+        const sceneParamsMapped = template.mapUniformBufferF32(KingdomHeartsIIProgram.ub_SceneParams);
+        offs += fillMatrix4x4(sceneParamsMapped, offs, viewerInput.camera.projectionMatrix);
+        sceneParamsMapped[offs] = viewerInput.time;
+
+        for (const instance of this.drawCallInstances) {
+            instance.prepareToRender(device, renderInstManager, this.worldTransform, viewerInput);
+        }
+
+        renderInstManager.popTemplateRenderInst();
+    }
+
+    public setVertexColorsEnabled(v: boolean): void {
+        for (let i = 0; i < this.drawCallInstances.length; i++)
+            this.drawCallInstances[i].setVertexColorsEnabled(v);
+    }
+
+    public setTexturesEnabled(v: boolean): void {
+        for (let i = 0; i < this.drawCallInstances.length; i++)
+            this.drawCallInstances[i].setTexturesEnabled(v);
+    }
+}
+
+export class KingdomHeartsIIRenderer implements Viewer.SceneGfx {
+    private renderInstManager = new GfxRenderInstManager;
+    private renderTarget = new BasicRenderTarget;
+    private uniformBuffer: GfxRenderDynamicUniformBuffer;
+    private sceneRenderers: SceneRenderer[] = [];
+    private mapData: MapData;
+
+    constructor(device: GfxDevice, public textureHolder: TextureHolder<any>, map: MAP.KingdomHeartsIIMap) {
+        this.mapData = new MapData(device, map);
+        this.uniformBuffer = new GfxRenderDynamicUniformBuffer(device);
+        this.sceneRenderers.push(new SceneRenderer(device, this.mapData, this.mapData.drawCalls));
+    }
+
+    public createPanels(): UI.Panel[] {
+        const renderHacksPanel = new UI.Panel();
+        renderHacksPanel.customHeaderBackgroundColor = UI.COOL_BLUE_COLOR;
+        renderHacksPanel.setTitle(UI.RENDER_HACKS_ICON, 'Render Hacks');
+        const enableVertexColorsCheckbox = new UI.Checkbox('Enable Vertex Colors', true);
+        enableVertexColorsCheckbox.onchanged = () => {
+            this.sceneRenderers.forEach((sceneRenderer: SceneRenderer) => {
+                sceneRenderer.setVertexColorsEnabled(enableVertexColorsCheckbox.checked);
+            });
+        };
+        renderHacksPanel.contents.appendChild(enableVertexColorsCheckbox.elem);
+        const enableTextures = new UI.Checkbox('Enable Textures', true);
+        enableTextures.onchanged = () => {
+            this.sceneRenderers.forEach((sceneRenderer: SceneRenderer) => {
+                sceneRenderer.setTexturesEnabled(enableTextures.checked);
+            });
+        };
+        renderHacksPanel.contents.appendChild(enableTextures.elem);
+        return [renderHacksPanel, new UI.LayerPanel(this.mapData.layers)];
+    }
+
+    protected prepareToRender(device: GfxDevice, hostAccessPass: GfxHostAccessPass, viewerInput: Viewer.ViewerRenderInput) {
+        const template = this.renderInstManager.pushTemplateRenderInst();
+        template.setUniformBuffer(this.uniformBuffer);
+        for (let i = 0; i < this.sceneRenderers.length; i++) {
+            this.sceneRenderers[i].prepareToRender(device, this.renderInstManager, viewerInput);
+        }
+        this.renderInstManager.popTemplateRenderInst();
+        this.uniformBuffer.prepareToRender(device, hostAccessPass);
+
+        for (const textureAnim of this.mapData.textureAnimations) {
+            textureAnim.advanceTime(viewerInput.deltaTime);
+        }
+    }
+
+    public render(device: GfxDevice, viewerInput: Viewer.ViewerRenderInput): GfxRenderPass {
+        const hostAccessPass = device.createHostAccessPass();
+        this.prepareToRender(device, hostAccessPass, viewerInput);
+        device.submitPass(hostAccessPass);
+        this.renderTarget.setParameters(device, viewerInput.viewportWidth, viewerInput.viewportHeight);
+
+        // Create main render pass.
+        const passRenderer = this.renderTarget.createRenderPass(device, transparentBlackFullClearRenderPassDescriptor);
+        passRenderer.setViewport(viewerInput.viewportWidth, viewerInput.viewportHeight);
+        executeOnPass(this.renderInstManager, device, passRenderer, RenderPass.MAIN);
+        this.renderInstManager.resetRenderInsts();
+        return passRenderer;
+    }
+
+    public destroy(device: GfxDevice) {
+        this.renderInstManager.destroy(device);
+        this.uniformBuffer.destroy(device);
+        this.renderTarget.destroy(device);
+        this.textureHolder.destroy(device);
+        this.mapData.destroy(device);
+    }
+}

--- a/src/kh2fm/scenes.ts
+++ b/src/kh2fm/scenes.ts
@@ -1,0 +1,386 @@
+import * as MAP from './map';
+import * as Viewer from '../viewer';
+
+import { FakeTextureHolder } from '../TextureHolder';
+import { GfxDevice } from '../gfx/platform/GfxPlatform';
+import { SceneContext } from '../SceneBase';
+import { textureToCanvas, textureAnimationToCanvas, KingdomHeartsIIRenderer } from './render';
+
+export class KingdomHeartsIISceneDesc implements Viewer.SceneDesc {
+    constructor(public id: string, public name: string = id) {
+    }
+
+    public async createScene(device: GfxDevice, context: SceneContext): Promise<Viewer.SceneGfx> {
+        const dataFetcher = context.dataFetcher;
+        const mapData = await dataFetcher.fetchData(`kh2fm/${this.id}.map`);
+        const map = MAP.parseMap(mapData);
+
+        const viewerTextures: Viewer.Texture[] = [];
+        for (const textureBlock of map.mapGroup.textureBlocks) {
+            for (const texture of textureBlock.textures) {
+                viewerTextures.push(textureToCanvas(texture, "map"));
+                if (texture.textureAnim) {
+                    viewerTextures.push(textureAnimationToCanvas(texture.textureAnim, texture, "map"));
+                }
+            }
+        }
+        for (const textureBlock of map.sky0Group.textureBlocks) {
+            for (const texture of textureBlock.textures) {
+                viewerTextures.push(textureToCanvas(texture, "sky0"));
+                if (texture.textureAnim) {
+                    viewerTextures.push(textureAnimationToCanvas(texture.textureAnim, texture, "sky0"));
+                }
+            }
+        }
+        for (const textureBlock of map.sky1Group.textureBlocks) {
+            for (const texture of textureBlock.textures) {
+                viewerTextures.push(textureToCanvas(texture, "sky1"));
+                if (texture.textureAnim) {
+                    viewerTextures.push(textureAnimationToCanvas(texture.textureAnim, texture, "sky1"));
+                }
+            }
+        }
+        viewerTextures.sort(function(a, b) {
+            return a.name < b.name ? -1 : 1;
+        });
+        const fakeTextureHolder = new FakeTextureHolder(viewerTextures);
+
+        const renderer = new KingdomHeartsIIRenderer(device, fakeTextureHolder, map);
+        return renderer;
+    }
+}
+
+const id = "kh2fm";
+const name = "Kingdom Hearts II Final Mix";
+const sceneDescs = [
+    "100 Acre Wood",
+    new KingdomHeartsIISceneDesc("po00", "The Hundred Acre Wood"),
+    new KingdomHeartsIISceneDesc("po01", "Starry Hill"),
+    new KingdomHeartsIISceneDesc("po02", "Pooh Bear's House"),
+    new KingdomHeartsIISceneDesc("po03", "Rabbit's House"),
+    new KingdomHeartsIISceneDesc("po04", "Piglet's House"),
+    new KingdomHeartsIISceneDesc("po05", "Kanga's House"),
+    new KingdomHeartsIISceneDesc("po06", "A Blustery Rescue"),
+    new KingdomHeartsIISceneDesc("po07", "Hunny Slider"),
+    new KingdomHeartsIISceneDesc("po08", "Balloon Bounce"),
+    new KingdomHeartsIISceneDesc("po09", "The Spooky Cave"),
+
+    "Agrabah",
+    new KingdomHeartsIISceneDesc("al00", "Agrabah"),
+    new KingdomHeartsIISceneDesc("al01", "Bazaar"),
+    new KingdomHeartsIISceneDesc("al02", "The Peddler's Shop"),
+    new KingdomHeartsIISceneDesc("al03", "Palace Gates"),
+    new KingdomHeartsIISceneDesc("al04", "Palace Dungeon"),
+    new KingdomHeartsIISceneDesc("al05", "Agrabah (Boss)"),
+    new KingdomHeartsIISceneDesc("al06", "Palace Walls"),
+    new KingdomHeartsIISceneDesc("al07", "Cave of Wonders: Entrance"),
+    new KingdomHeartsIISceneDesc("al09", "Stone Guardians"),
+    new KingdomHeartsIISceneDesc("al10", "Treasure Room"),
+    new KingdomHeartsIISceneDesc("al11", "Ruined Chamber"),
+    new KingdomHeartsIISceneDesc("al12", "Valley of Stone"),
+    new KingdomHeartsIISceneDesc("al13", "Chasm of Challenges"),
+    new KingdomHeartsIISceneDesc("al14", "Sandswept Ruins"),
+    new KingdomHeartsIISceneDesc("al15", "The Peddler's Shop (Gold)"),
+
+    "Atlantica",
+    new KingdomHeartsIISceneDesc("lm00", "Triton's Throne"),
+    new KingdomHeartsIISceneDesc("lm01", "Ariel's Grotto"),
+    new KingdomHeartsIISceneDesc("lm02", "Undersea Courtyard"),
+    new KingdomHeartsIISceneDesc("lm03", "Undersea Courtyard (Night)"),
+    new KingdomHeartsIISceneDesc("lm04", "Stage"),
+    new KingdomHeartsIISceneDesc("lm05", "Sunken Ship"),
+    new KingdomHeartsIISceneDesc("lm06", "The Shore"),
+    new KingdomHeartsIISceneDesc("lm07", "The Shore (Night)"),
+    new KingdomHeartsIISceneDesc("lm08", "The Shore (Sunset)"),
+    new KingdomHeartsIISceneDesc("lm09", "Wrath of the Sea"),
+    new KingdomHeartsIISceneDesc("lm10", "Wedding Ship"),
+
+    "Beast's Castle",
+    new KingdomHeartsIISceneDesc("bb00", "Entrance Hall"),
+    new KingdomHeartsIISceneDesc("bb01", "Parlor"),
+    new KingdomHeartsIISceneDesc("bb02", "Belle's Room"),
+    new KingdomHeartsIISceneDesc("bb03", "Beast's Room"),
+    new KingdomHeartsIISceneDesc("bb04", "Ballroom"),
+    new KingdomHeartsIISceneDesc("bb05", "Ballroom (Boss)"),
+    new KingdomHeartsIISceneDesc("bb06", "Courtyard"),
+    new KingdomHeartsIISceneDesc("bb07", "The East Wing"),
+    new KingdomHeartsIISceneDesc("bb08", "The West Hall"),
+    new KingdomHeartsIISceneDesc("bb09", "The West Wing"),
+    new KingdomHeartsIISceneDesc("bb10", "Dungeon"),
+    new KingdomHeartsIISceneDesc("bb11", "Undercroft"),
+    new KingdomHeartsIISceneDesc("bb12", "Secret Passage"),
+    new KingdomHeartsIISceneDesc("bb13", "Bridge"),
+    new KingdomHeartsIISceneDesc("bb14", "Ballroom (Cutscene)"),
+    new KingdomHeartsIISceneDesc("bb15", "Bridge (Boss)"),
+
+    "Destiny Islands",
+    new KingdomHeartsIISceneDesc("di00", "Secret Place"),
+    new KingdomHeartsIISceneDesc("di01", "Destiny Islands (Hill)"),
+    new KingdomHeartsIISceneDesc("di02", "Destiny Islands (Shore)"),
+
+    "Disney Castle",
+    new KingdomHeartsIISceneDesc("dc00", "Audience Chamber"),
+    new KingdomHeartsIISceneDesc("dc01", "Library"),
+    new KingdomHeartsIISceneDesc("dc02", "Colonnade"),
+    new KingdomHeartsIISceneDesc("dc03", "Courtyard"),
+    new KingdomHeartsIISceneDesc("dc04", "Hall of the Cornerstone"),
+    new KingdomHeartsIISceneDesc("dc05", "Hall of the Cornerstone (Light)"),
+    new KingdomHeartsIISceneDesc("dc06", "Gummi Hangar"),
+    new KingdomHeartsIISceneDesc("dc07", "Lingering Will"),
+
+    "Dive to the Heart",
+    new KingdomHeartsIISceneDesc("tt32", "Station of Serenity"),
+    new KingdomHeartsIISceneDesc("tt33", "Station of Calling"),
+    new KingdomHeartsIISceneDesc("tt34", "Station of Awakening"),
+
+    "Halloween Town",
+    new KingdomHeartsIISceneDesc("nm00", "Halloween Town Square"),
+    new KingdomHeartsIISceneDesc("nm01", "Dr. Finkelstein's Lab"),
+    new KingdomHeartsIISceneDesc("nm02", "Graveyard"),
+    new KingdomHeartsIISceneDesc("nm03", "Curly Hill"),
+    new KingdomHeartsIISceneDesc("nm04", "Hinterlands"),
+    new KingdomHeartsIISceneDesc("nm05", "Yuletide Hill"),
+    new KingdomHeartsIISceneDesc("nm06", "Candy Cane Lane"),
+    new KingdomHeartsIISceneDesc("nm07", "Christmas Tree Plaza"),
+    new KingdomHeartsIISceneDesc("nm08", "Santa's House"),
+    new KingdomHeartsIISceneDesc("nm09", "Toy Factory: Shipping and Receiving"),
+    new KingdomHeartsIISceneDesc("nm10", "Toy Factory: The Wrapping Room"),
+
+    "Hollow Bastion",
+    new KingdomHeartsIISceneDesc("hb00", "Villain's Vale"),
+    new KingdomHeartsIISceneDesc("hb01", "The Dark Depths"),
+    new KingdomHeartsIISceneDesc("hb02", "The Great Maw"),
+    new KingdomHeartsIISceneDesc("hb03", "Crystal Fissure"),
+    new KingdomHeartsIISceneDesc("hb04", "Castle Gate"),
+    new KingdomHeartsIISceneDesc("hb05", "Ansem's Study"),
+    new KingdomHeartsIISceneDesc("hb06", "Postern"),
+    new KingdomHeartsIISceneDesc("hb07", "Restoration Site"),
+    new KingdomHeartsIISceneDesc("hb08", "Bailey"),
+    new KingdomHeartsIISceneDesc("hb09", "Borough"),
+    new KingdomHeartsIISceneDesc("hb10", "Marketplace"),
+    new KingdomHeartsIISceneDesc("hb11", "Corridors"),
+    new KingdomHeartsIISceneDesc("hb12", "Hearless Manufactory"),
+    new KingdomHeartsIISceneDesc("hb13", "Merlin's House"),
+    new KingdomHeartsIISceneDesc("hb14", "Castle Oblivion"),
+    new KingdomHeartsIISceneDesc("hb15", "Ansem's Study (Past)"),
+    new KingdomHeartsIISceneDesc("hb16", "Ravine Trail"),
+    new KingdomHeartsIISceneDesc("hb17", "The Great Maw"),
+    new KingdomHeartsIISceneDesc("hb18", "Restoration Site"),
+    new KingdomHeartsIISceneDesc("hb19", "Bailey (Damaged)"),
+    new KingdomHeartsIISceneDesc("hb20", "Corridors (Cutscene)"),
+    new KingdomHeartsIISceneDesc("hb21", "Cavern of Remembrance: Depths"),
+    new KingdomHeartsIISceneDesc("hb22", "Cavern of Remembrance: Mining Area"),
+    new KingdomHeartsIISceneDesc("hb23", "Cavern of Remembrance: Engine Chamber"),
+    new KingdomHeartsIISceneDesc("hb24", "Cavern of Remembrance: Mineshaft"),
+    new KingdomHeartsIISceneDesc("hb25", "Transport to Remembrance"),
+    new KingdomHeartsIISceneDesc("hb26", "Garden of Assemblage"),
+    new KingdomHeartsIISceneDesc("hb27", "Chamber of Repose"),
+    new KingdomHeartsIISceneDesc("hb32", "The Old Mansion"),
+    new KingdomHeartsIISceneDesc("hb33", "Data Battle Arena"),
+    new KingdomHeartsIISceneDesc("hb34", "Destiny Islands Remnants"),
+    new KingdomHeartsIISceneDesc("hb38", "Station of Oblivion"),
+
+    "The Land of Dragons",
+    new KingdomHeartsIISceneDesc("mu00", "Bamboo Grove"),
+    new KingdomHeartsIISceneDesc("mu01", "Encampment"),
+    new KingdomHeartsIISceneDesc("mu02", "Checkpoint"),
+    new KingdomHeartsIISceneDesc("mu03", "Mountain Trail"),
+    new KingdomHeartsIISceneDesc("mu04", "Village"),
+    new KingdomHeartsIISceneDesc("mu05", "Village Cave"),
+    new KingdomHeartsIISceneDesc("mu06", "Ridge"),
+    new KingdomHeartsIISceneDesc("mu07", "Summit"),
+    new KingdomHeartsIISceneDesc("mu08", "Imperial Square"),
+    new KingdomHeartsIISceneDesc("mu09", "Palace Gate"),
+    new KingdomHeartsIISceneDesc("mu10", "Antechamber"),
+    new KingdomHeartsIISceneDesc("mu11", "Throne Room"),
+    new KingdomHeartsIISceneDesc("mu12", "Village (Burned)"),
+
+    "Mysterious Tower",
+    new KingdomHeartsIISceneDesc("tt25", "The Tower"),
+    new KingdomHeartsIISceneDesc("tt26", "Tower: Entryway"),
+    new KingdomHeartsIISceneDesc("tt27", "Tower: Sorcerer's Loft"),
+    new KingdomHeartsIISceneDesc("tt28", "Tower: Wardrobe"),
+    new KingdomHeartsIISceneDesc("tt29", "Tower: Star Chamber"),
+    new KingdomHeartsIISceneDesc("tt30", "Tower: Moon Chamber"),
+    new KingdomHeartsIISceneDesc("tt31", "Tower: Wayward Stairs"),
+    new KingdomHeartsIISceneDesc("tt38", "Tower: Wayward Stairs"),
+    new KingdomHeartsIISceneDesc("tt39", "Tower: Wayward Stairs"),
+
+    "Olympus Coliseum",
+    new KingdomHeartsIISceneDesc("he00", "The Coliseum"),
+    new KingdomHeartsIISceneDesc("he01", "Coliseum Gates"),
+    new KingdomHeartsIISceneDesc("he02", "Coliseum Gates (Ruins)"),
+    new KingdomHeartsIISceneDesc("he03", "Underworld Entrance"),
+    new KingdomHeartsIISceneDesc("he04", "Coliseum Foyer"),
+    new KingdomHeartsIISceneDesc("he05", "Valley of the Dead"),
+    new KingdomHeartsIISceneDesc("he06", "Hades' Chamber"),
+    new KingdomHeartsIISceneDesc("he07", "Cave of the Dead: Entrance"),
+    new KingdomHeartsIISceneDesc("he08", "Well of Captivity"),
+    new KingdomHeartsIISceneDesc("he09", "The Underdrome"),
+    new KingdomHeartsIISceneDesc("he10", "Cave of the Dead: Inner Chamber"),
+    new KingdomHeartsIISceneDesc("he11", "Underworld Caverns: Entrance"),
+    new KingdomHeartsIISceneDesc("he12", "The Lock"),
+    new KingdomHeartsIISceneDesc("he13", "The Underdrome"),
+    new KingdomHeartsIISceneDesc("he14", "Coliseum Gates (Ruins, Night)"),
+    new KingdomHeartsIISceneDesc("he15", "Cave of the Dead: Passage"),
+    new KingdomHeartsIISceneDesc("he16", "Underworld Caverns: The Lost Road"),
+    new KingdomHeartsIISceneDesc("he17", "Underworld Caverns: Atrium"),
+    new KingdomHeartsIISceneDesc("he18", "Coliseum Gates (Ruins)"),
+    new KingdomHeartsIISceneDesc("he19", "The Underdrome"),
+
+    "Port Royal",
+    new KingdomHeartsIISceneDesc("ca00", "Rampart"),
+    new KingdomHeartsIISceneDesc("ca01", "Harbor"),
+    new KingdomHeartsIISceneDesc("ca02", "Town"),
+    new KingdomHeartsIISceneDesc("ca03", "The Interceptor"),
+    new KingdomHeartsIISceneDesc("ca04", "The Interceptor: Ship's Hold"),
+    new KingdomHeartsIISceneDesc("ca05", "The Black Pearl"),
+    new KingdomHeartsIISceneDesc("ca06", "The Black Pearl: Captain's Stateroom"),
+    new KingdomHeartsIISceneDesc("ca07", "The Interceptor"),
+    new KingdomHeartsIISceneDesc("ca08", "Isla de Muerta: Rock Face"),
+    new KingdomHeartsIISceneDesc("ca09", "Isla de Muerta: Cave Mouth"),
+    new KingdomHeartsIISceneDesc("ca10", "Isla de Muerta: Treasure Heap"),
+    new KingdomHeartsIISceneDesc("ca11", "Ship Graveyard: The Interceptor's Hold"),
+    new KingdomHeartsIISceneDesc("ca12", "Isla de Muerta: Powder Store"),
+    new KingdomHeartsIISceneDesc("ca13", "Isla de Muerta: Moonlight Nook"),
+    new KingdomHeartsIISceneDesc("ca14", "Ship Graveyard: Seadrift Keep"),
+    new KingdomHeartsIISceneDesc("ca15", "Ship Graveyard: Seadrift Row"),
+    new KingdomHeartsIISceneDesc("ca16", "Isla de Muerta: Rock Face"),
+    new KingdomHeartsIISceneDesc("ca17", "Isla de Muerta: Treasure Heap (Cutscene)"),
+    new KingdomHeartsIISceneDesc("ca18", "The Black Pearl"),
+    new KingdomHeartsIISceneDesc("ca19", "The Black Pearl"),
+    new KingdomHeartsIISceneDesc("ca20", "The Black Pearl"),
+    new KingdomHeartsIISceneDesc("ca21", "The Black Pearl"),
+    new KingdomHeartsIISceneDesc("ca22", "The Black Pearl"),
+    new KingdomHeartsIISceneDesc("ca23", "The Black Pearl: Captain's Stateroom (Cutscene)"),
+    new KingdomHeartsIISceneDesc("ca24", "Harbor"),
+    new KingdomHeartsIISceneDesc("ca25", "Isla de Muerta: Rock Face"),
+
+    "Pride Lands",
+    new KingdomHeartsIISceneDesc("lk00", "Pride Rock"),
+    new KingdomHeartsIISceneDesc("lk01", "Stone Hollow"),
+    new KingdomHeartsIISceneDesc("lk02", "The King's Den"),
+    new KingdomHeartsIISceneDesc("lk03", "Wildebeest Valley"),
+    new KingdomHeartsIISceneDesc("lk04", "The Savannah"),
+    new KingdomHeartsIISceneDesc("lk05", "Elephant Graveyard"),
+    new KingdomHeartsIISceneDesc("lk06", "Gorge"),
+    new KingdomHeartsIISceneDesc("lk07", "Wastelands"),
+    new KingdomHeartsIISceneDesc("lk08", "Jungle"),
+    new KingdomHeartsIISceneDesc("lk09", "Oasis"),
+    new KingdomHeartsIISceneDesc("lk10", "Pride Rock (Ending)"),
+    new KingdomHeartsIISceneDesc("lk11", "Oasis (Night)"),
+    new KingdomHeartsIISceneDesc("lk12", "Cliff Edge"),
+    new KingdomHeartsIISceneDesc("lk13", "Peak"),
+    new KingdomHeartsIISceneDesc("lk14", "Peak (Boss)"),
+    new KingdomHeartsIISceneDesc("lk15", "Savannah (Boss)"),
+    new KingdomHeartsIISceneDesc("lk16", "Wildebeest Valley (Past)"),
+
+    "Realm of Darkness",
+    new KingdomHeartsIISceneDesc("es00", "Dark Meridian"),
+    new KingdomHeartsIISceneDesc("es01", "es01"),
+
+    "Space Paranoids",
+    new KingdomHeartsIISceneDesc("tr00", "Pit Cell"),
+    new KingdomHeartsIISceneDesc("tr01", "Canyon"),
+    new KingdomHeartsIISceneDesc("tr02", "Light Cycle"),
+    new KingdomHeartsIISceneDesc("tr03", "Dataspace"),
+    new KingdomHeartsIISceneDesc("tr04", "I/O Tower: Hallway"),
+    new KingdomHeartsIISceneDesc("tr05", "I/O Tower: Communications Room"),
+    new KingdomHeartsIISceneDesc("tr06", "Simulation Hangar"),
+    new KingdomHeartsIISceneDesc("tr07", "Solar Sailer Simulation"),
+    new KingdomHeartsIISceneDesc("tr08", "Central Computer Mesa"),
+    new KingdomHeartsIISceneDesc("tr09", "Central Computer Core"),
+    new KingdomHeartsIISceneDesc("tr10", "Simulation Hangar"),
+    new KingdomHeartsIISceneDesc("tr11", "Central Computer Mesa"),
+
+    "Timeless River",
+    new KingdomHeartsIISceneDesc("wi00", "Cornerstone Hill"),
+    new KingdomHeartsIISceneDesc("wi01", "Pier"),
+    new KingdomHeartsIISceneDesc("wi02", "Waterway"),
+    new KingdomHeartsIISceneDesc("wi03", "Wharf"),
+    new KingdomHeartsIISceneDesc("wi04", "Lilliput"),
+    new KingdomHeartsIISceneDesc("wi05", "Building Site"),
+    new KingdomHeartsIISceneDesc("wi06", "Scene of the Fire"),
+    new KingdomHeartsIISceneDesc("wi07", "Mickey's House"),
+    new KingdomHeartsIISceneDesc("wi08", "Villain's Vale"),
+
+    "Twilight Town",
+    new KingdomHeartsIISceneDesc("tt00", "Realm of Nothingness"),
+    new KingdomHeartsIISceneDesc("tt01", "Roxas' Room"),
+    new KingdomHeartsIISceneDesc("tt02", "The Usual Spot"),
+    new KingdomHeartsIISceneDesc("tt03", "Back Alley"),
+    new KingdomHeartsIISceneDesc("tt04", "Sandlot"),
+    new KingdomHeartsIISceneDesc("tt05", "Sandlot (Struggle)"),
+    new KingdomHeartsIISceneDesc("tt06", "Market Street: Station Heights"),
+    new KingdomHeartsIISceneDesc("tt07", "Market Street: Tram Common"),
+    new KingdomHeartsIISceneDesc("tt08", "Station Plaza"),
+    new KingdomHeartsIISceneDesc("tt09", "Central Station"),
+    new KingdomHeartsIISceneDesc("tt10", "Sunset Terrace"),
+    new KingdomHeartsIISceneDesc("tt11", "Sunset Station"),
+    new KingdomHeartsIISceneDesc("tt12", "Sunset Hill"),
+    new KingdomHeartsIISceneDesc("tt13", "The Woods"),
+    new KingdomHeartsIISceneDesc("tt14", "The Old Mansion"),
+    new KingdomHeartsIISceneDesc("tt15", "Mansion: Foyer"),
+    new KingdomHeartsIISceneDesc("tt16", "Mansion: Dining Room"),
+    new KingdomHeartsIISceneDesc("tt17", "Mansion: Library"),
+    new KingdomHeartsIISceneDesc("tt18", "Mansion: The White Room"),
+    new KingdomHeartsIISceneDesc("tt19", "Mansion: Basement Hall"),
+    new KingdomHeartsIISceneDesc("tt20", "Mansion: Basement Hall"),
+    new KingdomHeartsIISceneDesc("tt21", "Mansion: Computer Room"),
+    new KingdomHeartsIISceneDesc("tt22", "Mansion: Basement Corridor"),
+    new KingdomHeartsIISceneDesc("tt23", "Mansion: Pod Room"),
+    new KingdomHeartsIISceneDesc("tt24", "Train (Twilight Town)"),
+    new KingdomHeartsIISceneDesc("tt35", "Train (Space)"),
+    new KingdomHeartsIISceneDesc("tt36", "Tunnelway"),
+    new KingdomHeartsIISceneDesc("tt37", "Underground Concourse"),
+    new KingdomHeartsIISceneDesc("tt40", "Betwixt and Between"),
+    new KingdomHeartsIISceneDesc("tt41", "The Old Mansion"),
+
+    "The World That Never Was",
+    new KingdomHeartsIISceneDesc("eh00", "Where Nothing Gathers"),
+    new KingdomHeartsIISceneDesc("eh01", "Alley to Between"),
+    new KingdomHeartsIISceneDesc("eh02", "Fragment Crossing"),
+    new KingdomHeartsIISceneDesc("eh03", "Memory's Skyscraper"),
+    new KingdomHeartsIISceneDesc("eh04", "The Brink of Despair"),
+    new KingdomHeartsIISceneDesc("eh05", "Soundless Prison"),
+    new KingdomHeartsIISceneDesc("eh06", "Nothing's Call"),
+    new KingdomHeartsIISceneDesc("eh07", "Crooked Ascension"),
+    new KingdomHeartsIISceneDesc("eh08", "Crooked Ascension"),
+    new KingdomHeartsIISceneDesc("eh09", "Twilight's View"),
+    new KingdomHeartsIISceneDesc("eh10", "Hall of Empty Melodies"),
+    new KingdomHeartsIISceneDesc("eh11", "Hall of Empty Melodies"),
+    new KingdomHeartsIISceneDesc("eh12", "Naught's Skyway"),
+    new KingdomHeartsIISceneDesc("eh13", "Proof of Existence"),
+    new KingdomHeartsIISceneDesc("eh14", "Havoc's Divide"),
+    new KingdomHeartsIISceneDesc("eh15", "Addled Impasse"),
+    new KingdomHeartsIISceneDesc("eh16", "Naught's Approach"),
+    new KingdomHeartsIISceneDesc("eh17", "Ruin and Creation's Passage"),
+    new KingdomHeartsIISceneDesc("eh18", "The Altar of Naught"),
+    new KingdomHeartsIISceneDesc("eh19", "Memory's Contortion"),
+    new KingdomHeartsIISceneDesc("eh20", "Realm of Nothingness (Final Boss)"),
+    new KingdomHeartsIISceneDesc("eh21", "Dive to the Heart (Roxas)"),
+    new KingdomHeartsIISceneDesc("eh22", "Xemnas: Dragon"),
+    new KingdomHeartsIISceneDesc("eh23", "Xemnas: Armor II"),
+    new KingdomHeartsIISceneDesc("eh24", "Xemnas: Armor"),
+    new KingdomHeartsIISceneDesc("eh25", "Xemnas: Energy Core"),
+    new KingdomHeartsIISceneDesc("eh26", "Xemnas: Cannons"),
+    new KingdomHeartsIISceneDesc("eh27", "Xemnas: City"),
+    new KingdomHeartsIISceneDesc("eh28", "Xemnas: City II"),
+    new KingdomHeartsIISceneDesc("eh29", "The Altar of Naught (Pre-Boss)"),
+
+    "Gummi Missions",
+    new KingdomHeartsIISceneDesc("gm00", "Asteroid Sweep"),
+    new KingdomHeartsIISceneDesc("gm01", "Stardust Sweep"),
+    new KingdomHeartsIISceneDesc("gm02", "Broken Highway"),
+    new KingdomHeartsIISceneDesc("gm03", "Ancient Highway"),
+    new KingdomHeartsIISceneDesc("gm04", "Phantom Storm"),
+    new KingdomHeartsIISceneDesc("gm05", "Sunlight Storm"),
+    new KingdomHeartsIISceneDesc("gm06", "Splash Island"),
+    new KingdomHeartsIISceneDesc("gm07", "Floating Island"),
+    new KingdomHeartsIISceneDesc("gm08", "Assault of the Dreadnought"),
+
+    "World Map",
+    new KingdomHeartsIISceneDesc("wm00", "World Map"),
+];
+
+export const sceneGroup: Viewer.SceneGroup = { id, name, sceneDescs };

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,7 @@ import * as Scenes_SuperPaperMario from './ttyd/spm_scenes';
 import * as Scenes_MarioKartDS from './nns_g3d/mkds_scenes';
 import * as Scenes_NewSuperMarioBrosDS from './nns_g3d/nsmbds_scenes';
 import * as Scenes_KingdomHearts from './kh/scenes';
+import * as Scenes_KingdomHeartsIIFinalMix from './kh2fm/scenes';
 import * as Scenes_Psychonauts from './psychonauts/scenes';
 import * as Scenes_DarkSouls from './dks/scenes';
 import * as Scenes_KatamariDamacy from './katamari_damacy/scenes';
@@ -110,6 +111,7 @@ const sceneGroups = [
     "PlayStation 2",
     Scenes_KatamariDamacy.sceneGroup,
     Scenes_KingdomHearts.sceneGroup,
+    Scenes_KingdomHeartsIIFinalMix.sceneGroup,
     "Other",
     Scenes_DarkSoulsCollision.sceneGroup,
     Scenes_SonicMania.sceneGroup,

--- a/src/ps2/gs.ts
+++ b/src/ps2/gs.ts
@@ -1,0 +1,508 @@
+import ArrayBufferSlice from "../ArrayBufferSlice";
+
+export const enum GSRegister {
+    PRIM      = 0x00,
+    TEX0_1    = 0x06,
+    CLAMP_1   = 0x08,
+    TEX1_1    = 0x14,
+    TEX2_1    = 0x16,
+    TEXFLUSH  = 0x3F,
+    MIPTBP1_1 = 0x34,
+    MIPTBP2_1 = 0x36,
+    ALPHA_1   = 0x42,
+    TEST_1    = 0x47,
+    BITBLTBUF = 0x50,
+    TRXPOS    = 0x51,
+    TRXREG    = 0x52,
+    TRXDIR    = 0x53
+}
+
+export const enum GSPixelStorageFormat {
+    PSMCT32  = 0x00,
+    PSMCT24  = 0x01,
+    PSMCT16  = 0x02,
+    PSMCT16S = 0x0A,
+    PSMT8    = 0x13,
+    PSMT4    = 0x14,
+    PSMT8H   = 0x1B,
+    PSMT4HL  = 0x24,
+    PSMT4HH  = 0x2C,
+    PSMZ32   = 0x30,
+    PSMZ24   = 0x31,
+    PSMZ16   = 0x32,
+    PSMZ16S  = 0x3A,
+}
+
+export const enum GSCLUTStorageFormat {
+    PSMCT32  = 0x00,
+    PSMCT16  = 0x02,
+    PSMCT16S = 0x0A,
+}
+
+export const enum GSTextureColorComponent {
+    RGB  = 0x00,
+    RGBA = 0x01,
+}
+
+export const enum GSTextureFunction {
+    MODULATE   = 0x00,
+    DECAL      = 0x01,
+    HIGHLIGHT  = 0x02,
+    HIGHLIGHT2 = 0x03,
+}
+
+export const enum GSAlphaCompareMode {
+    NEVER    = 0x00,
+    ALWAYS   = 0x01,
+    LESS     = 0x02,
+    LEQUAL   = 0x03,
+    EQUAL    = 0x04,
+    GEQUAL   = 0x05,
+    GREATER  = 0x06,
+    NOTEQUAL = 0x07,
+}
+
+export const enum GSAlphaFailMode {
+    KEEP     = 0x00,
+    FB_ONLY  = 0x01,
+    ZB_ONLY  = 0x02,
+    RGB_ONLY = 0x03,
+}
+
+export const enum GSDepthCompareMode {
+    NEVER   = 0x00,
+    ALWAYS  = 0x01,
+    GEQUAL  = 0x02,
+    GREATER = 0x03,
+}
+
+export const enum GSTextureFilter {
+    NEAREST                = 0x00,
+    LINEAR                 = 0x01,
+    NEAREST_MIPMAP_NEAREST = 0x02,
+    NEAREST_MIPMAP_LINEAR  = 0x03,
+    LINEAR_MIPMAP_NEAREST  = 0x04,
+    LINEAR_MIPMAP_LINEAR   = 0x05,
+}
+
+export const enum GSWrapMode {
+    REPEAT        = 0x00,
+    CLAMP         = 0x01,
+    REGION_CLAMP  = 0x02,
+    REGION_REPEAT = 0x03,
+}
+
+export const enum GSPixelTransmissionOrder {
+    UPPER_LEFT_TO_LOWER_RIGHT = 0x00,
+    LOWER_LEFT_TO_UPPER_RIGHT = 0x01,
+    UPPER_RIGHT_TO_LOWER_LEFT = 0x02,
+    LOWER_RIGHT_TO_UPPER_LEFT = 0x03,
+}
+
+export interface GSRegisterTEX0 {
+    tbp0: number;
+    tbw: number;
+    psm: GSPixelStorageFormat;
+    tw: number;
+    th: number;
+    tcc: GSTextureColorComponent;
+    tfx: GSTextureFunction;
+    cbp: number;
+    cpsm: GSPixelStorageFormat;
+    csm: GSCLUTStorageFormat;
+    csa: number;
+    cld: number;
+}
+
+export interface GSRegisterCLAMP {
+    wms: GSWrapMode;
+    wmt: GSWrapMode;
+    minu: number;
+    maxu: number;
+    minv: number;
+    maxv: number;
+}
+
+export interface GSRegisterBITBLTBUF {
+    sbp: number;
+    sbw: number;
+    spsm: GSPixelStorageFormat;
+    dbp: number;
+    dbw: number;
+    dpsm: GSPixelStorageFormat;
+}
+
+export interface GSRegisterTRXPOS {
+    ssax: number;
+    ssay: number;
+    dsax: number;
+    dsay: number;
+    dir: GSPixelTransmissionOrder;
+}
+
+export interface GSRegisterTRXREG {
+    rrw: number;
+    rrh: number;
+}
+
+function getBitField(data: number, start: number, end: number): number {
+    return (data >> start) & ((1 << (end - start + 1)) - 1);
+}
+
+export function getGSRegisterTEX0(dataLower: number, dataUpper: number): GSRegisterTEX0 {
+    return {
+        tbp0: getBitField(dataLower, 0, 13),
+        tbw:  getBitField(dataLower, 14, 19),
+        psm:  getBitField(dataLower, 20, 25),
+        tw:   getBitField(dataLower, 26, 29),
+        th:   getBitField(dataLower, 30, 31) | (getBitField(dataUpper, 0, 1) << 2),
+        tcc:  getBitField(dataUpper, 2, 2),
+        tfx:  getBitField(dataUpper, 3, 4),
+        cbp:  getBitField(dataUpper, 5, 18),
+        cpsm: getBitField(dataUpper, 19, 22),
+        csm:  getBitField(dataUpper, 23, 23),
+        csa:  getBitField(dataUpper, 24, 28),
+        cld:  getBitField(dataUpper, 29, 31)
+    };
+}
+
+export function getGSRegisterCLAMP(dataLower: number, dataUpper: number): GSRegisterCLAMP {
+    return {
+        wms:  getBitField(dataLower, 0, 1),
+        wmt:  getBitField(dataLower, 2, 3),
+        minu: getBitField(dataLower, 4, 13),
+        maxu: getBitField(dataLower, 14, 23),
+        minv: getBitField(dataLower, 24, 31) | (getBitField(dataUpper, 0, 1) << 2),
+        maxv: getBitField(dataUpper, 2, 11)
+    };
+}
+
+export function getGSRegisterBITBLTBUF(dataLower: number, dataUpper: number): GSRegisterBITBLTBUF {
+    return {
+        sbp:  getBitField(dataLower, 0, 13),
+        sbw:  getBitField(dataLower, 16, 21),
+        spsm: getBitField(dataLower, 24, 29),
+        dbp:  getBitField(dataUpper, 0, 13),
+        dbw:  getBitField(dataUpper, 16, 21),
+        dpsm: getBitField(dataUpper, 24, 29)
+    };
+}
+
+export function getGSRegisterTRXPOS(dataLower: number, dataUpper: number): GSRegisterTRXPOS {
+    return {
+        ssax: getBitField(dataLower, 0, 10),
+        ssay: getBitField(dataLower, 16, 26),
+        dsax: getBitField(dataUpper, 0, 10),
+        dsay: getBitField(dataUpper, 16, 26),
+        dir:  getBitField(dataUpper, 27, 28)
+    };
+}
+
+export function getGSRegisterTRXREG(dataLower: number, dataUpper: number): GSRegisterTRXREG {
+    return {
+        rrw: getBitField(dataLower, 0, 11),
+        rrh: getBitField(dataUpper, 0, 11)
+    }
+}
+
+export interface GSMemoryMap {
+    data: Uint8Array;
+}
+
+export function gsMemoryMapNew(): GSMemoryMap {
+    // GS Memory is 4MB.
+    return { data: new Uint8Array(4 * 1024 * 1024) };
+}
+
+export interface GSConfiguration {
+    tex0_1_data0: number;
+    tex0_1_data1: number;
+    tex1_1_data0: number;
+    tex1_1_data1: number;
+    clamp_1_data0: number;
+    clamp_1_data1: number;
+    alpha_1_data0: number;
+    alpha_1_data1: number;
+    test_1_data0: number;
+    test_1_data1: number;
+}
+
+const blockTablePSMCT32 = [
+     0,  1,  4,  5, 16, 17, 20, 21,
+     2,  3,  6,  7, 18, 19, 22, 23,
+     8,  9, 12, 13, 24, 25, 28, 29,
+    10, 11, 14, 15, 26, 27, 30, 31,
+];
+const columnTablePSMCT32 = [
+     0,  1,  4,  5,  8, 9,  12, 13,
+     2,  3,  6,  7, 10, 11, 14, 15,
+];
+const blockTablePSMT8 = [
+     0,  1,  4,  5, 16, 17, 20, 21,
+     2,  3,  6,  7, 18, 19, 22, 23,
+     8,  9, 12, 13, 24, 25, 28, 29,
+    10, 11, 14, 15, 26, 27, 30, 31,
+];
+const columnTablePSMT8 = [
+      0,   4,  16,  20,  32,  36,  48,  52,	// Column 0
+      2,   6,  18,  22,  34,  38,  50,  54,
+      8,  12,  24,  28,  40,  44,  56,  60,
+     10,  14,  26,  30,  42,  46,  58,  62,
+     33,  37,  49,  53,   1,   5,  17,  21,
+     35,  39,  51,  55,   3,   7,  19,  23,
+     41,  45,  57,  61,   9,  13,  25,  29,
+     43,  47,  59,  63,  11,  15,  27,  31,
+     96, 100, 112, 116,  64,  68,  80,  84, // Column 1
+     98, 102, 114, 118,  66,  70,  82,  86,
+    104, 108, 120, 124,  72,  76,  88,  92,
+    106, 110, 122, 126,  74,  78,  90,  94,
+     65,  69,  81,  85,  97, 101, 113, 117,
+     67,  71,  83,  87,  99, 103, 115, 119,
+     73,  77,  89,  93, 105, 109, 121, 125,
+     75,  79,  91,  95, 107, 111, 123, 127,
+    128, 132, 144, 148, 160, 164, 176, 180,	// Column 2
+    130, 134, 146, 150, 162, 166, 178, 182,
+    136, 140, 152, 156, 168, 172, 184, 188,
+    138, 142, 154, 158, 170, 174, 186, 190,
+    161, 165, 177, 181, 129, 133, 145, 149,
+    163, 167, 179, 183, 131, 135, 147, 151,
+    169, 173, 185, 189, 137, 141, 153, 157,
+    171, 175, 187, 191, 139, 143, 155, 159,
+    224, 228, 240, 244, 192, 196, 208, 212,	// Column 3
+    226, 230, 242, 246, 194, 198, 210, 214,
+    232, 236, 248, 252, 200, 204, 216, 220,
+    234, 238, 250, 254, 202, 206, 218, 222,
+    193, 197, 209, 213, 225, 229, 241, 245,
+    195, 199, 211, 215, 227, 231, 243, 247,
+    201, 205, 217, 221, 233, 237, 249, 253,
+    203, 207, 219, 223, 235, 239, 251, 255,
+];
+const blockTablePSMT4 = [
+     0,  2,  8, 10,
+     1,  3,  9, 11,
+     4,  6, 12, 14,
+     5,  7, 13, 15,
+];
+const columnTablePSMT4 = [
+      0,   8,  32,  40,  64,  72,  96, 104, // Column 0
+      2,  10,  34,  42,  66,  74,  98, 106,
+      4,  12,  36,  44,  68,  76, 100, 108,
+      6,  14,  38,  46,  70,  78, 102, 110,
+     16,  24,  48,  56,  80,  88, 112, 120,
+     18,  26,  50,  58,  82,  90, 114, 122,
+     20,  28,  52,  60,  84,  92, 116, 124,
+     22,  30,  54,  62,  86,  94, 118, 126,
+     65,  73,  97, 105,   1,   9,  33,  41,
+     67,  75,  99, 107,   3,  11,  35,  43,
+     69,  77, 101, 109,   5,  13,  37,  45,
+     71,  79, 103, 111,   7,  15,  39,  47,
+     81,  89, 113, 121,  17,  25,  49,  57,
+     83,  91, 115, 123,  19,  27,  51,  59,
+     85,  93, 117, 125,  21,  29,  53,  61,
+     87,  95, 119, 127,  23,  31,  55,  63,
+    192, 200, 224, 232, 128, 136, 160, 168, // Column 1
+    194, 202, 226, 234, 130, 138, 162, 170,
+    196, 204, 228, 236, 132, 140, 164, 172,
+    198, 206, 230, 238, 134, 142, 166, 174,
+    208, 216, 240, 248, 144, 152, 176, 184,
+    210, 218, 242, 250, 146, 154, 178, 186,
+    212, 220, 244, 252, 148, 156, 180, 188,
+    214, 222, 246, 254, 150, 158, 182, 190,
+    129, 137, 161, 169, 193, 201, 225, 233,
+    131, 139, 163, 171, 195, 203, 227, 235,
+    133, 141, 165, 173, 197, 205, 229, 237,
+    135, 143, 167, 175, 199, 207, 231, 239,
+    145, 153, 177, 185, 209, 217, 241, 249,
+    147, 155, 179, 187, 211, 219, 243, 251,
+    149, 157, 181, 189, 213, 221, 245, 253,
+    151, 159, 183, 191, 215, 223, 247, 255,
+    256, 264, 288, 296, 320, 328, 352, 360, // Column 2
+    258, 266, 290, 298, 322, 330, 354, 362,
+    260, 268, 292, 300, 324, 332, 356, 364,
+    262, 270, 294, 302, 326, 334, 358, 366,
+    272, 280, 304, 312, 336, 344, 368, 376,
+    274, 282, 306, 314, 338, 346, 370, 378,
+    276, 284, 308, 316, 340, 348, 372, 380,
+    278, 286, 310, 318, 342, 350, 374, 382,
+    321, 329, 353, 361, 257, 265, 289, 297,
+    323, 331, 355, 363, 259, 267, 291, 299,
+    325, 333, 357, 365, 261, 269, 293, 301,
+    327, 335, 359, 367, 263, 271, 295, 303,
+    337, 345, 369, 377, 273, 281, 305, 313,
+    339, 347, 371, 379, 275, 283, 307, 315,
+    341, 349, 373, 381, 277, 285, 309, 317,
+    343, 351, 375, 383, 279, 287, 311, 319,
+    448, 456, 480, 488, 384, 392, 416, 424, // Column 3
+    450, 458, 482, 490, 386, 394, 418, 426,
+    452, 460, 484, 492, 388, 396, 420, 428,
+    454, 462, 486, 494, 390, 398, 422, 430,
+    464, 472, 496, 504, 400, 408, 432, 440,
+    466, 474, 498, 506, 402, 410, 434, 442,
+    468, 476, 500, 508, 404, 412, 436, 444,
+    470, 478, 502, 510, 406, 414, 438, 446,
+    385, 393, 417, 425, 449, 457, 481, 489,
+    387, 395, 419, 427, 451, 459, 483, 491,
+    389, 397, 421, 429, 453, 461, 485, 493,
+    391, 399, 423, 431, 455, 463, 487, 495,
+    401, 409, 433, 441, 465, 473, 497, 505,
+    403, 411, 435, 443, 467, 475, 499, 507,
+    405, 413, 437, 445, 469, 477, 501, 509,
+    407, 415, 439, 447, 471, 479, 503, 511,
+];
+
+function getBlockIdPSMCT32(block: number, x: number, y: number): number {
+    const blockY = (y >>> 3) & 0x03;
+    const blockX = (x >>> 3) & 0x07;
+    return block + ((x >>> 1) & ~0x1F) + blockTablePSMCT32[(blockY << 3) | blockX];
+}
+
+function getPixelAddressPSMCT32(block: number, width: number, x: number, y: number): number {
+    const page = ((block >>> 5) + (y >>> 5) * width + (x >>> 6));
+    const columnBase = ((y >>> 1) & 0x03) << 4;
+    const columnY = y & 0x01;
+    const columnX = x & 0x07;
+    const column = columnBase + columnTablePSMCT32[(columnY << 3) | columnX];
+    const addr = ((page << 11) + (getBlockIdPSMCT32(block & 0x1F, x & 0x3F, y & 0x1F) << 6) + column);
+    return (addr << 2) & 0x003FFFFC;
+}
+
+function getBlockIdPSMT8(block: number, x: number, y: number): number {
+    const blockY = (y >>> 4) & 0x03;
+    const blockX = (x >>> 4) & 0x07;
+    return block + ((x >>> 2) & ~0x1F) + blockTablePSMT8[(blockY << 3) | blockX];
+}
+
+function getPixelAddressPSMT8(block: number, width: number, x: number, y: number): number {
+    const page = ((block >>> 5) + (y >>> 6) * (width >>> 1) + (x >>> 7));
+    const columnY = y & 0x0F;
+    const columnX = x & 0x0F;
+    const column = columnTablePSMT8[(columnY << 4) | columnX];
+    const addr = (page << 13) + (getBlockIdPSMT8(block & 0x1F, x & 0x7F, y & 0x3F) << 8) + column;
+    return addr;
+}
+
+function getBlockIdPSMT4(block: number, x: number, y: number): number {
+    const blockBase = ((y >>> 6) & 0x01) << 4;
+    const blockY = (y >>> 4) & 0x03;
+    const blockX = (x >>> 5) & 0x03;
+    return block + ((x >>> 2) & ~0x1F) + blockBase + blockTablePSMT4[(blockY << 2) | blockX];
+}
+
+function getPixelAddressPSMT4(block: number, width: number, x: number, y: number): number {
+    const page = ((block >>> 5) + (y >>> 7) * (width >>> 1) + (x >>> 7));
+    const columnY = y & 0x0F;
+    const columnX = x & 0x1F;
+    const column = columnTablePSMT4[(columnY << 5) | columnX];
+    const addr = (page << 14) + (getBlockIdPSMT4(block & 0x1F, x & 0x7F, y & 0x7F) << 9) + column;
+    return addr;
+}
+
+function gsMemoryMapUploadImagePSMCT32(map: GSMemoryMap, dbp: number, dbw: number, dsax: number, dsay: number, rrw: number, rrh: number, buffer: ArrayBufferSlice): void {
+    const view = buffer.createDataView();
+
+    let srcIdx = 0;
+    for (let y = dsay; y < dsay + rrh; y++) {
+        for (let x = dsax; x < dsax + rrw; x++) {
+            const p = getPixelAddressPSMCT32(dbp, dbw, x, y);
+            map.data[p + 0x00] = view.getUint8(srcIdx + 0x00);
+            map.data[p + 0x01] = view.getUint8(srcIdx + 0x01);
+            map.data[p + 0x02] = view.getUint8(srcIdx + 0x02);
+            map.data[p + 0x03] = view.getUint8(srcIdx + 0x03);
+            srcIdx += 0x04;
+        }
+    }
+}
+
+function gsMemoryMapUploadImagePSMT8(map: GSMemoryMap, dbp: number, dbw: number, dsax: number, dsay: number, rrw: number, rrh: number, buffer: ArrayBufferSlice): void {
+    const view = buffer.createDataView();
+
+    let srcIdx = 0;
+    for (let y = dsay; y < dsay + rrh; y++) {
+        for (let x = dsax; x < dsax + rrw; x++) {
+            const p = getPixelAddressPSMT8(dbp, dbw, x, y);
+            map.data[p] = view.getUint8(srcIdx);
+            srcIdx++;
+        }
+    }
+}
+
+function gsMemoryMapUploadImagePSMT4(map: GSMemoryMap, dbp: number, dbw: number, dsax: number, dsay: number, rrw: number, rrh: number, buffer: ArrayBufferSlice): void {
+    const view = buffer.createDataView();
+
+    let srcIdx = 0;
+    for (let y = dsay; y < dsay + rrh; y++) {
+        for (let x = dsax; x < dsax + rrw; x++) {
+            const p = getPixelAddressPSMT4(dbp, dbw, x, y);
+            const nibble = (view.getUint8(srcIdx >> 1) >> ((srcIdx & 1) << 2)) & 0xF;
+            map.data[p >> 1] = (nibble << ((p & 1) << 2)) | (map.data[p >> 1] & (0xF0 >> ((p & 1) << 2)));
+            srcIdx++;
+        }
+    }
+}
+
+export function gsMemoryMapUploadImage(map: GSMemoryMap, dpsm: GSPixelStorageFormat, dbp: number, dbw: number, dsax: number, dsay: number, rrw: number, rrh: number, buffer: ArrayBufferSlice): void {
+    if (dpsm === GSPixelStorageFormat.PSMCT32)
+        gsMemoryMapUploadImagePSMCT32(map, dbp, dbw, dsax, dsay, rrw, rrh, buffer);
+    else if (dpsm === GSPixelStorageFormat.PSMT8)
+        gsMemoryMapUploadImagePSMT8(map, dbp, dbw, dsax, dsay, rrw, rrh, buffer);
+    else if (dpsm === GSPixelStorageFormat.PSMT4)
+        gsMemoryMapUploadImagePSMT4(map, dbp, dbw, dsax, dsay, rrw, rrh, buffer);
+    else
+        throw "whoops";
+}
+
+export function gsMemoryMapReadImagePSMT4_PSMCT32(pixels: Uint8Array, map: GSMemoryMap, dbp: number, dbw: number, rrw: number, rrh: number, cbp: number, csa: number, alphaReg: number) {
+    let dstIdx = 0;
+
+    for (let y = 0; y < rrh; y++) {
+        for (let x = 0; x < rrw; x++) {
+            const addr = getPixelAddressPSMT4(dbp, dbw, x, y);
+            const clutIndex = (map.data[addr >>> 1] >> ((addr & 0x01) << 2)) & 0x0F;
+
+            const cy = ((clutIndex >>> 3) & 0x1) + (csa & 0xE);
+            const cx = (clutIndex & 0x07) + ((csa & 0x1) << 3);
+            const p = getPixelAddressPSMCT32(cbp, 1, cx, cy);
+            pixels[dstIdx + 0] = map.data[p + 0x00];
+            pixels[dstIdx + 1] = map.data[p + 0x01];
+            pixels[dstIdx + 2] = map.data[p + 0x02];
+            const rawAlpha = alphaReg == -1 ? map.data[p + 0x03] : alphaReg;
+            pixels[dstIdx + 3] = Math.min(0xFF, rawAlpha * 2);
+
+            dstIdx += 0x04;
+        }
+    }
+}
+
+export function gsMemoryMapReadImagePSMT8_PSMCT32(pixels: Uint8Array, map: GSMemoryMap, dbp: number, dbw: number, rrw: number, rrh: number, cbp: number, alphaReg: number) {
+    let dstIdx = 0;
+    for (let y = 0; y < rrh; y++) {
+        for (let x = 0; x < rrw; x++) {
+            const addr = getPixelAddressPSMT8(dbp, dbw, x, y);
+            const clutIndex = map.data[addr];
+
+            let cy = (clutIndex & 0xE0) >>> 4;
+            if (clutIndex & 0x08)
+                cy++;
+            let cx = clutIndex & 0x07;
+            if (clutIndex & 0x10)
+                cx += 0x08;
+
+            const p = getPixelAddressPSMCT32(cbp, 1, cx, cy);
+            pixels[dstIdx + 0] = map.data[p + 0x00];
+            pixels[dstIdx + 1] = map.data[p + 0x01];
+            pixels[dstIdx + 2] = map.data[p + 0x02];
+            const rawAlpha = alphaReg == -1 ? map.data[p + 0x03] : alphaReg;
+            pixels[dstIdx + 3] = Math.min(0xFF, rawAlpha * 2);
+
+            dstIdx += 0x04;
+        }
+    }
+}
+
+export function psmToString(psm: GSPixelStorageFormat): string {
+    switch (psm) {
+    case GSPixelStorageFormat.PSMT4: return 'PSMT4';
+    case GSPixelStorageFormat.PSMT8: return 'PSMT8';
+    default: return 'unknown';
+    }
+}


### PR DESCRIPTION
Parser and renderer for Kingdom Hearts II Final Mix (PS2). Final Mix contains a few extra maps including Cavern of Remembrance, Data Battles and some extra cutscenes.

.MAP files should be placed in: `data/kh2fm/`

This also includes a common library for EE GS operations in `src/ps2/gs.ts` copied from Katamari's parser, which could be used by KH1 and Katamari at some point in the future.