### PR TITLE
NitorTex A5I3 fixed

### DIFF
--- a/src/SuperMario64DS/nitro_tex.ts
+++ b/src/SuperMario64DS/nitro_tex.ts
@@ -209,7 +209,7 @@ function readTexture_A5I3(width: number, height: number, texData: ArrayBufferSli
     for (let y = 0; y < height; y++) {
         for (let x = 0; x < width; x++) {
             const texBlock = texView.getUint8(srcOffs++);
-            const palIdx = (texBlock & 0x03) << 1;
+            const palIdx = (texBlock & 0x07) << 1;
             const alpha = texBlock >>> 3;
             const p = palView.getUint16(palIdx, true);
             const dstOffs = 4 * ((y * width) + x);


### PR DESCRIPTION
fixed NitorTex A5I3.
I coding mph stages on noclip website.
and recognized NitroTex's A5I3 is incorrect.

https://github.com/hackyourlife/metroidprimehunters/blob/1c3170b35d8b3465a6b2df3c4c3097f3a2316d73/models/scene.c#L578

this is hackyourlife's itegrated ndsgraph(first mph model viwer).
it's support A3I5 and A5I3 by NoneGiven.