### PR TITLE
GTA: compress assets

### DIFF
--- a/src/GrandTheftAuto3/tools/compress.ts
+++ b/src/GrandTheftAuto3/tools/compress.ts
@@ -1,0 +1,12 @@
+
+import { readFileSync, writeFileSync } from 'fs';
+import { deflate } from 'pako';
+
+for (const release of ['3', 'ViceCity', 'SanAndreas']) {
+    const pathBase = `../../../data/GrandTheftAuto${release}/models/gta3`;
+    console.log('Compressing', `${pathBase}.img`);
+    const img = readFileSync(`${pathBase}.img`);
+    const imgz = deflate(img, { level: 9 });
+    console.log('Writing', `${pathBase}.imgz`);
+    writeFileSync(`${pathBase}.imgz`, imgz);
+}


### PR DESCRIPTION
This roughly halves the download size for each map. You'll need to run the `compress` script and upload the `.imgz` files it generates.