### PR TITLE
viewer: Increase default FoV from 45 to 60 degrees

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -9,7 +9,7 @@ import { GITHUB_REVISION_URL, GITHUB_URL, GIT_SHORT_REVISION, IS_DEVELOPMENT } f
 import { SaveManager, GlobalSaveManager } from "./SaveManager";
 import { RenderStatistics } from './RenderStatistics';
 import { GlobalGrabManager } from './GrabManager';
-import { clamp } from './MathHelpers';
+import { clamp, MathConstants } from './MathHelpers';
 
 // @ts-ignore
 import logoURL from './assets/logo.png';
@@ -1465,7 +1465,7 @@ class ViewerSettings extends Panel {
         this.fovSlider = new Slider();
         this.fovSlider.setLabel("Field of View");
         this.fovSlider.setRange(1, 100);
-        this.fovSlider.setValue(25);
+        this.fovSlider.setValue(Viewer.Viewer.FOV_Y_DEFAULT / MathConstants.TAU);
         this.fovSlider.onvalue = this.onFovSliderChange.bind(this);
         sliderContainer.appendChild(this.fovSlider.elem);
 

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -95,7 +95,9 @@ export class Viewer {
     public xrCameraController: XRCameraController = new XRCameraController();
 
     public camera = new Camera();
-    public fovY: number = MathConstants.TAU / 8;
+
+    static readonly FOV_Y_DEFAULT: number = MathConstants.TAU / 6;
+    public fovY: number = Viewer.FOV_Y_DEFAULT;
     // Scene time. Can be paused / scaled / rewound / whatever.
     public sceneTime: number = 0;
     // requestAnimationFrame time. Used to calculate dt from the new time.
@@ -220,7 +222,7 @@ export class Viewer {
 
         resetGfxDebugGroup(this.debugGroup);
         this.gfxDevice.pushDebugGroup(this.debugGroup);
-        
+
         this.viewerRenderInput.onscreenTexture = this.gfxSwapChain.getOnscreenTexture();
 
         for (let i = 0; i < webXRContext.views.length; i++) {


### PR DESCRIPTION
Low FoV values such as 45 are common in console games where the TV
screen is usually quite far, but not so in Desktop/mobile scenarioes
where noclip.website is most commonly used for.

Values of 80-90 are much more common in these cases, I picked 60 since
it's around the middle (also it divided evenly).

---
The exact value is of course open to bikeshedding (should probably be even more?), but I do believe it's necessary to increase it.