### PR TITLE
Rendering fixes for KH and KH2FM

### DIFF
--- a/src/kh/render.ts
+++ b/src/kh/render.ts
@@ -368,8 +368,8 @@ export class MapData {
         return device.createSampler({
             wrapS: GfxWrapMode.REPEAT,
             wrapT: GfxWrapMode.REPEAT,
-            minFilter: GfxTexFilterMode.POINT,
-            magFilter: GfxTexFilterMode.POINT,
+            minFilter: GfxTexFilterMode.BILINEAR,
+            magFilter: GfxTexFilterMode.BILINEAR,
             mipFilter: GfxMipFilterMode.NO_MIP,
             minLOD: 0, maxLOD: 0,
         });

--- a/src/kh2fm/map.ts
+++ b/src/kh2fm/map.ts
@@ -30,6 +30,8 @@ export class MapMesh {
     public layer = 0;
     public translucent: boolean = false;
     public uvScroll = vec2.fromValues(0, 0);
+    // Sets GS register ALPHA_1: {A = 0, B = 1, C = 0, D = 1, FIX = 0x80}
+    public addAlpha: boolean = false;
 }
 
 export class TextureBlock {
@@ -451,6 +453,7 @@ function parseGeometry(buffer: ArrayBufferSlice, geometryFile: BarFile, mapGroup
             mesh.texture = mapGroup.textureIndexMap.get(textureIndex)[1];
         }
         mesh.translucent = view.getUint16(i * 0x10 + 0x2A, true) === 0x1;
+        mesh.addAlpha = (view.getUint8(i * 0x10 + 0x2C) & 0x40) > 0;
         const uvScrollIndex = (view.getUint16(i * 0x10 + 0x2C, true) >> 1) & 0xF;
         if (uvScrollIndex > 0 && (mesh.texture.tiledU || mesh.texture.tiledV)) {
             mesh.uvScroll = vec2.fromValues(

--- a/src/kh2fm/map.ts
+++ b/src/kh2fm/map.ts
@@ -130,14 +130,17 @@ export class TextureAnimation {
         if (this.frames.length === 0) {
             return;
         }
-        this.frameTimer -= deltaTime / 1000;
+        this.frameTimer -= Math.abs(deltaTime) / 1000;
         if (this.frameTimer > 0) {
             return;
         }
-        this.frameIndex = (this.frameIndex + 1) % this.frames.length;
         const minTime = this.frames[this.frameIndex].minLength / 60;
         const maxTime = this.frames[this.frameIndex].maxLength / 60;
-        this.frameTimer += Math.random() * (maxTime - minTime) + minTime;
+        const nextFrame = deltaTime < 0 ? -1 : 1;
+        while (this.frameTimer < 0) {
+            this.frameIndex = ((this.frameIndex + nextFrame) % this.frames.length + this.frames.length) % this.frames.length;
+            this.frameTimer += Math.random() * (maxTime - minTime) + minTime;
+        }
     }
 
     public fillUVOffset(uvOffset: vec2) {


### PR DESCRIPTION
Small fixes for Kingdom Hearts renderers:

* Kingdom Hearts II Final Mix: 
   * Handle geometry flag which changes blending function via ALPHA_1.
   * Update TEXA animation timer to work with rewind, and fix timer breaking after tabbing out of the window.
* Kingdom Hearts:
   * Change texture filtering from point to bilinear.
