### PR TITLE
Fine control camera hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you would like contribute, there is a Getting Started guide in the [Official 
 	- WASD/Arrow Keys: Move camera
 	- IJKL/Drag Mouse: Pan/tilt camera
 	- Shift: Increase camera speed
-	- Control: Reduce camera speed
+	- Backslash: Reduce camera speed
 	- Q/Page Down/Ctrl+Space: Move camera down
 	- E/Page Up/Space: Move camera up
 	- Scroll Wheel: Change camera speed

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If you would like contribute, there is a Getting Started guide in the [Official 
 	- WASD/Arrow Keys: Move camera
 	- IJKL/Drag Mouse: Pan/tilt camera
 	- Shift: Increase camera speed
+	- Control: Reduce camera speed
 	- Q/Page Down/Ctrl+Space: Move camera down
 	- E/Page Up/Space: Move camera up
 	- Scroll Wheel: Change camera speed

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -311,6 +311,7 @@ export class FPSCameraController implements CameraController {
 
     private keyMoveSpeed = 60;
     private keyMoveShiftMult = 5;
+    private keyMoveCtrlMult = 0.1;
     private keyMoveVelocityMult = 1/5;
     private keyMoveDrag = 0.8;
     private keyAngleChangeVelFast = 0.1;
@@ -352,10 +353,14 @@ export class FPSCameraController implements CameraController {
 
         this.keyMoveSpeed = Math.max(this.keyMoveSpeed, 1);
         const isShiftPressed = inputManager.isKeyDown('ShiftLeft') || inputManager.isKeyDown('ShiftRight');
+        const isControlPressed = inputManager.isKeyDown('ControlLeft') || inputManager.isKeyDown('ControlRight');
 
         let keyMoveMult = 1;
         if (isShiftPressed)
             keyMoveMult = this.keyMoveShiftMult;
+
+        if (isControlPressed)
+            keyMoveMult = this.keyMoveCtrlMult;
 
         if (inputManager.isKeyDownEventTriggered('Numpad4') || inputManager.isKeyDownEventTriggered('Numpad1')) {
             // Save world forward vector from current position.

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -311,7 +311,7 @@ export class FPSCameraController implements CameraController {
 
     private keyMoveSpeed = 60;
     private keyMoveShiftMult = 5;
-    private keyMoveCtrlMult = 0.1;
+    private keyMoveSlashMult = 0.1;
     private keyMoveVelocityMult = 1/5;
     private keyMoveDrag = 0.8;
     private keyAngleChangeVelFast = 0.1;
@@ -353,14 +353,14 @@ export class FPSCameraController implements CameraController {
 
         this.keyMoveSpeed = Math.max(this.keyMoveSpeed, 1);
         const isShiftPressed = inputManager.isKeyDown('ShiftLeft') || inputManager.isKeyDown('ShiftRight');
-        const isControlPressed = inputManager.isKeyDown('ControlLeft') || inputManager.isKeyDown('ControlRight');
+        const isSlashPressed = inputManager.isKeyDown('IntlBackslash');
 
         let keyMoveMult = 1;
         if (isShiftPressed)
             keyMoveMult = this.keyMoveShiftMult;
 
-        if (isControlPressed)
-            keyMoveMult = this.keyMoveCtrlMult;
+        if (isSlashPressed)
+            keyMoveMult = this.keyMoveSlashMult;
 
         if (inputManager.isKeyDownEventTriggered('Numpad4') || inputManager.isKeyDownEventTriggered('Numpad1')) {
             // Save world forward vector from current position.


### PR DESCRIPTION
In most engines, the default behaviour for noclip cameras is to slow the camera to from the set speed when the control key is pressed. Most of the time, the value is reduced to 1/10th. This is usually used to finely control the camera into small areas. This kind of tripped me up at first when I came across the site - because I was used to this hotkey working. So, I've added it using the same logic as the shift hotkey.

I've made this hotkey takes priority over the shift key, but I can easily change it if you think it should be the other way around.

## Example in Gary's Mod

If I use ```cl_showpos 1``` to show the velocity of the camera, you can see that the default speed is 500 Hu/S:

![Normal noclip speed](https://i.imgur.com/cPVITcO.png)

But if I press shift while noclipping, the speed triples

![Sprint noclip speed](https://i.imgur.com/W4xg19F.png)

And when pressing control it is divided by ten

![Control noclip speed](https://i.imgur.com/9qYmUeD.png)

## Problem with default hotkeys

Because of interference by the browser, for this hotkey to work without closing the tab or saving a copy (for example with Ctrl-W and Ctrl-S), you have to start moving with a movement key and then press the control key. I'll see if I can find a workaround that doesn't disrupt the default browser hotkeys too much.