### PR TITLE
Add basic touch controls

### DIFF
--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -364,6 +364,8 @@ export class FPSCameraController implements CameraController {
             if (Math.abs(keyMovement[0]) < keyMoveLowSpeedCap) keyMovement[0] = 0.0;
         }
 
+        keyMovement[0] += -inputManager.getTouchDeltaX();
+
         if (inputManager.isKeyDown('KeyQ') || inputManager.isKeyDown('PageDown') || (inputManager.isKeyDown('ControlLeft') && inputManager.isKeyDown('Space'))) {
             keyMovement[1] = clampRange(keyMovement[1] - keyMoveVelocity, keyMoveSpeedCap);
         } else if (inputManager.isKeyDown('KeyE') || inputManager.isKeyDown('PageUp') || inputManager.isKeyDown('Space')) {
@@ -372,6 +374,8 @@ export class FPSCameraController implements CameraController {
             keyMovement[1] *= this.keyMoveDrag;
             if (Math.abs(keyMovement[1]) < keyMoveLowSpeedCap) keyMovement[1] = 0.0;
         }
+
+        keyMovement[1] += inputManager.getTouchDeltaY();
 
         const worldUp = scratchVec3b;
         // Instead of getting the camera up, instead use world up. Feels more natural.

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -353,6 +353,8 @@ export class FPSCameraController implements CameraController {
             if (Math.abs(keyMovement[2]) < keyMoveLowSpeedCap) keyMovement[2] = 0.0;
         }
 
+        keyMovement[2] += -inputManager.getDoubleTouchDeltaDist();
+
         if (inputManager.isKeyDown('KeyA') || inputManager.isKeyDown('ArrowLeft')) {
             keyMovement[0] = clampRange(keyMovement[0] - keyMoveVelocity, keyMoveSpeedCap);
         } else if (inputManager.isKeyDown('KeyD') || inputManager.isKeyDown('ArrowRight')) {

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -353,7 +353,7 @@ export class FPSCameraController implements CameraController {
             if (Math.abs(keyMovement[2]) < keyMoveLowSpeedCap) keyMovement[2] = 0.0;
         }
 
-        keyMovement[2] += -inputManager.getDoubleTouchDeltaDist();
+        keyMovement[2] += -inputManager.getPinchDeltaDist();
 
         if (inputManager.isKeyDown('KeyA') || inputManager.isKeyDown('ArrowLeft')) {
             keyMovement[0] = clampRange(keyMovement[0] - keyMoveVelocity, keyMoveSpeedCap);

--- a/src/InputManager.ts
+++ b/src/InputManager.ts
@@ -110,6 +110,16 @@ export default class InputManager {
         return this.dy;
     }
 
+    public getTouchDeltaX(): number {
+        // XXX: In non-pinch mode, touch deltas are turned into mouse deltas.
+        return this.touchGesture == TouchGesture.Pinch ? this.dTouchX : 0;
+    }
+
+    public getTouchDeltaY(): number {
+        // XXX: In non-pinch mode, touch deltas are turned into mouse deltas.
+        return this.touchGesture == TouchGesture.Pinch ? this.dTouchY : 0;
+    }
+
     public getPinchDeltaDist(): number {
         return this.touchGesture == TouchGesture.Pinch ? this.dPinchDist : 0;
     }
@@ -130,6 +140,8 @@ export default class InputManager {
         this.dx = 0;
         this.dy = 0;
         this.dz = 0;
+        this.dTouchX = 0;
+        this.dTouchY = 0;
         this.dPinchDist = 0;
 
         // Go through and mark all keys as non-event-triggered.


### PR DESCRIPTION
This PR adds basic (crude) touch controls, in order to make noclip usable on mobile devices.

The following touch controls are implemented:
- [x] Single-touch and drag to perform the equivalent of mouse dragging.
- [x] Double-touch and pinch (or spread apart) to move forward or back in FPS mode.

The following features would be desirable, but are not implemented by this PR:
- [ ] A button to open or close the UI. This is currently difficult on touch devices in portrait mode.
- [ ] Specialized touch controls for orbit and orthographic cameras.
- [ ] Speed controls