### PR TITLE
Noclip Studio - Fixes and Enhancements

### DIFF
--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -526,8 +526,8 @@ export class StudioCameraController extends FPSCameraController {
                 this.animationManager.addNextKeyframe(mat4.clone(this.camera.worldMatrix));
                 this.isOnKeyframe = true;
             }
-            if (inputManager.isKeyDownEventTriggered('Escape') && this.animationManager.editingKeyframePosition) {
-                this.animationManager.cancelEditKeyframePosition();
+            if (inputManager.isKeyDownEventTriggered('Escape')) {
+                this.animationManager.endEditKeyframePosition();
             }
             result = super.update(inputManager, dt);
             if (this.isOnKeyframe && result !== CameraUpdateResult.Unchanged) {

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -526,6 +526,9 @@ export class StudioCameraController extends FPSCameraController {
                 this.animationManager.addNextKeyframe(mat4.clone(this.camera.worldMatrix));
                 this.isOnKeyframe = true;
             }
+            if (inputManager.isKeyDownEventTriggered('Escape') && this.animationManager.editingKeyframePosition) {
+                this.animationManager.cancelEditKeyframePosition();
+            }
             result = super.update(inputManager, dt);
             if (this.isOnKeyframe && result !== CameraUpdateResult.Unchanged) {
                 this.isOnKeyframe = false;

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -87,11 +87,8 @@ export class CameraAnimationManager {
      * Used for calculating tangents.
      */
     private prevTrs: vec3 = vec3.create();
-    private curTrs: vec3 = vec3.create();
-    private curPlus1Trs: vec3 = vec3.create();
-    private curPlus2Trs: vec3 = vec3.create();
-    private trsTangentInScratch: vec3 = vec3.create();
-    private trsTangentOutScratch: vec3 = vec3.create();
+    private nextTrs: vec3 = vec3.create();
+    private tangentScratchVec: vec3 = vec3.create();
 
     /**
      * Variables for animation playback.
@@ -324,65 +321,65 @@ export class CameraAnimationManager {
         const keyframes = this.animation.keyframes;
 
         if (keyframes.length < 4) {
-            mat4.getTranslation(this.prevTrs, keyframes[keyframes.length - 1].endPos);
-            mat4.getTranslation(this.curTrs, keyframes[0].endPos);
-            mat4.getTranslation(this.curPlus1Trs, keyframes[1].endPos);
-            mat4.getTranslation(this.curPlus2Trs, keyframes[keyframes.length - 1].endPos);
+            mat4.getTranslation(this.prevTrs, keyframes[0].endPos);
+            mat4.getTranslation(this.nextTrs, keyframes[1].endPos);
 
-            vec3.sub(this.trsTangentInScratch, this.curPlus1Trs, this.prevTrs);
-            vec3.scale(this.trsTangentInScratch, this.trsTangentInScratch, 0.5);
-            vec3.sub(this.trsTangentOutScratch, this.curPlus2Trs, this.curTrs);
-            vec3.scale(this.trsTangentOutScratch, this.trsTangentOutScratch, 0.5);
+            vec3.sub(this.tangentScratchVec, this.nextTrs, this.prevTrs);
+            vec3.scale(this.tangentScratchVec, this.tangentScratchVec, 0.5);
+            vec3.copy(keyframes[0].trsTangentIn, this.tangentScratchVec);
+            vec3.copy(keyframes[0].trsTangentOut, this.tangentScratchVec);
 
-            vec3.copy(keyframes[0].trsTangentIn, this.trsTangentInScratch);
-            vec3.copy(keyframes[0].trsTangentOut, this.trsTangentOutScratch);
-            vec3.copy(keyframes[1].trsTangentIn, this.trsTangentOutScratch);
             if (keyframes.length === 2) {
-                vec3.copy(keyframes[1].trsTangentOut, this.trsTangentInScratch);
+                vec3.sub(this.tangentScratchVec, this.prevTrs, this.nextTrs);
+                vec3.scale(this.tangentScratchVec, this.tangentScratchVec, 0.5);
+                vec3.copy(keyframes[1].trsTangentIn, this.tangentScratchVec);
+                vec3.copy(keyframes[1].trsTangentOut, this.tangentScratchVec);
                 return;
             }
-            vec3.copy(this.prevTrs, this.curPlus1Trs);
-            vec3.copy(this.curPlus1Trs, this.curTrs);
-            vec3.copy(this.curTrs, this.curPlus2Trs);
-            vec3.copy(this.curPlus2Trs, this.prevTrs);
+            mat4.getTranslation(this.nextTrs, keyframes[2].endPos);
 
-            vec3.sub(this.trsTangentInScratch, this.curPlus1Trs, this.prevTrs);
-            vec3.scale(this.trsTangentInScratch, this.trsTangentInScratch, 0.5);
-            vec3.sub(this.trsTangentOutScratch, this.curPlus2Trs, this.curTrs);
-            vec3.scale(this.trsTangentOutScratch, this.trsTangentOutScratch, 0.5);
+            vec3.sub(this.tangentScratchVec, this.nextTrs, this.prevTrs);
+            vec3.scale(this.tangentScratchVec, this.tangentScratchVec, 0.5);
+            vec3.copy(keyframes[1].trsTangentIn, this.tangentScratchVec);
+            vec3.copy(keyframes[1].trsTangentOut, this.tangentScratchVec);
 
-            vec3.copy(keyframes[1].trsTangentOut, this.trsTangentInScratch);
-            vec3.copy(keyframes[2].trsTangentIn, this.trsTangentInScratch);
-            vec3.copy(keyframes[2].trsTangentOut, this.trsTangentOutScratch);
+            mat4.getTranslation(this.prevTrs, keyframes[1].endPos);
+            vec3.sub(this.tangentScratchVec, this.nextTrs, this.prevTrs);
+            vec3.scale(this.tangentScratchVec, this.tangentScratchVec, 0.5);
+
+            vec3.copy(keyframes[2].trsTangentIn, this.tangentScratchVec);
+            vec3.copy(keyframes[2].trsTangentOut, this.tangentScratchVec);
             return;
         }
 
         mat4.getTranslation(this.prevTrs, keyframes[keyframes.length - 1].endPos);
-        mat4.getTranslation(this.curTrs, keyframes[0].endPos);
-        mat4.getTranslation(this.curPlus1Trs, keyframes[1].endPos);
-        mat4.getTranslation(this.curPlus2Trs, keyframes[2].endPos);
+        mat4.getTranslation(this.nextTrs, keyframes[1].endPos);
 
-        vec3.sub(this.trsTangentInScratch, this.curPlus1Trs, this.prevTrs);
-        vec3.scale(this.trsTangentInScratch, this.trsTangentInScratch, 0.5);
-        vec3.sub(this.trsTangentOutScratch, this.curPlus2Trs, this.curTrs);
-        vec3.scale(this.trsTangentOutScratch, this.trsTangentOutScratch, 0.5);
+        vec3.sub(this.tangentScratchVec, this.nextTrs, this.prevTrs);
+        vec3.scale(this.tangentScratchVec, this.tangentScratchVec, 0.5);
 
-        vec3.copy(keyframes[0].trsTangentIn, this.trsTangentInScratch);
-        vec3.copy(keyframes[0].trsTangentOut, this.trsTangentOutScratch);
+        vec3.copy(keyframes[0].trsTangentOut, this.tangentScratchVec);
+        vec3.copy(keyframes[1].trsTangentIn, this.tangentScratchVec);
 
-        for (let i = 1; i < keyframes.length; i++) {
-            vec3.copy(this.prevTrs, this.curTrs);
-            vec3.copy(this.curTrs, this.curPlus1Trs);
-            vec3.copy(this.curPlus1Trs, this.curPlus2Trs);
-            mat4.getTranslation(this.curPlus2Trs, keyframes[(i + 2) % keyframes.length].endPos);
+        for (let i = 1; i < keyframes.length - 1; i++) {
+            mat4.getTranslation(this.prevTrs, keyframes[i - 1].endPos);
+            mat4.getTranslation(this.nextTrs, keyframes[i + 1].endPos);
 
-            vec3.sub(this.trsTangentInScratch, this.curPlus1Trs, this.prevTrs);
-            vec3.scale(this.trsTangentInScratch, this.trsTangentInScratch, 0.5);
-            vec3.sub(this.trsTangentOutScratch, this.curPlus2Trs, this.curTrs);
-            vec3.scale(this.trsTangentOutScratch, this.trsTangentOutScratch, 0.5);
+            vec3.sub(this.tangentScratchVec, this.nextTrs, this.prevTrs);
+            vec3.scale(this.tangentScratchVec, this.tangentScratchVec, 0.5);
 
-            vec3.copy(keyframes[i].trsTangentIn, this.trsTangentInScratch);
-            vec3.copy(keyframes[i].trsTangentOut, this.trsTangentOutScratch);
+            vec3.copy(keyframes[i].trsTangentOut, this.tangentScratchVec);
+            vec3.copy(keyframes[i + 1].trsTangentIn, this.tangentScratchVec);
+        }
+
+        if (this.loopAnimation) {
+            mat4.getTranslation(this.prevTrs, keyframes[keyframes.length - 1].endPos);
+            mat4.getTranslation(this.nextTrs, keyframes[0].endPos);
+
+            vec3.sub(this.tangentScratchVec, this.nextTrs, this.prevTrs);
+            vec3.scale(this.tangentScratchVec, this.tangentScratchVec, 0.5);
+            vec3.copy(keyframes[keyframes.length - 1].trsTangentOut, this.tangentScratchVec);
+            vec3.copy(keyframes[0].trsTangentIn, this.tangentScratchVec);
         }
     }
 }

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -81,7 +81,7 @@ export class CameraAnimationManager {
     private animation: CameraAnimation;
     private studioCameraController: StudioCameraController;
     private selectedKeyframeIndex: number = -1;
-    private editingKeyframePosition: boolean = false;
+    public editingKeyframePosition: boolean = false;
     /**
      * The translation vector components of the keyframes following and preceding the current keyframe.
      * Used for calculating tangents.
@@ -160,6 +160,11 @@ export class CameraAnimationManager {
 
     public enableEditKeyframePosition(): void {
         this.editingKeyframePosition = true;
+    }
+
+    public cancelEditKeyframePosition(): void {
+        this.editingKeyframePosition = false;
+        this.uiKeyframeList.dispatchEvent(new Event('keyframePositionEdited'));
     }
 
     public previewKeyframe() {

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -113,6 +113,20 @@ export class CameraAnimationManager {
         viewer.setCameraController(this.studioCameraController);
     }
 
+    public loadAnimation(keyframes: Keyframe[]) {
+        this.animation = new CameraAnimation();
+        this.animation.keyframes = keyframes;
+        this.uiKeyframeList.dispatchEvent(new Event('startPositionSet'));
+        for (let i = 1; i < keyframes.length; i++) {
+            this.animation.totalKeyframesAdded = i;
+            this.uiKeyframeList.dispatchEvent(new CustomEvent('newKeyframe', { detail: i }));
+        }
+    }
+
+    public serializeAnimation(): string {
+        return JSON.stringify(this.animation.keyframes);
+    }
+
     public totalKeyframesAdded(): number {
         return this.animation.totalKeyframesAdded;
     }

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -204,7 +204,7 @@ export class CameraAnimationManager {
      */
     public update(dt: number): void {
         if (this.currentKeyframeProgressMs < this.currentKeyframe.interpDuration)
-            this.currentKeyframeProgressMs = Math.min(this.currentKeyframeProgressMs + dt, this.currentKeyframeInterpDurationMs);
+            this.currentKeyframeProgressMs += dt;
         else
             this.currentKeyframeProgressMs = Math.min(this.currentKeyframeProgressMs + dt, this.currentKeyframeTotalDurationMs);
     }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1717,6 +1717,11 @@ class StudioPanel extends FloatingPanel {
     private studioPanelContents: HTMLElement;
     private studioHelpText: HTMLElement;
 
+    private studioDataBtn: HTMLInputElement;
+    private studioSaveLoadControls: HTMLElement;
+    private loadAnimationBtn: HTMLInputElement;
+    private saveAnimationBtn: HTMLInputElement;
+
     private studioControlsContainer: HTMLElement;
 
     private keyframeList: HTMLElement;
@@ -1889,6 +1894,15 @@ class StudioPanel extends FloatingPanel {
         </style>
         `);
         this.studioPanelContents.insertAdjacentHTML('afterbegin', `
+        <div style="width: 40%;margin: auto;">
+            <button type="button" id="studioDataBtn" class="SettingsButton">📁</button>
+            <div id="studioSaveLoadControls" hidden>
+                <div style="display: grid;grid-template-columns: 1fr 1fr;gap: 1rem;">
+                    <button type="button" id="loadAnimationBtn" class="SettingsButton">Load</button>
+                    <button type="button" id="saveAnimationBtn" class="SettingsButton">Save</button>
+                </div>
+            </div>
+        </div>
         <div id="studioHelpText"></div>
         <div id="studioControlsContainer" hidden>
             <div style="display: grid; grid-template-columns: 1fr 1fr;">
@@ -1950,7 +1964,17 @@ class StudioPanel extends FloatingPanel {
         this.studioHelpText = this.contents.querySelector('#studioHelpText') as HTMLElement;
         this.studioHelpText.dataset.startPosHelpText = 'Move the camera to the desired starting position and press Enter.';
         this.studioHelpText.dataset.editPosHelpText = 'Move the camera to the desired position and press Enter. Press Escape to cancel.';
+        this.studioHelpText.dataset.default = 'Move the camera to the desired starting position and press Enter.';
         this.studioHelpText.innerText = this.studioHelpText.dataset.startPosHelpText;
+
+        this.studioDataBtn = this.contents.querySelector('#studioDataBtn') as HTMLInputElement;
+        this.studioDataBtn.dataset.helpText = 'Save the current animation, or load a previously-saved animation.';
+        this.studioSaveLoadControls = this.contents.querySelector('#studioSaveLoadControls') as HTMLElement;
+        this.loadAnimationBtn = this.contents.querySelector('#loadAnimationBtn') as HTMLInputElement;
+        this.loadAnimationBtn.dataset.helpText = 'Load the previously-saved animation for this map. Overwrites the current keyframes!';
+        this.saveAnimationBtn = this.contents.querySelector('#saveAnimationBtn') as HTMLInputElement;
+        this.saveAnimationBtn.dataset.helpText = 'Save the current animation for this map to your browser\'s local storage.';
+
         this.studioControlsContainer = this.contents.querySelector('#studioControlsContainer') as HTMLElement;
         this.keyframeList = this.contents.querySelector('#keyframeList') as HTMLElement;
 
@@ -2004,6 +2028,22 @@ class StudioPanel extends FloatingPanel {
         this.stopAnimationBtn = this.contents.querySelector('#stopAnimationBtn') as HTMLInputElement;
 
         this.animationManager = new CameraAnimationManager(this.keyframeList, this.studioControlsContainer);
+
+        this.studioDataBtn.onclick = () => {
+            this.studioSaveLoadControls.toggleAttribute('hidden');
+        }
+        this.loadAnimationBtn.onclick = () => {
+            const jsonAnim = window.localStorage.getItem('studio-animation-' + GlobalSaveManager.getCurrentSceneDescId());
+            if (jsonAnim) {
+                this.keyframeList.innerText = '';
+                const animation: Keyframe[] = JSON.parse(jsonAnim);
+                this.animationManager.loadAnimation(animation);
+            }
+        }
+        this.saveAnimationBtn.onclick = () => {
+            const jsonAnim: string = this.animationManager.serializeAnimation();
+            window.localStorage.setItem('studio-animation-' + GlobalSaveManager.getCurrentSceneDescId(), jsonAnim);
+        }
 
         this.keyframeList.dataset.helpText = 'Click on a keyframe to jump to its end position.';
         // Event fired when start position for an animation is first set.

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1948,7 +1948,7 @@ class StudioPanel extends FloatingPanel {
         </div>`);
         this.studioHelpText = this.contents.querySelector('#studioHelpText') as HTMLElement;
         this.studioHelpText.dataset.startPosHelpText = 'Move the camera to the desired starting position and press Enter.';
-        this.studioHelpText.dataset.editPosHelpText = 'Move the camera to the desired position and press Enter.';
+        this.studioHelpText.dataset.editPosHelpText = 'Move the camera to the desired position and press Enter. Press Escape to cancel.';
         this.studioHelpText.innerText = this.studioHelpText.dataset.startPosHelpText;
         this.studioControlsContainer = this.contents.querySelector('#studioControlsContainer') as HTMLElement;
         this.keyframeList = this.contents.querySelector('#keyframeList') as HTMLElement;
@@ -2259,11 +2259,13 @@ class StudioPanel extends FloatingPanel {
     }
 
     private displayHelpText(elem: HTMLElement) {
-        this.studioHelpText.innerText = elem.dataset.helpText ? elem.dataset.helpText : this.studioHelpText.dataset.default as string;
+        if (!this.animationManager.editingKeyframePosition)
+            this.studioHelpText.innerText = elem.dataset.helpText ? elem.dataset.helpText : this.studioHelpText.dataset.default as string;
     }
 
     private resetHelpText() {
-        this.studioHelpText.innerText = this.studioHelpText.dataset.default as string;
+        if (!this.animationManager.editingKeyframePosition)
+            this.studioHelpText.innerText = this.studioHelpText.dataset.default as string;
     }
 
     private handleNewKeyframeEvent(e: CustomEvent) {


### PR DESCRIPTION
This PR adds a few fixes to the Noclip Studio feature introduced in #325, and a couple new bits. Namely:

- Tangent calculation has been simplified, with some logic errors fixed to produce [buttery-smooth transitions](https://gfycat.com/amusingapprehensiveguineafowl).
- We no longer clamp the t value at the end of each keyframe (f1ee498), which was likely causing the occasional jutter/delay on transitions between keyframes. (This change is not reflected in the animation linked above.)
- Edit Position mode can now be cancelled with Escape. Help text has been updated to reflect this.
- State tracking for the UI is moved to the UI class to the greatest extent possible.
    - CameraAnimationManager no longer tracks the selected keyframe index, instead retrieving it from a data attribute on the keyframe list when necessary.
    - The Edit Position Mode flag is now kept in the UI, and is also retrieved by CameraAnimationManager via a data attribute on the keyframe list.
- A basic saving/loading functionality is added. Animations are saved in localStorage as a `JSON.stringify`-ed array of Keyframes, keyed to a prefixed value returned by `SaveManager.getCurrentSceneDescId()`. Loading and saving is currently done manually via a collapsible pair of buttons at the top of the panel, to save space and prevent accidental mis-clicks.