### PR TITLE
Studio - Interpolation Improvements

### DIFF
--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -554,8 +554,7 @@ export class StudioCameraController extends FPSCameraController {
             this.animationManager.update(dt);
             this.animationManager.playbackInterpolationStep(this.interpStep);
             mat4.targetTo(this.camera.worldMatrix, this.interpStep.pos, this.interpStep.lookAtPos, Vec3UnitY);
-            // TODO(Veegie): Someday, we will figure out bank rotation. And we will do sweet corkscrews all day long.
-            // mat4.rotateZ(this.camera.worldMatrix, this.camera.worldMatrix, this.interpStep.bank);
+            mat4.rotateZ(this.camera.worldMatrix, this.camera.worldMatrix, this.interpStep.bank);
             return CameraUpdateResult.Changed;
         }
     }

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -540,7 +540,7 @@ export class StudioCameraController extends FPSCameraController {
     public updateAnimation(dt: number): CameraUpdateResult {
         if (this.animationManager.isKeyframeFinished()) {
             if (this.animationManager.playbackHasNextKeyframe())
-                this.animationManager.playbackNextKeyframe();
+                this.animationManager.playbackAdvanceKeyframe();
             else
                 this.stopAnimation();
             return CameraUpdateResult.Unchanged;
@@ -559,16 +559,17 @@ export class StudioCameraController extends FPSCameraController {
         }
     }
 
-    public setToPosition(pos: mat4): void {
-        mat4.copy(this.camera.worldMatrix, pos);
+    public setToPosition(setStep: InterpolationStep): void {
+        mat4.targetTo(this.camera.worldMatrix, setStep.pos, setStep.lookAtPos, Vec3UnitY);
+        mat4.rotateZ(this.camera.worldMatrix, this.camera.worldMatrix, setStep.bank);
         mat4.invert(this.camera.viewMatrix, this.camera.worldMatrix);
         this.camera.worldMatrixUpdated();
         this.isOnKeyframe = true;
     }
 
-    public playAnimation(startPos: mat4) {
+    public playAnimation(startStep: InterpolationStep) {
         this.isAnimationPlaying = true;
-        this.setToPosition(startPos);
+        this.setToPosition(startStep);
     }
 
     public stopAnimation() {

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -499,7 +499,7 @@ export class FPSCameraController implements CameraController {
 
 export class StudioCameraController extends FPSCameraController {
     private isAnimationPlaying: boolean = false;
-    private interpStep: InterpolationStep = {bank: 0, pos: vec3.create(), lookAtPos: vec3.create()};
+    private interpStep: InterpolationStep = {pos: vec3.create(), lookAtPos: vec3.create(), bank: 0};
     /**
      * Indicates if the camera is currently positioned on a keyframe's end position.
      */

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -499,7 +499,7 @@ export class FPSCameraController implements CameraController {
 
 export class StudioCameraController extends FPSCameraController {
     private isAnimationPlaying: boolean = false;
-    private interpStep: InterpolationStep = {pos: vec3.create(), lookAtPos: vec3.create(), bank: 0};
+    private interpStep: InterpolationStep = new InterpolationStep();
     /**
      * Indicates if the camera is currently positioned on a keyframe's end position.
      */

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -554,7 +554,8 @@ export class StudioCameraController extends FPSCameraController {
             this.animationManager.update(dt);
             this.animationManager.playbackInterpolationStep(this.interpStep);
             mat4.targetTo(this.camera.worldMatrix, this.interpStep.pos, this.interpStep.lookAtPos, Vec3UnitY);
-            mat4.rotateZ(this.camera.worldMatrix, this.camera.worldMatrix, this.interpStep.bank);
+            // TODO(Veegie): Someday, we will figure out bank rotation. And we will do sweet corkscrews all day long.
+            // mat4.rotateZ(this.camera.worldMatrix, this.camera.worldMatrix, this.interpStep.bank);
             return CameraUpdateResult.Changed;
         }
     }

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -209,7 +209,7 @@ export class CameraAnimationManager {
     }
 
     public editKeyframePosition(pos: mat4, index: number) {
-        if (index > -1 && index < this.animation.keyframes.length)
+        if (index >= 0 && index < this.animation.keyframes.length)
             this.animation.keyframes[index].endPos = pos;
         this.endEditKeyframePosition();
     }

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -404,9 +404,10 @@ export class CameraAnimationManager {
         let length = 0;
         if (!vec3.exactEquals(this.prevPos, this.nextPos)) {
             vec3.copy(this.scratchVec1, this.prevPos);
-            for (let t = 0.0001; t <= 1; t += 0.0001) {
+            const numSteps = 10000;
+            for (let i = 1; i <= numSteps; i++) {
                 for (let j = 0; j < 3; j++) {
-                    this.scratchVec2[j] = getPointHermite(this.prevPos[j], this.nextPos[j], toKeyframe.posTangentIn[j], toKeyframe.posTangentOut[j], t);
+                    this.scratchVec2[j] = getPointHermite(this.prevPos[j], this.nextPos[j], toKeyframe.posTangentIn[j], toKeyframe.posTangentOut[j], i / numSteps);
                 }
                 length += vec3.distance(this.scratchVec1, this.scratchVec2);
                 vec3.copy(this.scratchVec1, this.scratchVec2);

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -143,6 +143,12 @@ export class CameraAnimationManager {
     public loadAnimation(keyframes: Keyframe[]) {
         if (keyframes.length === 0)
             return;
+        for (let i = 0; i < keyframes.length; i++) {
+            keyframes[i].posTangentIn = vec3.create();
+            keyframes[i].posTangentOut = vec3.create();
+            keyframes[i].lookAtPosTangentIn = vec3.create();
+            keyframes[i].lookAtPosTangentOut = vec3.create();
+        }
         this.animation = new CameraAnimation();
         this.animation.keyframes = keyframes;
         this.uiKeyframeList.dispatchEvent(new Event('startPositionSet'));
@@ -159,7 +165,13 @@ export class CameraAnimationManager {
     }
 
     public serializeAnimation(): string {
-        return JSON.stringify(this.animation.keyframes);
+        const exclude = ['posTangentIn', 'posTangentOut', 'lookAtPosTangentIn', 'lookAtPosTangentOut'];
+        return JSON.stringify(this.animation.keyframes, (key, value) => {
+            if (exclude.includes(key))
+                return undefined;
+            else
+                return value;
+        });
     }
 
     public getKeyframeByIndex(index: number): Keyframe {
@@ -402,11 +414,6 @@ export class CameraAnimationManager {
                 for (let j = 0; j < 16; j++) {
                     if (typeof a[i].endPos[j] !== 'number')
                         return false;
-                    if (j < 3) {
-                        if (typeof a[i].posTangentIn[j] !== 'number'
-                            || typeof a[i].posTangentOut[j] !== 'number')
-                            return false;
-                    }
                 }
                 if (typeof a[i].holdDuration !== 'number')
                     return false;

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -24,10 +24,10 @@ const easeBothFunc: Function = (t: number) => {
     return getPointBezier(0, 0, 1, 1, t);
 }
 
-export interface InterpolationStep {
-    pos: vec3;
-    lookAtPos: vec3;
-    bank: number;
+export class InterpolationStep {
+    pos: vec3 = vec3.create();
+    lookAtPos: vec3 = vec3.create();
+    bank: number = 0;
 }
 
 export interface Keyframe {

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -529,7 +529,10 @@ export class CameraAnimationManager {
             return;
         }
 
-        this.calculateTangents(keyframes[keyframes.length - 1], keyframes[0], keyframes[1]);
+        if (this.loopAnimation)
+            this.calculateTangents(keyframes[keyframes.length - 1], keyframes[0], keyframes[1]);
+        else
+            this.calculateTangents(keyframes[0], keyframes[0], keyframes[1]);
 
         for (let i = 1; i < keyframes.length - 1; i++) {
             this.calculateTangents(keyframes[i - 1], keyframes[i], keyframes[i + 1]);

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -185,7 +185,7 @@ export class CameraAnimationManager {
     }
 
     public editKeyframePosition(pos: mat4, index: number) {
-        if (index > 0 && index < this.animation.keyframes.length)
+        if (index > -1 && index < this.animation.keyframes.length)
             this.animation.keyframes[index].endPos = pos;
         this.endEditKeyframePosition();
     }
@@ -269,8 +269,9 @@ export class CameraAnimationManager {
             for (let i = 0; i < 3; i++) {
                 if (this.interpPos)
                     outInterpStep.pos[i] = getPointHermite(this.posFrom[i], this.posTo[i], this.currentKeyframe.trsTangentIn[i], this.currentKeyframe.trsTangentOut[i], interpAmount);
-                if (this.interpLookAtPos)
-                    outInterpStep.lookAtPos[i] = getPointHermite(this.lookAtPosFrom[i], this.lookAtPosTo[i], this.currentKeyframe.trsTangentIn[i], this.currentKeyframe.trsTangentOut[i], interpAmount);
+                else
+                    outInterpStep.pos[i] = this.posTo[i];
+                outInterpStep.lookAtPos[i] = getPointHermite(this.lookAtPosFrom[i], this.lookAtPosTo[i], this.currentKeyframe.trsTangentIn[i], this.currentKeyframe.trsTangentOut[i], interpAmount);
             }
             // TODO(Veegie) Interpolate bank rotation.
         }

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -97,6 +97,7 @@ export class CameraAnimationManager {
     private currentKeyframeIndex: number;
     private currentKeyframe: Keyframe;
     private currentKeyframeProgressMs: number = 0;
+    private pastDurationMs: number = 0;
     private currentKeyframeInterpDurationMs: number = 0;
     private currentKeyframeTotalDurationMs: number = 0;
     private loopAnimation: boolean = false;
@@ -215,10 +216,13 @@ export class CameraAnimationManager {
      * @param dt delta time since last update
      */
     public update(dt: number): void {
-        if (this.currentKeyframeProgressMs < this.currentKeyframe.interpDuration)
+        if (this.currentKeyframeProgressMs < this.currentKeyframe.interpDuration) {
             this.currentKeyframeProgressMs += dt;
-        else
+            if (this.currentKeyframeProgressMs > this.currentKeyframe.interpDuration)
+                this.pastDurationMs = this.currentKeyframeProgressMs - this.currentKeyframe.interpDuration;
+        } else {
             this.currentKeyframeProgressMs = Math.min(this.currentKeyframeProgressMs + dt, this.currentKeyframeTotalDurationMs);
+        }
     }
 
     public interpFinished(): boolean {
@@ -270,7 +274,7 @@ export class CameraAnimationManager {
             this.currentKeyframeIndex++;
         }
         this.currentKeyframe = this.animation.keyframes[this.currentKeyframeIndex];
-        this.currentKeyframeProgressMs = 0;
+        this.currentKeyframeProgressMs = 0 + this.pastDurationMs;
         this.currentKeyframeInterpDurationMs = this.currentKeyframe.interpDuration * MILLISECONDS_IN_SECOND;
         this.currentKeyframeTotalDurationMs = (this.currentKeyframe.interpDuration + this.currentKeyframe.holdDuration) * MILLISECONDS_IN_SECOND;
         if (this.currentKeyframe.interpDuration === 0)

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -271,6 +271,9 @@ export class CameraAnimationManager {
             if (easeFunc)
                 interpAmount = easeFunc(interpAmount);
             vec3.lerp(outInterpStep.pos, this.posFrom, this.posTo, interpAmount);
+            vec3.lerp(outInterpStep.lookAtPos, this.lookAtPosFrom, this.lookAtPosTo, interpAmount);
+            vec3.lerp(this.nextRot, this.rotEFrom, this.rotETo, interpAmount);
+            outInterpStep.bank = this.nextRot[2];
         } else {
             for (let i = 0; i < 3; i++) {
                 if (this.interpPos)
@@ -428,7 +431,7 @@ export class CameraAnimationManager {
         vec3.scaleAndAdd(this.lookAtPosTo, this.posTo, this.forwardVecTo, -100);
         this.interpPos = !vec3.exactEquals(this.posFrom, this.posTo);
         this.interpLookAtPos = !vec3.exactEquals(this.lookAtPosFrom, this.lookAtPosTo);
-        this.interpRot = this.rotEFrom[2] != this.rotETo[2];
+        this.interpRot = Math.round(this.rotEFrom[2] * 10000) != Math.round(this.rotETo[2] * 10000);
     }
 
     /**

--- a/src/CameraAnimationManager.ts
+++ b/src/CameraAnimationManager.ts
@@ -216,10 +216,10 @@ export class CameraAnimationManager {
      * @param dt delta time since last update
      */
     public update(dt: number): void {
-        if (this.currentKeyframeProgressMs < this.currentKeyframe.interpDuration) {
+        if (this.currentKeyframeProgressMs < this.currentKeyframeInterpDurationMs) {
             this.currentKeyframeProgressMs += dt;
-            if (this.currentKeyframeProgressMs > this.currentKeyframe.interpDuration)
-                this.pastDurationMs = this.currentKeyframeProgressMs - this.currentKeyframe.interpDuration;
+            if (this.currentKeyframeProgressMs > this.currentKeyframeInterpDurationMs)
+                this.pastDurationMs = this.currentKeyframeProgressMs - this.currentKeyframeInterpDurationMs;
         } else {
             this.currentKeyframeProgressMs = Math.min(this.currentKeyframeProgressMs + dt, this.currentKeyframeTotalDurationMs);
         }
@@ -275,6 +275,7 @@ export class CameraAnimationManager {
         }
         this.currentKeyframe = this.animation.keyframes[this.currentKeyframeIndex];
         this.currentKeyframeProgressMs = 0 + this.pastDurationMs;
+        this.pastDurationMs = 0;
         this.currentKeyframeInterpDurationMs = this.currentKeyframe.interpDuration * MILLISECONDS_IN_SECOND;
         this.currentKeyframeTotalDurationMs = (this.currentKeyframe.interpDuration + this.currentKeyframe.holdDuration) * MILLISECONDS_IN_SECOND;
         if (this.currentKeyframe.interpDuration === 0)

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1762,6 +1762,7 @@ class StudioPanel extends FloatingPanel {
     private keyframeNameInput: HTMLInputElement;
     private keyframeDurationContainer: HTMLElement;
     private keyframeDurationInput: HTMLInputElement;
+    private matchPrevSpeedBtn: HTMLInputElement;
     private keyframeHoldDurationInput: HTMLInputElement;
 
     private interpolationSettings: HTMLElement;
@@ -1955,7 +1956,10 @@ class StudioPanel extends FloatingPanel {
                     </div>
                     <div id="keyframeDurationContainer">
                         <div class="SettingsHeader KeyframeSettingsName">Duration</div>
-                        <input id="keyframeDuration" class="KeyframeNumericInput" type="number" min="0" max="100.0" step="0.1"/> <span>s</span>
+                        <div style="display:flex; align-items:center; justify-content:space-evenly">
+                            <input id="keyframeDuration" class="KeyframeNumericInput" type="number" min="0" max="100.0" step="0.1"/> <span>s</span>
+                            <button type="button" id="matchPrevSpeedBtn" class="SettingsButton" style="width:60%">Match Prev Speed</button>
+                        </div>
                     </div>
                     <div id="interpolationSettings">
                         <div class="SettingsHeader KeyframeSettingsName">Motion Interpolation</div>
@@ -2029,6 +2033,8 @@ class StudioPanel extends FloatingPanel {
         this.keyframeNameInput = this.contents.querySelector('#keyframeName') as HTMLInputElement;
         this.keyframeDurationContainer = this.contents.querySelector('#keyframeDurationContainer') as HTMLElement;
         this.keyframeDurationInput = this.contents.querySelector('#keyframeDuration') as HTMLInputElement;
+        this.matchPrevSpeedBtn = this.contents.querySelector('#matchPrevSpeedBtn') as HTMLInputElement;
+        this.matchPrevSpeedBtn.dataset.helpText = 'Attempt to auto-calculate the duration to match the previous keyframe\'s speed. Not guaranteed to work.';
         this.keyframeHoldDurationInput = this.contents.querySelector('#keyframeHoldDuration') as HTMLInputElement;
 
         this.interpolationSettings = this.contents.querySelector('#interpolationSettings') as HTMLElement;
@@ -2181,6 +2187,15 @@ class StudioPanel extends FloatingPanel {
                 this.interpolationSettings.setAttribute('hidden', '');
             }
             this.saveAnimation();
+        }
+
+        this.matchPrevSpeedBtn.onclick = () => {
+            if (this.selectedKeyframeListItem) {
+                const index = parseInt(this.selectedKeyframeListItem.dataset.index as string);
+                const duration = this.animationManager.getMatchedSpeedDuration(index);
+                this.selectedKeyframe.interpDuration = duration;
+                this.keyframeDurationInput.value = duration.toString();
+            }
         }
 
         this.hermiteBtn.onclick = () => {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -2272,7 +2272,7 @@ class StudioPanel extends FloatingPanel {
                 this.stopPreviewKeyframeBtn.classList.remove('disabled');
                 this.stopAnimationBtn.removeAttribute('hidden');
                 this.stopAnimationBtn.removeAttribute('disabled');
-                this.animationManager.previewKeyframe(parseInt(this.selectedKeyframeListItem.dataset.index as string));
+                this.animationManager.previewKeyframe(parseInt(this.selectedKeyframeListItem.dataset.index as string), this.loopAnimationCheckbox.checked);
             }
         }
 

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -2192,7 +2192,7 @@ class StudioPanel extends FloatingPanel {
         this.matchPrevSpeedBtn.onclick = () => {
             if (this.selectedKeyframeListItem) {
                 const index = parseInt(this.selectedKeyframeListItem.dataset.index as string);
-                const duration = this.animationManager.getMatchedSpeedDuration(index);
+                const duration = this.animationManager.getMatchedSpeedDuration(index, this.loopAnimationCheckbox.checked);
                 this.selectedKeyframe.interpDuration = duration;
                 this.keyframeDurationInput.value = duration.toString();
             }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -2034,7 +2034,7 @@ class StudioPanel extends FloatingPanel {
         this.keyframeDurationContainer = this.contents.querySelector('#keyframeDurationContainer') as HTMLElement;
         this.keyframeDurationInput = this.contents.querySelector('#keyframeDuration') as HTMLInputElement;
         this.matchPrevSpeedBtn = this.contents.querySelector('#matchPrevSpeedBtn') as HTMLInputElement;
-        this.matchPrevSpeedBtn.dataset.helpText = 'Attempt to auto-calculate the duration to match the previous keyframe\'s speed. Not guaranteed to work.';
+        this.matchPrevSpeedBtn.dataset.helpText = 'Attempt to auto-calculate the duration to match the previous keyframe\'s speed.';
         this.keyframeHoldDurationInput = this.contents.querySelector('#keyframeHoldDuration') as HTMLInputElement;
 
         this.interpolationSettings = this.contents.querySelector('#interpolationSettings') as HTMLElement;


### PR DESCRIPTION
This PR introduces some improvements to the interpolation methods used in Studio mode.

- A bug in the playback engine has been fixed. Now, if the delta time between one animation step and the next overruns the current keyframe's duration, we save that value and carry it over to the next keyframe. I've done some testing and haven't noticed any issues with this yet, and it should help to reduce judder on keyframe boundaries.
- Interpolation is now done via the generation of a lookAt matrix (or targetTo matrix, more precisely) every animation step, so that we can use Hermite interpolation on both rotation and translation. The difference between [quaternion slerp](https://gfycat.com/neighboringultimateblacknorwegianelkhound) and [Hermite](https://gfycat.com/charmingaromaticivorybackedwoodswallow) is subtle, but the latter is definitely an improvement. Big thanks to Jasper for all their help on this one.
- A new button has been added to the interface, which, when clicked, will attempt to calculate the duration necessary to match the preceding keyframe's interpolation speed.
   - It estimates the curve length of a segment between two keyframes by taking 10,000 sample points along the curve, calculates the euclidean distance between each point, and sums them all together.
   - The duration of the previous keyframe is divided by its curve length, then multiplied by the current keyframe's curve length to retrieve an approximate duration to match the (average) speed. This doesn't account for acceleration, just a constant average speed, but it's a decent starting point for a user to smooth things out manually.
- Fixed a bug where the starting position couldn't be edited.

**Limitations**
- Keyframes consisting only of rotation are a bit wonky with Hermite interpolation owing to the unwieldy tangents. This might be fixable with configurable focus distances, but I'm not sure. Linear interpolation is a good alternative for these kinds of keyframes.
- (Fixed in 78cbb7f) ~~The lookAt/targetTo interpolation method does not support bank rotation, ("roll rotation" about the z-axis) because math is really hard. If anyone knows how to make math less hard, please email me at my webzone.~~
- (Fixed in 10aa85f) ~~Animations saved with the previous system are incompatible with this update. Animations saved in localStorage will be deleted upon enabling studio mode, but the JSON will be printed to the console before deleting. If you've exported an animation to JSON using the previous interpolation method, you'll need to do two search-and-replace edits to make them compatible with this new system:~~
   - ~~Find `trsTangent`, replace all with `posTangent`~~
   - ~~Find `rotTangent`, replace all with `lookAtPosTangent`~~