### PR TITLE
Pilotwings 64: Fix lots of small texture issues.

### DIFF
--- a/src/Common/N64/Image.ts
+++ b/src/Common/N64/Image.ts
@@ -137,7 +137,7 @@ export function decodeTex_CI8(dst: Uint8Array, view: DataView, srcIdx: number, t
 export function decodeTex_IA4(dst: Uint8Array, view: DataView, srcOffs: number, tileW: number, tileH: number, line: number = 0, deinterleave: boolean = false): void {
     let dstIdx = 0;
     let srcIdx = 0;
-    const padW = (line !== 0) ? (((line << 4) - tileW) << 1) : 0x00;
+    const padW = (line !== 0) ? (((line << 4) - tileW) >>> 1) : 0x00;
     for (let y = 0; y < tileH; y++) {
         const di = deinterleave ? ((y & 1) << 2) : 0;
         for (let x = 0; x < tileW; x += 2) {
@@ -164,7 +164,7 @@ export function decodeTex_IA4(dst: Uint8Array, view: DataView, srcOffs: number, 
 export function decodeTex_IA8(dst: Uint8Array, view: DataView, srcOffs: number, tileW: number, tileH: number, line: number = 0, deinterleave: boolean = false): void {
     let dstIdx = 0;
     let srcIdx = 0;
-    const padW = (line !== 0) ? (((line << 3) - tileW) << 1) : 0x00;
+    const padW = (line !== 0) ? ((line << 3) - tileW) : 0x00;
     for (let y = 0; y < tileH; y++) {
         const di = deinterleave ? ((y & 1) << 2) : 0;
         for (let x = 0; x < tileW; x++) {
@@ -205,7 +205,7 @@ export function decodeTex_IA16(dst: Uint8Array, view: DataView, srcOffs: number,
 export function decodeTex_I4(dst: Uint8Array, view: DataView, srcOffs: number, tileW: number, tileH: number, line: number = 0, deinterleave: boolean = false): void {
     let dstIdx = 0;
     let srcIdx = 0;
-    const padW = (line !== 0) ? (((line << 4) - tileW) << 1) : 0x00;
+    const padW = (line !== 0) ? (((line << 4) - tileW) >>> 1) : 0x00;
     for (let y = 0; y < tileH; y++) {
         const di = deinterleave ? ((y & 1) << 2) : 0;
         for (let x = 0; x < tileW; x += 2) {

--- a/src/bk/render.ts
+++ b/src/bk/render.ts
@@ -1,7 +1,7 @@
 
 import * as Viewer from '../viewer';
 import { DeviceProgram } from "../Program";
-import { Texture, getImageFormatString, RSPOutput, Vertex, DrawCall, GeometryMode, OtherModeH_CycleType } from "./f3dex";
+import { Texture, getImageFormatString, RSPOutput, Vertex, DrawCall, GeometryMode, OtherModeH_CycleType, getTextFiltFromOtherModeH } from "./f3dex";
 import { GfxDevice, GfxTextureDimension, GfxFormat, GfxTexture, GfxSampler, GfxWrapMode, GfxTexFilterMode, GfxMipFilterMode, GfxBuffer, GfxBufferUsage, GfxInputLayout, GfxInputState, GfxVertexAttributeDescriptor, GfxVertexAttributeFrequency, GfxBindingLayoutDescriptor, GfxBlendMode, GfxBlendFactor, GfxCullMode, GfxMegaStateDescriptor, GfxProgram } from "../gfx/platform/GfxPlatform";
 import { makeStaticDataBuffer } from '../gfx/helpers/BufferHelpers';
 import { assert, nArray } from '../util';
@@ -12,6 +12,7 @@ import { TextureMapping } from '../TextureHolder';
 import { interactiveVizSliderSelect } from '../DebugJunk';
 import { GfxRenderInstManager } from '../gfx/render/GfxRenderer';
 import { GfxRenderCache } from '../gfx/render/GfxRenderCache';
+import { TextFilt } from '../Common/N64/Image';
 
 class F3DEX_Program extends DeviceProgram {
     public static a_Position = 0;
@@ -83,7 +84,7 @@ void main() {
         const drawCall = this.drawCall;
         const cycletype: OtherModeH_CycleType = (drawCall.DP_OtherModeH >>> 20) & 0x03;
 
-        const textFilt = (this.drawCall.DP_OtherModeH >>> 12) & 0x03;
+        const textFilt = getTextFiltFromOtherModeH(drawCall.DP_OtherModeH);
         let texFiltStr: string;
         if (textFilt === TextFilt.G_TF_POINT)
             texFiltStr = 'Point';
@@ -271,12 +272,6 @@ function translateCullMode(m: number): GfxCullMode {
         return GfxCullMode.BACK;
     else
         return GfxCullMode.NONE;
-}
-
-const enum TextFilt {
-    G_TF_POINT   = 0x00,
-    G_TF_AVERAGE = 0x03,
-    G_TF_BILERP  = 0x02,
 }
 
 const modelViewScratch = mat4.create();


### PR DESCRIPTION
- Set scrolling texture dimensions correctly
- Fix I4 and IA4 decoding
- Properly handle paired textures in tile 0
- Check 2-cycle and filtering "other" modes