### PR TITLE
ztp: Improve mirror render hack

### DIFF
--- a/src/MathHelpers.ts
+++ b/src/MathHelpers.ts
@@ -46,6 +46,34 @@ export function computeModelMatrixSRT(dst: mat4, scaleX: number, scaleY: number,
 }
 
 /**
+ * Computes a model matrix {@param dst} from given scale parameters.
+ * 
+ * This is equivalent to {@link computeModelMatrixSRT} with the rotation parameters set to
+ * 0 and the translation set to 0.
+ */
+export function computeModelMatrixS(dst: mat4, scaleX: number, scaleY: number, scaleZ: number): void {
+    dst[0] =  scaleX;
+    dst[1] =  0.0;
+    dst[2] =  0.0;
+    dst[3] =  0.0;
+
+    dst[4] =  0.0;
+    dst[5] =  scaleY;
+    dst[6] =  0.0;
+    dst[7] =  0.0;
+
+    dst[8] =  0.0;
+    dst[9] =  0.0;
+    dst[10] = scaleZ;
+    dst[11] = 0.0;
+
+    dst[12] = 0.0;
+    dst[13] = 0.0;
+    dst[14] = 0.0;
+    dst[15] = 1.0;
+}
+
+/**
  * Computes a model matrix {@param dst} from given rotation parameters. Rotation is assumed
  * to be in radians.
  * 

--- a/src/j3d/ztp_scenes.ts
+++ b/src/j3d/ztp_scenes.ts
@@ -17,6 +17,7 @@ import { GXRenderHelperGfx, fillSceneParamsDataOnTemplate } from '../gx/gx_rende
 import { BasicRenderTarget, ColorTexture, standardFullClearRenderPassDescriptor, depthClearRenderPassDescriptor, noClearRenderPassDescriptor } from '../gfx/helpers/RenderTargetHelpers';
 import { GfxRenderCache } from '../gfx/render/GfxRenderCache';
 import { SceneContext } from '../SceneBase';
+import { computeModelMatrixS } from '../MathHelpers';
 
 class ZTPExtraTextures {
     public extraTextures: BTIData[] = [];
@@ -97,7 +98,8 @@ class TwilightPrincessRenderer implements Viewer.SceneGfx {
     }
 
     private setMirrored(mirror: boolean): void {
-        const negScaleMatrix = mat4.fromValues(-1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1);
+        const negScaleMatrix = mat4.create();
+        computeModelMatrixS(negScaleMatrix, -1, 1, 1);
         for (let i = 0; i < this.modelInstances.length; i++) {
             mat4.mul(this.modelInstances[i].modelMatrix, negScaleMatrix, this.modelInstances[i].modelMatrix);
             for (let j = 0; j < this.modelInstances[i].materialInstances.length; j++)

--- a/src/j3d/ztp_scenes.ts
+++ b/src/j3d/ztp_scenes.ts
@@ -7,6 +7,7 @@ import * as UI from '../ui';
 
 import { BMD, BMT, BTK, BTI, BRK, BCK, BTI_Texture } from './j3d';
 import * as RARC from './rarc';
+import { mat4 } from 'gl-matrix';
 import { BMDModel, BMDModelInstance, BTIData, BMDModelMaterialData } from './render';
 import { EFB_WIDTH, EFB_HEIGHT, GXMaterialHacks } from '../gx/gx_material';
 import { TextureMapping } from '../TextureHolder';
@@ -96,8 +97,9 @@ class TwilightPrincessRenderer implements Viewer.SceneGfx {
     }
 
     private setMirrored(mirror: boolean): void {
+        const negScaleMatrix = mat4.fromValues(-1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1);
         for (let i = 0; i < this.modelInstances.length; i++) {
-            this.modelInstances[i].modelMatrix[0] = mirror ? -1 : 1;
+            mat4.mul(this.modelInstances[i].modelMatrix, negScaleMatrix, this.modelInstances[i].modelMatrix);
             for (let j = 0; j < this.modelInstances[i].materialInstances.length; j++)
                 this.modelInstances[i].materialInstances[j].materialHelper.megaStateFlags.frontFace = mirror ? GfxFrontFaceMode.CCW : GfxFrontFaceMode.CW;
         }

--- a/src/rres/Scenes_MarioKartWii.ts
+++ b/src/rres/Scenes_MarioKartWii.ts
@@ -14,7 +14,7 @@ import { RRESTextureHolder, MDL0Model, MDL0ModelInstance } from './render';
 import AnimationController from '../AnimationController';
 import { BasicGXRendererHelper, fillSceneParamsDataOnTemplate } from '../gx/gx_render';
 import { GfxDevice, GfxHostAccessPass, GfxFrontFaceMode } from '../gfx/platform/GfxPlatform';
-import { computeModelMatrixSRT, MathConstants, lerp, clamp } from '../MathHelpers';
+import { computeModelMatrixSRT, computeModelMatrixS, MathConstants, lerp, clamp } from '../MathHelpers';
 import { SceneContext, GraphObjBase } from '../SceneBase';
 import { EggLightManager, parseBLIGHT } from './Egg';
 import { GfxRendererLayer, GfxRenderInstManager } from '../gfx/render/GfxRenderer';
@@ -70,7 +70,8 @@ class MarioKartWiiRenderer extends BasicGXRendererHelper {
     public modelCache = new ModelCache();
 
     private setMirrored(mirror: boolean): void {
-        const negScaleMatrix = mat4.fromValues(-1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1);
+        const negScaleMatrix = mat4.create();
+        computeModelMatrixS(negScaleMatrix, -1, 1, 1);
         for (let i = 0; i < this.baseObjects.length; i++) {
             mat4.mul(this.baseObjects[i].modelMatrix, negScaleMatrix, this.baseObjects[i].modelMatrix);
             for (let j = 0; j < getModelInstance(this.baseObjects[i]).materialInstances.length; j++)


### PR DESCRIPTION
Keeps spawned objects in the correct place, despite not being set yet.