### PR TITLE
BFBB: ENV support and more render hacks

### DIFF
--- a/src/SpongeBobBFBB/assets.ts
+++ b/src/SpongeBobBFBB/assets.ts
@@ -687,11 +687,17 @@ export function readModelInfo(stream: DataStream): ModelAssetInfo {
     return { Magic, NumModelInst, AnimTableID, CombatID, BrainID, modelInst };
 }
 
+export const enum PipeZWriteMode {
+    Enabled,
+    Disabled,
+    Dual
+}
+
 export const enum PipeCullMode {
     Unknown0,
     None,
     Back,
-    Unknown3 // front+back?
+    Dual
 }
 
 // RwBlendFunction
@@ -713,8 +719,8 @@ export const enum PipeBlendFunction {
 export class PipeInfoFlags {
     constructor(public flags: number) {}
 
-    public get noZWrite(): boolean {
-        return ((this.flags & 0xC) >>> 2) === 1;
+    public get zWriteMode(): PipeZWriteMode {
+        return ((this.flags & 0xC) >>> 2);
     }
 
     public get cullMode(): PipeCullMode {

--- a/src/SpongeBobBFBB/assets.ts
+++ b/src/SpongeBobBFBB/assets.ts
@@ -57,9 +57,50 @@ export function readBaseAsset(stream: DataStream): BaseAsset {
     return { id, baseType, linkCount, baseFlags, links };
 }
 
+export interface EnvAsset extends BaseAsset {
+    bspAssetID: number; // JSP info ID
+    startCameraAssetID: number;
+    climateFlags: number;
+    climateStrengthMin: number;
+    climateStrengthMax: number;
+    bspLightKit: number; // not used
+    objectLightKit: number;
+    padF1: number;
+    bspCollisionAssetID: number;
+    bspFXAssetID: number;
+    bspCameraAssetID: number;
+    bspMapperID: number;
+    bspMapperCollisionID: number;
+    bspMapperFXID: number;
+    loldHeight: number;
+}
+
+export function readEnvAsset(stream: DataStream): EnvAsset {
+    const { id, baseType, linkCount, baseFlags, links } = readBaseAsset(stream);
+    const bspAssetID = stream.readUInt32();
+    const startCameraAssetID = stream.readUInt32();
+    const climateFlags = stream.readUInt32();
+    const climateStrengthMin = stream.readFloat();
+    const climateStrengthMax = stream.readFloat();
+    const bspLightKit = stream.readUInt32();
+    const objectLightKit = stream.readUInt32();
+    const padF1 = stream.readFloat();
+    const bspCollisionAssetID = stream.readUInt32()
+    const bspFXAssetID = stream.readUInt32();
+    const bspCameraAssetID = stream.readUInt32();
+    const bspMapperID = stream.readUInt32()
+    const bspMapperCollisionID = stream.readUInt32();
+    const bspMapperFXID = stream.readUInt32();
+    const loldHeight = stream.readFloat();
+    const env: EnvAsset = { id, baseType, linkCount, baseFlags, links, bspAssetID, startCameraAssetID, climateFlags, climateStrengthMin, climateStrengthMax,
+        bspLightKit, objectLightKit, padF1, bspCollisionAssetID, bspFXAssetID, bspCameraAssetID, bspMapperID, bspMapperCollisionID, bspMapperFXID, loldHeight };
+    readLinks(stream, env);
+    return env;
+}
+
 export interface FogAsset extends BaseAsset {
-    bkgndColor: number[];
-    fogColor: number[];
+    bkgndColor: Color;
+    fogColor: Color;
     fogDensity: number;
     fogStart: number;
     fogStop: number;
@@ -70,16 +111,8 @@ export interface FogAsset extends BaseAsset {
 
 export function readFogAsset(stream: DataStream): FogAsset {
     const { id, baseType, linkCount, baseFlags, links } = readBaseAsset(stream);
-    const bkgndColor: number[] = [];
-    bkgndColor.push(stream.readUInt8());
-    bkgndColor.push(stream.readUInt8());
-    bkgndColor.push(stream.readUInt8());
-    bkgndColor.push(stream.readUInt8());
-    const fogColor: number[] = [];
-    fogColor.push(stream.readUInt8());
-    fogColor.push(stream.readUInt8());
-    fogColor.push(stream.readUInt8());
-    fogColor.push(stream.readUInt8());
+    const bkgndColor = stream.readColor8();
+    const fogColor = stream.readColor8();
     const fogDensity = stream.readFloat();
     const fogStart = stream.readFloat();
     const fogStop = stream.readFloat();
@@ -593,6 +626,10 @@ export function readLightKit(stream: DataStream): LightKit {
         lightListArray.push({ type, color, matrix, radius, angle, platLight });
     }
     return { tagID, groupID, lightCount, lightList, lightListArray };
+}
+
+interface JSPInfo {
+
 }
 
 export const enum PipeCullMode {

--- a/src/SpongeBobBFBB/program.glsl
+++ b/src/SpongeBobBFBB/program.glsl
@@ -52,7 +52,7 @@ void main() {
     v_Color = a_Color;
     v_TexCoord = a_TexCoord;
 
-    vec3 t_Normal = normalize(Mul(transpose(inverse(_Mat4x4(u_ModelMatrix))), vec4(a_Normal, 1.0)).xyz);
+    vec3 t_Normal = normalize(Mul(_Mat4x4(u_ModelMatrix), vec4(a_Normal, 0.0)).xyz);
 
 #ifdef USE_LIGHTING
     if (USE_LIGHTING == 1) {

--- a/src/SpongeBobBFBB/program.glsl
+++ b/src/SpongeBobBFBB/program.glsl
@@ -52,7 +52,8 @@ void main() {
     v_Color = a_Color;
     v_TexCoord = a_TexCoord;
 
-    vec3 t_Normal = normalize(Mul(_Mat4x4(u_ModelMatrix), vec4(a_Normal, 0.0)).xyz);
+   // vec4 t_Normal = Mul(transpose(inverse(_Mat4x4(u_ModelMatrix))), vec4(a_Normal, 1.0));
+    //vec4 t_Normal = vec4(a_Normal, 1.0);
 
 #ifdef USE_LIGHTING
     if (USE_LIGHTING == 1) {
@@ -62,14 +63,14 @@ void main() {
             Light light = u_Lights[i];
             if (light.type == 0.0) break;
 
-            vec3 lightColor = light.color.rgb; // alpha is ignored
+            vec3 colorFactor = (light.color.rgb * light.color.a);
 
             if (light.type == LIGHT_TYPE_AMBIENT) {
-                v_LightColor += lightColor;
+                v_LightColor += colorFactor;
             } else if (light.type == LIGHT_TYPE_DIRECTIONAL) {
-                vec3 lightDir = normalize(light.direction.xyz);
-                float diffuse = clamp(dot(t_Normal, lightDir), 0.0, 1.0);
-                v_LightColor += diffuse * lightColor;
+                vec3 lightDir = normalize(-light.rotation.xyz);
+                float diffuse = max(dot(a_Normal, lightDir), 0.0);
+                v_LightColor += diffuse * colorFactor;
             }
         }
     }

--- a/src/SpongeBobBFBB/program.glsl
+++ b/src/SpongeBobBFBB/program.glsl
@@ -52,8 +52,7 @@ void main() {
     v_Color = a_Color;
     v_TexCoord = a_TexCoord;
 
-   // vec4 t_Normal = Mul(transpose(inverse(_Mat4x4(u_ModelMatrix))), vec4(a_Normal, 1.0));
-    //vec4 t_Normal = vec4(a_Normal, 1.0);
+    vec3 t_Normal = normalize(Mul(transpose(inverse(_Mat4x4(u_ModelMatrix))), vec4(a_Normal, 1.0)).xyz);
 
 #ifdef USE_LIGHTING
     if (USE_LIGHTING == 1) {
@@ -63,14 +62,14 @@ void main() {
             Light light = u_Lights[i];
             if (light.type == 0.0) break;
 
-            vec3 colorFactor = (light.color.rgb * light.color.a);
+            vec3 lightColor = light.color.rgb; // alpha is ignored
 
             if (light.type == LIGHT_TYPE_AMBIENT) {
-                v_LightColor += colorFactor;
+                v_LightColor += lightColor;
             } else if (light.type == LIGHT_TYPE_DIRECTIONAL) {
-                vec3 lightDir = normalize(-light.rotation.xyz);
-                float diffuse = max(dot(a_Normal, lightDir), 0.0);
-                v_LightColor += diffuse * colorFactor;
+                vec3 lightDir = normalize(light.direction.xyz);
+                float diffuse = clamp(dot(t_Normal, lightDir), 0.0, 1.0);
+                v_LightColor += diffuse * lightColor;
             }
         }
     }

--- a/src/SpongeBobBFBB/program.glsl
+++ b/src/SpongeBobBFBB/program.glsl
@@ -23,11 +23,18 @@ layout(row_major, std140) uniform ub_SceneParams {
     Mat4x3 u_ViewMatrix;
     vec4 u_FogColor;
     vec4 u_FogParams;
-    Light u_Lights[LIGHT_COUNT];
+    Light u_ObjectLights[LIGHT_COUNT];
+    Light u_PlayerLights[LIGHT_COUNT];
 };
 
 #define u_FogStart (u_FogParams.x)
 #define u_FogStop (u_FogParams.y)
+
+#ifdef PLAYER
+#define u_Lights u_PlayerLights
+#else
+#define u_Lights u_ObjectLights
+#endif
 
 layout(row_major, std140) uniform ub_ModelParams {
     Mat4x3 u_ModelMatrix;
@@ -85,6 +92,10 @@ void main() {
     if (u_FogColor.a > 0.0 && t_Distance > u_FogStop) discard;
 
     vec4 t_Color = v_Color;
+
+#ifdef PLAYER
+    t_Color.rgb = vec3(1.0, 1.0, 1.0);
+#endif
 
 #ifdef USE_TEXTURE
     if (USE_TEXTURE == 1)

--- a/src/SpongeBobBFBB/program.glsl
+++ b/src/SpongeBobBFBB/program.glsl
@@ -2,13 +2,13 @@
 precision mediump float; precision lowp sampler2D;
 
 struct Light {
-    vec4 position;
-    vec4 direction;
-    vec4 color;
     float type;
     float radius;
     float angle;
     float pad;
+    vec4 position;
+    vec4 direction;
+    vec4 color;
 };
 
 #define LIGHT_TYPE_AMBIENT     1.0 // rpLIGHTAMBIENT

--- a/src/SpongeBobBFBB/render.ts
+++ b/src/SpongeBobBFBB/render.ts
@@ -26,6 +26,8 @@ import { TextureMapping } from '../TextureHolder';
 import { RWAtomicStruct, RWChunk, parseRWAtomic, createRWStreamFromChunk, RWAtomicFlags, quatFromYPR } from './util';
 import { EventID } from './events';
 import { reverseDepthForCompareMode } from '../gfx/helpers/ReversedDepthHelpers';
+import { computeEulerAngleRotationFromSRTMatrix } from '../MathHelpers';
+import { Asset } from './hip';
 
 const DRAW_DISTANCE = 1000.0;
 
@@ -424,9 +426,9 @@ class MeshRenderer {
             vbuf[voffs++] = posnorm[2];
             this.bbox.unionPoint(posnorm);
             frag.fillNormal(posnorm, i);
-            vbuf[voffs++] = posnorm[0];
-            vbuf[voffs++] = posnorm[1];
-            vbuf[voffs++] = posnorm[2];
+            vbuf[voffs++] = posnorm[2]; // Normal has to be rotated for whatever reason...
+            vbuf[voffs++] = posnorm[0]; // These coordinates might be wrong. They look
+            vbuf[voffs++] = posnorm[1]; // the most accurate out of all combinations though
             frag.fillColor(color, i);
             voffs += fillColor(vbuf, voffs, color);
             frag.fillTexCoord(texcoord, i);
@@ -704,6 +706,8 @@ export class BFBBRenderer implements Viewer.SceneGfx {
 
     private lightPositionCache: vec3[] = [];
     private lightDirectionCache: vec3[] = [];
+
+    private lightingEnabled = true;
 
     private lightingEnabled = true;
 

--- a/src/SpongeBobBFBB/render.ts
+++ b/src/SpongeBobBFBB/render.ts
@@ -602,12 +602,18 @@ export class FragRenderer extends BaseRenderer {
         renderInst.drawIndexes(this.indices);
         renderInst.setGfxProgram(this.gfxProgram);
 
+        const oldCullMode = this.megaStateFlags.cullMode;
+        const oldDepthWrite = this.megaStateFlags.depthWrite;
+
         if (this.dualCull)
             this.megaStateFlags.cullMode = secondPass ? GfxCullMode.BACK : GfxCullMode.FRONT;
         else if (this.dualZWrite)
             this.megaStateFlags.depthWrite = secondPass;
         
         renderInst.setMegaStateFlags(this.megaStateFlags);
+
+        this.megaStateFlags.cullMode = oldCullMode;
+        this.megaStateFlags.depthWrite = oldDepthWrite;
 
         if (this.frag.textureData !== undefined)
             renderInst.setSamplerBindingsFromTextureMappings(this.frag.textureData.textureMapping);

--- a/src/SpongeBobBFBB/render.ts
+++ b/src/SpongeBobBFBB/render.ts
@@ -26,8 +26,6 @@ import { TextureMapping } from '../TextureHolder';
 import { RWAtomicStruct, RWChunk, parseRWAtomic, createRWStreamFromChunk, RWAtomicFlags, quatFromYPR } from './util';
 import { EventID } from './events';
 import { reverseDepthForCompareMode } from '../gfx/helpers/ReversedDepthHelpers';
-import { computeEulerAngleRotationFromSRTMatrix } from '../MathHelpers';
-import { Asset } from './hip';
 
 const DRAW_DISTANCE = 1000.0;
 
@@ -426,9 +424,9 @@ class MeshRenderer {
             vbuf[voffs++] = posnorm[2];
             this.bbox.unionPoint(posnorm);
             frag.fillNormal(posnorm, i);
-            vbuf[voffs++] = posnorm[2]; // Normal has to be rotated for whatever reason...
-            vbuf[voffs++] = posnorm[0]; // These coordinates might be wrong. They look
-            vbuf[voffs++] = posnorm[1]; // the most accurate out of all combinations though
+            vbuf[voffs++] = posnorm[0];
+            vbuf[voffs++] = posnorm[1];
+            vbuf[voffs++] = posnorm[2];
             frag.fillColor(color, i);
             voffs += fillColor(vbuf, voffs, color);
             frag.fillTexCoord(texcoord, i);
@@ -706,8 +704,6 @@ export class BFBBRenderer implements Viewer.SceneGfx {
 
     private lightPositionCache: vec3[] = [];
     private lightDirectionCache: vec3[] = [];
-
-    private lightingEnabled = true;
 
     private lightingEnabled = true;
 

--- a/src/SpongeBobBFBB/scenes.ts
+++ b/src/SpongeBobBFBB/scenes.ts
@@ -6,7 +6,7 @@ import { SceneContext } from '../SceneBase';
 import { DataFetcher } from '../DataFetcher';
 import { initializeBasis } from '../vendor/basis_universal';
 
-import { ModelCache, BFBBRenderer, TextureCache, TextureData, EntRenderer, ModelData, Fog, JSP, JSPRenderer } from './render';
+import { ModelCache, BFBBRenderer, ModelRenderer, TextureCache, TextureData, EntRenderer, ModelData, Fog, JSP, JSPRenderer } from './render';
 import { Ent, Button, Platform, Player, SimpleObj } from './render';
 import { parseHIP, Asset } from './hip';
 import * as Assets from './assets';

--- a/src/SpongeBobBFBB/scenes.ts
+++ b/src/SpongeBobBFBB/scenes.ts
@@ -6,7 +6,7 @@ import { SceneContext } from '../SceneBase';
 import { DataFetcher } from '../DataFetcher';
 import { initializeBasis } from '../vendor/basis_universal';
 
-import { ModelCache, BFBBRenderer, ModelRenderer, TextureCache, TextureData, EntRenderer, ModelData, Fog, JSP, JSPRenderer } from './render';
+import { ModelCache, BFBBRenderer, TextureCache, TextureData, EntRenderer, ModelData, Fog, JSP, JSPRenderer } from './render';
 import { Ent, Button, Platform, Player, SimpleObj } from './render';
 import { parseHIP, Asset } from './hip';
 import * as Assets from './assets';

--- a/src/SpongeBobBFBB/scenes.ts
+++ b/src/SpongeBobBFBB/scenes.ts
@@ -340,12 +340,12 @@ class BFBBSceneDesc implements Viewer.SceneDesc {
         }
 
         if (dataHolder.fog) {
-            renderer.setFog(dataHolder.fog);
+            renderer.fog = dataHolder.fog;
             dataHolder.fog = undefined;
         }
 
         if (dataHolder.lightKit) {
-            renderer.setLightKit(dataHolder.lightKit);
+            renderer.lightKit = dataHolder.lightKit;
             dataHolder.lightKit = undefined;
         }
 

--- a/src/SpongeBobBFBB/util.ts
+++ b/src/SpongeBobBFBB/util.ts
@@ -159,6 +159,67 @@ export class DataStream {
     }
 }
 
+export class DataCacheIDName<T> {
+    private nameToDataMap = new Map<string, T>();
+    private idToDataMap = new Map<number, T>();
+
+    private nameToLockMap = new Map<string, boolean>();
+    private idToLockMap = new Map<number, boolean>();
+
+    private dataCount = 0;
+
+    public get count() { return this.dataCount; }
+
+    public add(data: T, name: string, id: number, lock: boolean) {
+        this.nameToDataMap.set(name, data);
+        this.idToDataMap.set(id, data);
+        this.nameToLockMap.set(name, lock);
+        this.idToLockMap.set(id, lock);
+        this.dataCount++;
+    }
+
+    public getByName(name: string) {
+        return this.nameToDataMap.get(name);
+    }
+
+    public getByID(id: number) {
+        return this.idToDataMap.get(id);
+    }
+
+    public removeByName(name: string, force: boolean) {
+        if (force || !this.nameToLockMap.get(name))
+            this.nameToDataMap.delete(name);
+    }
+
+    public removeByID(id: number, force: boolean) {
+        if (force || !this.idToLockMap.get(name))
+            this.idToDataMap.delete(id);
+    }
+
+    // Clears just unlocked data or all data
+    public clear(all: boolean = false) {
+        if (all) {
+            this.idToDataMap.clear();
+            this.nameToDataMap.clear();
+            this.idToLockMap.clear();
+            this.nameToLockMap.clear();
+        } else {
+            for (const [id, lock] of this.idToLockMap) {
+                if (!lock) {
+                    this.idToDataMap.delete(id);
+                    this.idToLockMap.delete(id);
+                }
+            }
+            for (const [name, lock] of this.nameToLockMap) {
+                if (!lock) {
+                    this.nameToDataMap.delete(name);
+                    this.nameToLockMap.delete(name);
+                }
+            }
+        }
+    }
+}
+
 export interface RWChunkHeader {
     type: number;
     length: number;

--- a/src/SpongeBobBFBB/util.ts
+++ b/src/SpongeBobBFBB/util.ts
@@ -170,7 +170,7 @@ export class DataCacheIDName<T> {
 
     public get count() { return this.dataCount; }
 
-    public add(data: T, name: string, id: number, lock: boolean) {
+    public add(data: T, name: string, id: number, lock: boolean = false) {
         this.nameToDataMap.set(name, data);
         this.idToDataMap.set(id, data);
         this.nameToLockMap.set(name, lock);
@@ -186,37 +186,46 @@ export class DataCacheIDName<T> {
         return this.idToDataMap.get(id);
     }
 
-    public removeByName(name: string, force: boolean) {
-        if (force || !this.nameToLockMap.get(name))
-            this.nameToDataMap.delete(name);
+    public ids() {
+        return this.idToDataMap.keys();
     }
 
-    public removeByID(id: number, force: boolean) {
-        if (force || !this.idToLockMap.get(name))
+    public names() {
+        return this.nameToDataMap.keys();
+    }
+
+    public data() {
+        return this.idToDataMap.values();
+    }
+
+    public isIDLocked(id: number) {
+        return this.idToLockMap.get(id) || false;
+    }
+
+    public isNameLocked(name: string) {
+        return this.nameToLockMap.get(name) || false;
+    }
+
+    public removeByName(name: string, force: boolean = false) {
+        if (force || !this.isNameLocked(name)) {
+            this.nameToDataMap.delete(name);
+            this.nameToLockMap.delete(name);
+        }
+    }
+
+    public removeByID(id: number, force: boolean = false) {
+        if (force || !this.isIDLocked(id)) {
             this.idToDataMap.delete(id);
+            this.idToLockMap.delete(id);
+        }
     }
 
     // Clears just unlocked data or all data
     public clear(all: boolean = false) {
-        if (all) {
-            this.idToDataMap.clear();
-            this.nameToDataMap.clear();
-            this.idToLockMap.clear();
-            this.nameToLockMap.clear();
-        } else {
-            for (const [id, lock] of this.idToLockMap) {
-                if (!lock) {
-                    this.idToDataMap.delete(id);
-                    this.idToLockMap.delete(id);
-                }
-            }
-            for (const [name, lock] of this.nameToLockMap) {
-                if (!lock) {
-                    this.nameToDataMap.delete(name);
-                    this.nameToLockMap.delete(name);
-                }
-            }
-        }
+        for (const [id] of this.idToDataMap)
+            this.removeByID(id, all);
+        for (const [name] of this.nameToDataMap)
+            this.removeByName(name, all);
     }
 }
 


### PR DESCRIPTION
This adds support for ENV assets, which specify which LightKit to apply to objects, among other things, as well as more render hacks:

- Fog (on/off)
- Skydome (on/off)
- Show Invisible Entities (on/off)
- Show Invisible Atomics (on/off)

A new BaseRenderer class and RenderState interface have also been added to encapsulate common properties and methods used throughout many renderer types.