### PR TITLE
Paper Mario 64: Fix extractor.ts

### DIFF
--- a/src/PaperMario64/tools/extractor.ts
+++ b/src/PaperMario64/tools/extractor.ts
@@ -3,7 +3,7 @@ import ArrayBufferSlice from "../../ArrayBufferSlice";
 import { readFileSync, writeFileSync } from "fs";
 import { assert, hexzero, hexdump, readString, assertExists } from "../../util";
 import { decode } from 'iconv-lite';
-import * as Yay0 from "../../compression/Yay0";
+import * as Yay0 from "../../Common/compression/Yay0";
 import * as BYML from "../../byml";
 
 function nulTerminate(S: string) {


### PR DESCRIPTION
At some point, `src/compression` was moved to `src/Common/compression`, but this particular map data extraction script's imports was not updated to reflect this! This one-line change resolves this issue :)