### PR TITLE
Pilotwings 64: Texture things mostly correctly

### DIFF
--- a/src/Pilotwings64/Scenes.ts
+++ b/src/Pilotwings64/Scenes.ts
@@ -1,5 +1,10 @@
 
-import { GfxDevice, GfxBuffer, GfxInputLayout, GfxInputState, GfxBufferUsage, GfxVertexAttributeDescriptor, GfxFormat, GfxVertexAttributeFrequency, GfxRenderPass, GfxHostAccessPass, GfxBindingLayoutDescriptor, GfxTextureDimension, GfxWrapMode, GfxMipFilterMode, GfxTexFilterMode, GfxTexture, GfxSampler } from "../gfx/platform/GfxPlatform";
+import {
+    GfxDevice, GfxBuffer, GfxInputLayout, GfxInputState, GfxBufferUsage,
+    GfxVertexAttributeDescriptor, GfxFormat, GfxVertexAttributeFrequency, GfxRenderPass,
+    GfxHostAccessPass, GfxBindingLayoutDescriptor, GfxTextureDimension, GfxWrapMode,
+    GfxMipFilterMode, GfxTexFilterMode, GfxSampler, GfxBlendFactor, GfxBlendMode
+} from "../gfx/platform/GfxPlatform";
 import { SceneGfx, ViewerRenderInput, Texture } from "../viewer";
 import { SceneDesc, SceneContext, SceneGroup } from "../SceneBase";
 import ArrayBufferSlice from "../ArrayBufferSlice";
@@ -1001,6 +1006,11 @@ class Pilotwings64Renderer implements SceneGfx {
     public prepareToRender(device: GfxDevice, hostAccessPass: GfxHostAccessPass, viewerInput: ViewerRenderInput): void {
         const template = this.renderHelper.pushTemplateRenderInst();
         template.setBindingLayouts(bindingLayouts);
+        template.setMegaStateFlags({
+            blendMode: GfxBlendMode.ADD,
+            blendSrcFactor: GfxBlendFactor.SRC_ALPHA,
+            blendDstFactor: GfxBlendFactor.ONE_MINUS_SRC_ALPHA,
+        });
 
         let offs = template.allocateUniformBuffer(PW64Program.ub_SceneParams, 16);
         const d = template.mapUniformBufferF32(PW64Program.ub_SceneParams);


### PR DESCRIPTION
The actually texture mapping is nowhere near correct yet.

I changed MeshInstance into MeshRenderer based on the bk naming, and it now has a collection of MaterialInstance s (not married to the name) which actually do the rendering.

I added a method to the TextureHolder that probably shouldn't be there, but it seemed preferable to unprotecting the equivalent method or adding an index->address lookup table, since everything uses those indices instead of addresses. 

I could also leave out the dummy texture, I just thought it would be visually helpful.