### PR TITLE
Studio - Data Management Improvements

### DIFF
--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -526,8 +526,8 @@ export class StudioCameraController extends FPSCameraController {
                 this.animationManager.addNextKeyframe(mat4.clone(this.camera.worldMatrix));
                 this.isOnKeyframe = true;
             }
-            if (inputManager.isKeyDownEventTriggered('Escape') && this.animationManager.editingKeyframePosition) {
-                this.animationManager.cancelEditKeyframePosition();
+            if (inputManager.isKeyDownEventTriggered('Escape')) {
+                this.animationManager.endEditKeyframePosition();
             }
             result = super.update(inputManager, dt);
             if (this.isOnKeyframe && result !== CameraUpdateResult.Unchanged) {

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -526,6 +526,9 @@ export class StudioCameraController extends FPSCameraController {
                 this.animationManager.addNextKeyframe(mat4.clone(this.camera.worldMatrix));
                 this.isOnKeyframe = true;
             }
+            if (inputManager.isKeyDownEventTriggered('Escape') && this.animationManager.editingKeyframePosition) {
+                this.animationManager.cancelEditKeyframePosition();
+            }
             result = super.update(inputManager, dt);
             if (this.isOnKeyframe && result !== CameraUpdateResult.Unchanged) {
                 this.isOnKeyframe = false;

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -87,11 +87,8 @@ export class CameraAnimationManager {
      * Used for calculating tangents.
      */
     private prevTrs: vec3 = vec3.create();
-    private curTrs: vec3 = vec3.create();
-    private curPlus1Trs: vec3 = vec3.create();
-    private curPlus2Trs: vec3 = vec3.create();
-    private trsTangentInScratch: vec3 = vec3.create();
-    private trsTangentOutScratch: vec3 = vec3.create();
+    private nextTrs: vec3 = vec3.create();
+    private tangentScratchVec: vec3 = vec3.create();
 
     /**
      * Variables for animation playback.
@@ -324,65 +321,65 @@ export class CameraAnimationManager {
         const keyframes = this.animation.keyframes;
 
         if (keyframes.length < 4) {
-            mat4.getTranslation(this.prevTrs, keyframes[keyframes.length - 1].endPos);
-            mat4.getTranslation(this.curTrs, keyframes[0].endPos);
-            mat4.getTranslation(this.curPlus1Trs, keyframes[1].endPos);
-            mat4.getTranslation(this.curPlus2Trs, keyframes[keyframes.length - 1].endPos);
+            mat4.getTranslation(this.prevTrs, keyframes[0].endPos);
+            mat4.getTranslation(this.nextTrs, keyframes[1].endPos);
 
-            vec3.sub(this.trsTangentInScratch, this.curPlus1Trs, this.prevTrs);
-            vec3.scale(this.trsTangentInScratch, this.trsTangentInScratch, 0.5);
-            vec3.sub(this.trsTangentOutScratch, this.curPlus2Trs, this.curTrs);
-            vec3.scale(this.trsTangentOutScratch, this.trsTangentOutScratch, 0.5);
+            vec3.sub(this.tangentScratchVec, this.nextTrs, this.prevTrs);
+            vec3.scale(this.tangentScratchVec, this.tangentScratchVec, 0.5);
+            vec3.copy(keyframes[0].trsTangentIn, this.tangentScratchVec);
+            vec3.copy(keyframes[0].trsTangentOut, this.tangentScratchVec);
 
-            vec3.copy(keyframes[0].trsTangentIn, this.trsTangentInScratch);
-            vec3.copy(keyframes[0].trsTangentOut, this.trsTangentOutScratch);
-            vec3.copy(keyframes[1].trsTangentIn, this.trsTangentOutScratch);
             if (keyframes.length === 2) {
-                vec3.copy(keyframes[1].trsTangentOut, this.trsTangentInScratch);
+                vec3.sub(this.tangentScratchVec, this.prevTrs, this.nextTrs);
+                vec3.scale(this.tangentScratchVec, this.tangentScratchVec, 0.5);
+                vec3.copy(keyframes[1].trsTangentIn, this.tangentScratchVec);
+                vec3.copy(keyframes[1].trsTangentOut, this.tangentScratchVec);
                 return;
             }
-            vec3.copy(this.prevTrs, this.curPlus1Trs);
-            vec3.copy(this.curPlus1Trs, this.curTrs);
-            vec3.copy(this.curTrs, this.curPlus2Trs);
-            vec3.copy(this.curPlus2Trs, this.prevTrs);
+            mat4.getTranslation(this.nextTrs, keyframes[2].endPos);
 
-            vec3.sub(this.trsTangentInScratch, this.curPlus1Trs, this.prevTrs);
-            vec3.scale(this.trsTangentInScratch, this.trsTangentInScratch, 0.5);
-            vec3.sub(this.trsTangentOutScratch, this.curPlus2Trs, this.curTrs);
-            vec3.scale(this.trsTangentOutScratch, this.trsTangentOutScratch, 0.5);
+            vec3.sub(this.tangentScratchVec, this.nextTrs, this.prevTrs);
+            vec3.scale(this.tangentScratchVec, this.tangentScratchVec, 0.5);
+            vec3.copy(keyframes[1].trsTangentIn, this.tangentScratchVec);
+            vec3.copy(keyframes[1].trsTangentOut, this.tangentScratchVec);
 
-            vec3.copy(keyframes[1].trsTangentOut, this.trsTangentInScratch);
-            vec3.copy(keyframes[2].trsTangentIn, this.trsTangentInScratch);
-            vec3.copy(keyframes[2].trsTangentOut, this.trsTangentOutScratch);
+            mat4.getTranslation(this.prevTrs, keyframes[1].endPos);
+            vec3.sub(this.tangentScratchVec, this.nextTrs, this.prevTrs);
+            vec3.scale(this.tangentScratchVec, this.tangentScratchVec, 0.5);
+
+            vec3.copy(keyframes[2].trsTangentIn, this.tangentScratchVec);
+            vec3.copy(keyframes[2].trsTangentOut, this.tangentScratchVec);
             return;
         }
 
         mat4.getTranslation(this.prevTrs, keyframes[keyframes.length - 1].endPos);
-        mat4.getTranslation(this.curTrs, keyframes[0].endPos);
-        mat4.getTranslation(this.curPlus1Trs, keyframes[1].endPos);
-        mat4.getTranslation(this.curPlus2Trs, keyframes[2].endPos);
+        mat4.getTranslation(this.nextTrs, keyframes[1].endPos);
 
-        vec3.sub(this.trsTangentInScratch, this.curPlus1Trs, this.prevTrs);
-        vec3.scale(this.trsTangentInScratch, this.trsTangentInScratch, 0.5);
-        vec3.sub(this.trsTangentOutScratch, this.curPlus2Trs, this.curTrs);
-        vec3.scale(this.trsTangentOutScratch, this.trsTangentOutScratch, 0.5);
+        vec3.sub(this.tangentScratchVec, this.nextTrs, this.prevTrs);
+        vec3.scale(this.tangentScratchVec, this.tangentScratchVec, 0.5);
 
-        vec3.copy(keyframes[0].trsTangentIn, this.trsTangentInScratch);
-        vec3.copy(keyframes[0].trsTangentOut, this.trsTangentOutScratch);
+        vec3.copy(keyframes[0].trsTangentOut, this.tangentScratchVec);
+        vec3.copy(keyframes[1].trsTangentIn, this.tangentScratchVec);
 
-        for (let i = 1; i < keyframes.length; i++) {
-            vec3.copy(this.prevTrs, this.curTrs);
-            vec3.copy(this.curTrs, this.curPlus1Trs);
-            vec3.copy(this.curPlus1Trs, this.curPlus2Trs);
-            mat4.getTranslation(this.curPlus2Trs, keyframes[(i + 2) % keyframes.length].endPos);
+        for (let i = 1; i < keyframes.length - 1; i++) {
+            mat4.getTranslation(this.prevTrs, keyframes[i - 1].endPos);
+            mat4.getTranslation(this.nextTrs, keyframes[i + 1].endPos);
 
-            vec3.sub(this.trsTangentInScratch, this.curPlus1Trs, this.prevTrs);
-            vec3.scale(this.trsTangentInScratch, this.trsTangentInScratch, 0.5);
-            vec3.sub(this.trsTangentOutScratch, this.curPlus2Trs, this.curTrs);
-            vec3.scale(this.trsTangentOutScratch, this.trsTangentOutScratch, 0.5);
+            vec3.sub(this.tangentScratchVec, this.nextTrs, this.prevTrs);
+            vec3.scale(this.tangentScratchVec, this.tangentScratchVec, 0.5);
 
-            vec3.copy(keyframes[i].trsTangentIn, this.trsTangentInScratch);
-            vec3.copy(keyframes[i].trsTangentOut, this.trsTangentOutScratch);
+            vec3.copy(keyframes[i].trsTangentOut, this.tangentScratchVec);
+            vec3.copy(keyframes[i + 1].trsTangentIn, this.tangentScratchVec);
+        }
+
+        if (this.loopAnimation) {
+            mat4.getTranslation(this.prevTrs, keyframes[keyframes.length - 1].endPos);
+            mat4.getTranslation(this.nextTrs, keyframes[0].endPos);
+
+            vec3.sub(this.tangentScratchVec, this.nextTrs, this.prevTrs);
+            vec3.scale(this.tangentScratchVec, this.tangentScratchVec, 0.5);
+            vec3.copy(keyframes[keyframes.length - 1].trsTangentOut, this.tangentScratchVec);
+            vec3.copy(keyframes[0].trsTangentIn, this.tangentScratchVec);
         }
     }
 }

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -81,7 +81,7 @@ export class CameraAnimationManager {
     private animation: CameraAnimation;
     private studioCameraController: StudioCameraController;
     private selectedKeyframeIndex: number = -1;
-    private editingKeyframePosition: boolean = false;
+    public editingKeyframePosition: boolean = false;
     /**
      * The translation vector components of the keyframes following and preceding the current keyframe.
      * Used for calculating tangents.
@@ -160,6 +160,11 @@ export class CameraAnimationManager {
 
     public enableEditKeyframePosition(): void {
         this.editingKeyframePosition = true;
+    }
+
+    public cancelEditKeyframePosition(): void {
+        this.editingKeyframePosition = false;
+        this.uiKeyframeList.dispatchEvent(new Event('keyframePositionEdited'));
     }
 
     public previewKeyframe() {

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -113,6 +113,20 @@ export class CameraAnimationManager {
         viewer.setCameraController(this.studioCameraController);
     }
 
+    public loadAnimation(keyframes: Keyframe[]) {
+        this.animation = new CameraAnimation();
+        this.animation.keyframes = keyframes;
+        this.uiKeyframeList.dispatchEvent(new Event('startPositionSet'));
+        for (let i = 1; i < keyframes.length; i++) {
+            this.animation.totalKeyframesAdded = i;
+            this.uiKeyframeList.dispatchEvent(new CustomEvent('newKeyframe', { detail: i }));
+        }
+    }
+
+    public serializeAnimation(): string {
+        return JSON.stringify(this.animation.keyframes);
+    }
+
     public totalKeyframesAdded(): number {
         return this.animation.totalKeyframesAdded;
     }

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -277,7 +277,6 @@ export class CameraAnimationManager {
             this.studioCameraController.setToPosition(this.currentKeyframe.endPos);
         else
             this.setInterpolationVectors();
-        return true;
     }
 
     public stopAnimation() {

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -204,7 +204,7 @@ export class CameraAnimationManager {
      */
     public update(dt: number): void {
         if (this.currentKeyframeProgressMs < this.currentKeyframe.interpDuration)
-            this.currentKeyframeProgressMs = Math.min(this.currentKeyframeProgressMs + dt, this.currentKeyframeInterpDurationMs);
+            this.currentKeyframeProgressMs += dt;
         else
             this.currentKeyframeProgressMs = Math.min(this.currentKeyframeProgressMs + dt, this.currentKeyframeTotalDurationMs);
     }

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -114,6 +114,8 @@ export class CameraAnimationManager {
     }
 
     public loadAnimation(keyframes: Keyframe[]) {
+        if (keyframes.length === 0)
+            return;
         this.animation = new CameraAnimation();
         this.animation.keyframes = keyframes;
         this.uiKeyframeList.dispatchEvent(new Event('startPositionSet'));
@@ -121,6 +123,10 @@ export class CameraAnimationManager {
             this.animation.totalKeyframesAdded = i;
             this.uiKeyframeList.dispatchEvent(new CustomEvent('newKeyframe', { detail: i }));
         }
+    }
+
+    public newAnimation() {
+        this.animation = new CameraAnimation();
     }
 
     public serializeAnimation(): string {
@@ -298,6 +304,35 @@ export class CameraAnimationManager {
             return true;
         }
         return false;
+    }
+
+    public isAnimation(a: Keyframe[]): boolean {
+        if (!Array.isArray(a))
+            return false;
+        try {
+            for (let i = 0; i < a.length; i++) {
+                for (let j = 0; j < 16; j++) {
+                    if (typeof a[i].endPos[j] !== 'number')
+                        return false;
+                    if (j < 3) {
+                        if (typeof a[i].trsTangentIn[j] !== 'number'
+                            || typeof a[i].trsTangentOut[j] !== 'number')
+                            return false;
+                    }
+                }
+                if (typeof a[i].holdDuration !== 'number')
+                    return false;
+                if (typeof a[i].interpDuration !== 'number')
+                    return false;
+                if (typeof a[i].linearEaseType !== 'string')
+                    return false;
+                if (typeof a[i].usesLinearInterp !== 'boolean')
+                    return false;
+            }
+            return true;
+        } catch (e) {
+            return false;
+        }
     }
 
     private getEasingFuncForEaseType(easeType: LinearEaseType): Function | null {

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -37,6 +37,7 @@ export interface Keyframe {
     trsTangentIn: vec3;
     trsTangentOut: vec3;
     endPos: mat4;
+    name?: string;
 }
 
 export class CameraAnimation {
@@ -54,6 +55,8 @@ export class CameraAnimation {
     public totalKeyframesAdded: number = -1;
 
     public insertKeyframe(after: number, keyframeEndPos: mat4) {
+        this.totalKeyframesAdded++;
+        const name = this.totalKeyframesAdded === 0 ? 'Starting Position' : 'Keyframe ' + this.totalKeyframesAdded;
         const newKeyframe: Keyframe = {
             interpDuration: 5,
             holdDuration: 0,
@@ -61,10 +64,10 @@ export class CameraAnimation {
             linearEaseType: LinearEaseType.EaseBoth,
             trsTangentIn: vec3.create(),
             trsTangentOut: vec3.create(),
-            endPos: keyframeEndPos
+            endPos: keyframeEndPos,
+            name: name
         }
         this.keyframes.splice(after + 1, 0, newKeyframe);
-        this.totalKeyframesAdded++;
     }
 
     public appendKeyframe(keyframeEndPos: mat4) {
@@ -120,6 +123,8 @@ export class CameraAnimationManager {
         this.animation.keyframes = keyframes;
         this.uiKeyframeList.dispatchEvent(new Event('startPositionSet'));
         for (let i = 1; i < keyframes.length; i++) {
+            if (this.animation.keyframes[i].name === undefined)
+                this.animation.keyframes[i].name = 'Keyframe ' + i;
             this.animation.totalKeyframesAdded = i;
             this.uiKeyframeList.dispatchEvent(new CustomEvent('newKeyframe', { detail: i }));
         }
@@ -131,10 +136,6 @@ export class CameraAnimationManager {
 
     public serializeAnimation(): string {
         return JSON.stringify(this.animation.keyframes);
-    }
-
-    public totalKeyframesAdded(): number {
-        return this.animation.totalKeyframesAdded;
     }
 
     public getKeyframeByIndex(index: number): Keyframe {
@@ -151,7 +152,7 @@ export class CameraAnimationManager {
         if (afterIndex > -1) {
             // Insert new keyframe after the specified index.
             this.animation.insertKeyframe(afterIndex, pos);
-            this.uiKeyframeList.dispatchEvent(new CustomEvent('newKeyframe', { detail: afterIndex }));
+            this.uiKeyframeList.dispatchEvent(new CustomEvent('newKeyframe', { detail: afterIndex + 1 }));
         } else {
             // No keyframe selected
             if (this.animation.keyframes.length === 0) {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -2340,6 +2340,7 @@ class StudioPanel extends FloatingPanel {
     public onSceneChange() {
         this.newAnimation();
         this.loadAnimation();
+        this.animationManager.enableStudioController(this.viewer);
     }
 
     private newAnimation(): void {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1717,6 +1717,11 @@ class StudioPanel extends FloatingPanel {
     private studioPanelContents: HTMLElement;
     private studioHelpText: HTMLElement;
 
+    private studioDataBtn: HTMLInputElement;
+    private studioSaveLoadControls: HTMLElement;
+    private loadAnimationBtn: HTMLInputElement;
+    private saveAnimationBtn: HTMLInputElement;
+
     private studioControlsContainer: HTMLElement;
 
     private keyframeList: HTMLElement;
@@ -1889,6 +1894,15 @@ class StudioPanel extends FloatingPanel {
         </style>
         `);
         this.studioPanelContents.insertAdjacentHTML('afterbegin', `
+        <div style="width: 40%;margin: auto;">
+            <button type="button" id="studioDataBtn" class="SettingsButton">📁</button>
+            <div id="studioSaveLoadControls" hidden>
+                <div style="display: grid;grid-template-columns: 1fr 1fr;gap: 1rem;">
+                    <button type="button" id="loadAnimationBtn" class="SettingsButton">Load</button>
+                    <button type="button" id="saveAnimationBtn" class="SettingsButton">Save</button>
+                </div>
+            </div>
+        </div>
         <div id="studioHelpText"></div>
         <div id="studioControlsContainer" hidden>
             <div style="display: grid; grid-template-columns: 1fr 1fr;">
@@ -1950,7 +1964,17 @@ class StudioPanel extends FloatingPanel {
         this.studioHelpText = this.contents.querySelector('#studioHelpText') as HTMLElement;
         this.studioHelpText.dataset.startPosHelpText = 'Move the camera to the desired starting position and press Enter.';
         this.studioHelpText.dataset.editPosHelpText = 'Move the camera to the desired position and press Enter. Press Escape to cancel.';
+        this.studioHelpText.dataset.default = 'Move the camera to the desired starting position and press Enter.';
         this.studioHelpText.innerText = this.studioHelpText.dataset.startPosHelpText;
+
+        this.studioDataBtn = this.contents.querySelector('#studioDataBtn') as HTMLInputElement;
+        this.studioDataBtn.dataset.helpText = 'Save the current animation, or load a previously-saved animation.';
+        this.studioSaveLoadControls = this.contents.querySelector('#studioSaveLoadControls') as HTMLElement;
+        this.loadAnimationBtn = this.contents.querySelector('#loadAnimationBtn') as HTMLInputElement;
+        this.loadAnimationBtn.dataset.helpText = 'Load the previously-saved animation for this map. Overwrites the current keyframes!';
+        this.saveAnimationBtn = this.contents.querySelector('#saveAnimationBtn') as HTMLInputElement;
+        this.saveAnimationBtn.dataset.helpText = 'Save the current animation for this map to your browser\'s local storage.';
+
         this.studioControlsContainer = this.contents.querySelector('#studioControlsContainer') as HTMLElement;
         this.keyframeList = this.contents.querySelector('#keyframeList') as HTMLElement;
 
@@ -2004,6 +2028,22 @@ class StudioPanel extends FloatingPanel {
         this.stopAnimationBtn = this.contents.querySelector('#stopAnimationBtn') as HTMLInputElement;
 
         this.animationManager = new CameraAnimationManager(this.keyframeList, this.studioControlsContainer);
+
+        this.studioDataBtn.onclick = () => {
+            this.studioSaveLoadControls.toggleAttribute('hidden');
+        }
+        this.loadAnimationBtn.onclick = () => {
+            const jsonAnim = window.localStorage.getItem('studio-animation-' + GlobalSaveManager.getCurrentSceneDescId());
+            if (jsonAnim) {
+                this.keyframeList.innerText = '';
+                const animation: Keyframe[] = JSON.parse(jsonAnim);
+                this.animationManager.loadAnimation(animation);
+            }
+        }
+        this.saveAnimationBtn.onclick = () => {
+            const jsonAnim: string = this.animationManager.serializeAnimation();
+            window.localStorage.setItem('studio-animation-' + GlobalSaveManager.getCurrentSceneDescId(), jsonAnim);
+        }
 
         this.keyframeList.dataset.helpText = 'Click on a keyframe to jump to its end position.';
         // Event fired when start position for an animation is first set.

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1948,7 +1948,7 @@ class StudioPanel extends FloatingPanel {
         </div>`);
         this.studioHelpText = this.contents.querySelector('#studioHelpText') as HTMLElement;
         this.studioHelpText.dataset.startPosHelpText = 'Move the camera to the desired starting position and press Enter.';
-        this.studioHelpText.dataset.editPosHelpText = 'Move the camera to the desired position and press Enter.';
+        this.studioHelpText.dataset.editPosHelpText = 'Move the camera to the desired position and press Enter. Press Escape to cancel.';
         this.studioHelpText.innerText = this.studioHelpText.dataset.startPosHelpText;
         this.studioControlsContainer = this.contents.querySelector('#studioControlsContainer') as HTMLElement;
         this.keyframeList = this.contents.querySelector('#keyframeList') as HTMLElement;
@@ -2259,11 +2259,13 @@ class StudioPanel extends FloatingPanel {
     }
 
     private displayHelpText(elem: HTMLElement) {
-        this.studioHelpText.innerText = elem.dataset.helpText ? elem.dataset.helpText : this.studioHelpText.dataset.default as string;
+        if (!this.animationManager.editingKeyframePosition)
+            this.studioHelpText.innerText = elem.dataset.helpText ? elem.dataset.helpText : this.studioHelpText.dataset.default as string;
     }
 
     private resetHelpText() {
-        this.studioHelpText.innerText = this.studioHelpText.dataset.default as string;
+        if (!this.animationManager.editingKeyframePosition)
+            this.studioHelpText.innerText = this.studioHelpText.dataset.default as string;
     }
 
     private handleNewKeyframeEvent(e: CustomEvent) {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1837,6 +1837,9 @@ class StudioPanel extends FloatingPanel {
                 document.addEventListener('mousedown', keepFocus);
                 setElementHighlighted(this.enableStudioBtn, true);
                 setElementHighlighted(this.disableStudioBtn, false);
+
+                // If there's an existing animation for the current map, load it automatically.
+                this.loadAnimation();
             }
         }
         this.disableStudioBtn.onclick = () => {
@@ -2106,6 +2109,7 @@ class StudioPanel extends FloatingPanel {
             startPositionListItem.dataset.index = '0';
             this.keyframeList.insertAdjacentElement('afterbegin', startPositionListItem);
             startPositionListItem.click();
+            this.saveAnimation();
         });
 
         // Event fired whenever a new keyframe is added.
@@ -2130,6 +2134,7 @@ class StudioPanel extends FloatingPanel {
                 this.enableKeyframeControls();
                 this.keyframeList.removeAttribute('data-editing-keyframe-position');
                 setElementHighlighted(this.editKeyframePositionBtn, false);
+                this.saveAnimation();
             }
         });
 
@@ -2152,6 +2157,7 @@ class StudioPanel extends FloatingPanel {
                 this.selectedKeyframeListItem.dataset.name = 'Keyframe';
                 this.selectedKeyframeListItem.childNodes[0].nodeValue = 'Keyframe';
             }
+            this.saveAnimation();
         }
 
         const MAX_KEYFRAME_DURATION = 100.0;
@@ -2172,6 +2178,7 @@ class StudioPanel extends FloatingPanel {
             } else if (durationVal === 0) {
                 this.interpolationSettings.setAttribute('hidden', '');
             }
+            this.saveAnimation();
         }
 
         this.hermiteBtn.onclick = () => {
@@ -2179,12 +2186,14 @@ class StudioPanel extends FloatingPanel {
             this.selectedKeyframe.usesLinearInterp = false;
             setElementHighlighted(this.hermiteBtn, true);
             setElementHighlighted(this.linearBtn, false);
+            this.saveAnimation();
         }
         this.linearBtn.onclick = () => {
             this.linearEaseSettingsDiv.removeAttribute('hidden');
             this.selectedKeyframe.usesLinearInterp = true;
             setElementHighlighted(this.hermiteBtn, false);
             setElementHighlighted(this.linearBtn, true);
+            this.saveAnimation();
         }
         setElementHighlighted(this.hermiteBtn, false);
         setElementHighlighted(this.linearBtn, false);
@@ -2205,6 +2214,7 @@ class StudioPanel extends FloatingPanel {
                 durationVal = clamp(durationVal, MIN_KEYFRAME_DURATION, MAX_KEYFRAME_DURATION);
             this.selectedKeyframe.holdDuration = durationVal;
             this.keyframeHoldDurationInput.value = durationVal.toString();
+            this.saveAnimation();
         }
 
         this.moveKeyframeUpBtn.onclick = () => {
@@ -2215,6 +2225,7 @@ class StudioPanel extends FloatingPanel {
                     this.keyframeList.insertBefore(listItems[index], listItems[index - 1]);
                     this.updateKeyframeIndices(index - 1);
                     this.selectedKeyframeListItem.click();
+                    this.saveAnimation();
                 }
             }
         }
@@ -2228,6 +2239,7 @@ class StudioPanel extends FloatingPanel {
                     this.keyframeList.insertBefore(listItems[index + 1], listItems[index]);
                     this.updateKeyframeIndices(index);
                     this.selectedKeyframeListItem.click();
+                    this.saveAnimation();
                 }
             }
         }
@@ -2323,6 +2335,11 @@ class StudioPanel extends FloatingPanel {
         }
     }
 
+    public onSceneChange() {
+        this.newAnimation();
+        this.loadAnimation();
+    }
+
     private newAnimation(): void {
         this.animationManager.newAnimation();
         this.studioControlsContainer.setAttribute('hidden','');
@@ -2416,6 +2433,7 @@ class StudioPanel extends FloatingPanel {
         }
         this.selectedEaseBtn = btn;
         setElementHighlighted(this.selectedEaseBtn, true);
+        this.saveAnimation();
     }
 
     private displayHelpText(elem: HTMLElement) {
@@ -2491,6 +2509,7 @@ class StudioPanel extends FloatingPanel {
             this.updateKeyframeIndices(keyframeIndex);
         }
         keyframeListItem.click();
+        this.saveAnimation();
     }
 
     /**
@@ -3505,6 +3524,9 @@ export class UI {
             else
                 this.textureViewer.setTextureList([]);
         }
+
+        if (this.studioModeEnabled)
+            this.studioPanel.onSceneChange();
     }
 
     private setPanels(panels: Panel[]): void {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -2151,13 +2151,15 @@ class StudioPanel extends FloatingPanel {
         }
 
         this.keyframeNameInput.onchange = () => {
-            if (this.selectedKeyframeListItem &&
-                (!this.keyframeNameInput.value || this.keyframeNameInput.value.trim() === '')) {
-                this.keyframeNameInput.value = 'Keyframe';
-                this.selectedKeyframeListItem.dataset.name = 'Keyframe';
-                this.selectedKeyframeListItem.childNodes[0].nodeValue = 'Keyframe';
+            if (this.selectedKeyframeListItem) {
+                if (!this.keyframeNameInput.value || this.keyframeNameInput.value.trim() === '') {
+                    this.keyframeNameInput.value = 'Keyframe';
+                    this.selectedKeyframeListItem.dataset.name = 'Keyframe';
+                    this.selectedKeyframeListItem.childNodes[0].nodeValue = 'Keyframe';
+                }
+                this.selectedKeyframe.name = this.keyframeNameInput.value;
+                this.saveAnimation();
             }
-            this.saveAnimation();
         }
 
         const MAX_KEYFRAME_DURATION = 100.0;
@@ -2463,7 +2465,8 @@ class StudioPanel extends FloatingPanel {
         const keyframeListItem: HTMLElement = document.createElement('li');
         // The keyframe index is passed as the CustomEvent detail.
         const keyframeIndex: number = e.detail;
-        keyframeListItem.innerText = 'Keyframe ' + (this.animationManager.totalKeyframesAdded());
+        const kf: Keyframe = this.animationManager.getKeyframeByIndex(keyframeIndex);
+        keyframeListItem.innerText = kf.name as string;
         keyframeListItem.dataset.index = keyframeIndex.toString();
         keyframeListItem.dataset.name = keyframeListItem.innerText;
         keyframeListItem.onclick = (e: MouseEvent) => this.selectKeyframeListItem(e);
@@ -2505,8 +2508,8 @@ class StudioPanel extends FloatingPanel {
         if (keyframeIndex === this.keyframeList.children.length) {
             this.keyframeList.insertAdjacentElement('beforeend', keyframeListItem);
         } else {
-            this.keyframeList.children[keyframeIndex].insertAdjacentElement('afterend', keyframeListItem);
-            this.updateKeyframeIndices(keyframeIndex);
+            this.keyframeList.children[keyframeIndex - 1].insertAdjacentElement('afterend', keyframeListItem);
+            this.updateKeyframeIndices(keyframeIndex - 1);
         }
         keyframeListItem.click();
         this.saveAnimation();


### PR DESCRIPTION
This PR introduces some more data management options and quality-of-life features to Studio Mode.

- Whenever a new scene is loaded with studio mode active, the animation for that scene is loaded from local storage, if one exists. Also fixes a bug where the studio camera controller is deselected when switching scenes.
- Added a "New" button which clears the current animation.
- Animations are auto-saved on every non-destructive edit (basically, everything except deleting keyframes and clicking "New"). This is perhaps a bit overzealous. I'm open to only auto-saving on scene changes instead.
- Keyframe names are now saved and loaded with animations.
- Added buttons for "Export" and "Import", which save and load animations as JSON files. Some very basic validation and error handling is also included.

I was going to bundle this PR with some upcoming interpolation tweaks but I figure it's easier to do these separately, in case those tweaks end up taking a while or don't pan out.