### PR TITLE
Improved MKDD. Objects, BCA, rotation fix and more

### DIFF
--- a/src/Common/JSYSTEM/J3D/J3DGraphAnimator.ts
+++ b/src/Common/JSYSTEM/J3D/J3DGraphAnimator.ts
@@ -46,6 +46,14 @@ export function sampleAnimationData(track: AnimationTrack, frame: number): numbe
     return hermiteInterpolate(k0, k1, frame);
 }
 
+function sampleANF1AnimationData(frames: number[], animFrame: number): number {
+    if (frames.length == 1) {
+        return frames[0];
+    }
+
+    return frames[animFrame];
+}
+
 export const enum J3DFrameCtrl__UpdateFlags {
     HasStopped  = 0b0001,
     HasRepeated = 0b0010,
@@ -339,9 +347,6 @@ export function calcJointMatrixMayaSSC(dst: mat4, parentScale: ReadonlyVec3): vo
 }
 
 export function calcJointMatrixFromTransform(dst: mat4, transform: JointTransformInfo, loadFlags: J3DLoadFlags, jnt1: Joint, shapeInstanceState: ShapeInstanceState): void {
-    
-    
-    
     mat4.fromQuat(dst, transform.rotation);
     setMatrixTranslation(dst, transform.translation);
     mat4.scale(dst, dst, transform.scale);
@@ -351,7 +356,7 @@ export function calcJointMatrixFromTransform(dst: mat4, transform: JointTransfor
         calcJointMatrixMayaSSC(dst, shapeInstanceState.parentScale);
 }
 
-const ank1ScratchQuat = quat.create();
+const scratchQuat = quat.create();
 export function calcANK1JointAnimationTransform(dst: JointTransformInfo, entry: ANK1JointAnimationEntry, animFrame: number, animFrame1: number): void {
     dst.scale[0] = sampleAnimationData(entry.scaleX, animFrame);
     dst.scale[1] = sampleAnimationData(entry.scaleY, animFrame);
@@ -368,8 +373,8 @@ export function calcANK1JointAnimationTransform(dst: JointTransformInfo, entry: 
         const r1x = sampleAnimationData(entry.rotationX, a1);
         const r1y = sampleAnimationData(entry.rotationY, a1);
         const r1z = sampleAnimationData(entry.rotationZ, a1);
-        quatFromEulerRadians(ank1ScratchQuat, r1x, r1y, r1z);
-        quat.slerp(dst.rotation, dst.rotation, ank1ScratchQuat, animFrame - a0);
+        quatFromEulerRadians(scratchQuat, r1x, r1y, r1z);
+        quat.slerp(dst.rotation, dst.rotation, scratchQuat, animFrame - a0);
     }
 
     dst.translation[0] = sampleAnimationData(entry.translationX, animFrame);
@@ -416,36 +421,28 @@ export function removeJointAnimator(modelInstance: J3DModelInstance, ank1: ANK1)
     modelInstance.jointMatrixCalc = new JointMatrixCalcNoAnm();
 }
 
-const anf1ScratchQuat = quat.create();
 export function calcANF1JointAnimationTransform(dst: JointTransformInfo, entry: ANF1JointAnimationEntry, animFrame: number, animFrame1: number): void {
-
-    const sample = (frames: number[]) => {
-        if (frames.length == 1) {
-            return frames[0];
-        }
-
-        return frames[animFrame | 0];
-    }
-
-    dst.scale[0] = sample(entry.scaleX);
-    dst.scale[1] = sample(entry.scaleY);
-    dst.scale[2] = sample(entry.scaleZ);
-
     const a0 = animFrame | 0;
-    const r0x = sample(entry.rotationX);
-    const r0y = sample(entry.rotationY);
-    const r0z = sample(entry.rotationZ);
+
+    dst.scale[0] = sampleANF1AnimationData(entry.scaleX, a0);
+    dst.scale[1] = sampleANF1AnimationData(entry.scaleY, a0);
+    dst.scale[2] = sampleANF1AnimationData(entry.scaleZ, a0);
+
+    const r0x = sampleANF1AnimationData(entry.rotationX, a0);
+    const r0y = sampleANF1AnimationData(entry.rotationY, a0);
+    const r0z = sampleANF1AnimationData(entry.rotationZ, a0);
     quatFromEulerRadians(dst.rotation, r0x, r0y, r0z);
 
     if (a0 !== animFrame) {
-        const r1x = sample(entry.rotationX);
-        const r1y = sample(entry.rotationY);
-        const r1z = sample(entry.rotationZ);
-        quatFromEulerRadians(anf1ScratchQuat, r1x, r1y, r1z);
-        quat.slerp(dst.rotation, dst.rotation, anf1ScratchQuat, animFrame - a0);
+        const a1 = animFrame1 | 0;
+        const r1x = sampleANF1AnimationData(entry.rotationX, a1);
+        const r1y = sampleANF1AnimationData(entry.rotationY, a1);
+        const r1z = sampleANF1AnimationData(entry.rotationZ, a1);
+        quatFromEulerRadians(scratchQuat, r1x, r1y, r1z);
+        quat.slerp(dst.rotation, dst.rotation, scratchQuat, animFrame - a0);
     }
 
-    dst.translation[0] = sample(entry.translationX);
-    dst.translation[1] = sample(entry.translationY);
-    dst.translation[2] = sample(entry.translationZ);
+    dst.translation[0] = sampleANF1AnimationData(entry.translationX, a0);
+    dst.translation[1] = sampleANF1AnimationData(entry.translationY, a0);
+    dst.translation[2] = sampleANF1AnimationData(entry.translationZ, a0);
 }

--- a/src/Common/JSYSTEM/J3D/J3DGraphSimple.ts
+++ b/src/Common/JSYSTEM/J3D/J3DGraphSimple.ts
@@ -37,7 +37,7 @@ function getAnimFrame(anim: AnimationBase, frame: number, loopMode: LoopMode = a
     return animFrame;
 }
 
-const ank1ScratchTransform = new JointTransformInfo();
+const scratchTransform = new JointTransformInfo();
 class JointMatrixCalcANK1 {
     constructor(public animationController: AnimationController, public ank1: ANK1) {
     }
@@ -51,8 +51,8 @@ class JointMatrixCalcANK1 {
             const frame = this.animationController.getTimeInFrames();
             const animFrame = getAnimFrame(this.ank1, frame);
             const animFrame1 = getAnimFrame(this.ank1, frame + 1);
-            calcANK1JointAnimationTransform(ank1ScratchTransform, entry, animFrame, animFrame1);
-            transform = ank1ScratchTransform;
+            calcANK1JointAnimationTransform(scratchTransform, entry, animFrame, animFrame1);
+            transform = scratchTransform;
         } else {
             transform = jnt1.transform;
         }
@@ -64,7 +64,6 @@ class JointMatrixCalcANK1 {
     }
 }
 
-const anf1ScratchTransform = new JointTransformInfo();
 class JointMatrixCalcANF1 {
     constructor(public animationController: AnimationController, public anf1: ANF1) {
     }
@@ -78,8 +77,8 @@ class JointMatrixCalcANF1 {
             const frame = this.animationController.getTimeInFrames();
             const animFrame = getAnimFrame(this.anf1, frame);
             const animFrame1 = getAnimFrame(this.anf1, frame + 1);
-            calcANF1JointAnimationTransform(anf1ScratchTransform, entry, animFrame, animFrame1);
-            transform = anf1ScratchTransform;
+            calcANF1JointAnimationTransform(scratchTransform, entry, animFrame, animFrame1);
+            transform = scratchTransform;
         } else {
             transform = jnt1.transform;
         }

--- a/src/Common/JSYSTEM/J3D/J3DGraphSimple.ts
+++ b/src/Common/JSYSTEM/J3D/J3DGraphSimple.ts
@@ -82,7 +82,7 @@ class JointMatrixCalcANF1 {
             transform = anf1ScratchTransform;
         } else {
             transform = jnt1.transform;
-        }        
+        }
 
         const loadFlags = modelData.bmd.inf1.loadFlags;
         calcJointMatrixFromTransform(dst, transform, loadFlags, jnt1, shapeInstanceState);
@@ -257,13 +257,6 @@ export class J3DModelInstanceSimple extends J3DModelInstance {
 
     public bindANF1(anf1: ANF1 | null, animationController: AnimationController = this.animationController) : void {
         this.jointMatrixCalc = anf1 !== null ? new JointMatrixCalcANF1(animationController, anf1) : new JointMatrixCalcNoAnm();
-
-        //if (anf1 === null) {
-        //    this.bindANK1(null, animationController);
-        //}
-        //else {            
-        //    this.bindANK1(BCA.toBCK(anf1), animationController);
-        //}
     }
 
     private calcSkybox(camera: Camera): void {

--- a/src/Common/JSYSTEM/J3D/J3DGraphSimple.ts
+++ b/src/Common/JSYSTEM/J3D/J3DGraphSimple.ts
@@ -3,7 +3,7 @@ import { J3DModelInstance, BMDModelMaterialData, JointMatrixCalcNoAnm, J3DModelD
 import AnimationController from "../../../AnimationController";
 import { assert } from "../../../util";
 import { Camera } from "../../../Camera";
-import { TTK1, TRK1, TPT1, ANK1, JointTransformInfo, TRK1AnimationEntry, TTK1AnimationEntry, TPT1AnimationEntry, calcTexMtx_Maya, calcTexMtx_Basic, LoopMode, AnimationBase } from "./J3DLoader";
+import { TTK1, TRK1, TPT1, ANK1, ANF1, BCA, JointTransformInfo, TRK1AnimationEntry, TTK1AnimationEntry, TPT1AnimationEntry, calcTexMtx_Maya, calcTexMtx_Basic, LoopMode, AnimationBase } from "./J3DLoader";
 import { GfxDevice } from "../../../gfx/platform/GfxPlatform";
 import { GfxRenderInstManager } from "../../../gfx/render/GfxRenderer";
 import { ViewerRenderInput } from "../../../viewer";
@@ -226,6 +226,10 @@ export class J3DModelInstanceSimple extends J3DModelInstance {
      */
     public bindANK1(ank1: ANK1 | null, animationController: AnimationController = this.animationController): void {
         this.jointMatrixCalc = ank1 !== null ? new JointMatrixCalcANK1(animationController, ank1) : new JointMatrixCalcNoAnm();
+    }
+
+    public bindANF1(anf1: ANF1 | null, animationController: AnimationController = this.animationController) : void {
+        this.bindANK1(BCA.toBCK(anf1), animationController);
     }
 
     private calcSkybox(camera: Camera): void {

--- a/src/Common/JSYSTEM/J3D/J3DLoader.ts
+++ b/src/Common/JSYSTEM/J3D/J3DLoader.ts
@@ -1793,50 +1793,6 @@ export class BCA {
 
         return readANF1Chunk(j3d.nextChunk('ANF1'));
     }
-
-    public static toBCK(anf1: ANF1): ANK1 {
-        const jointAnimationEntries: ANK1JointAnimationEntry[] = [];
-        
-        for (const anim of anf1.jointAnimationEntries) {
-            const convert = (fullFrames: number[]) => {
-                const frames: AnimationKeyframe[] = [];
-                
-                for (let i = 0; i < fullFrames.length; i++) {                
-                    const time = i;
-                    const value = fullFrames[i];
-                    const tangentIn = 0;
-                    const tangentOut = 0;
-    
-                    frames.push({time, value, tangentIn, tangentOut });
-                }
-
-                return { frames };
-            }
-
-            const scaleX = convert(anim.scaleX);
-            const rotationX = convert(anim.rotationX);
-            const translationX = convert(anim.translationX);
-
-            const scaleY = convert(anim.scaleY);
-            const rotationY = convert(anim.rotationY);
-            const translationY = convert(anim.translationY);
-
-            const scaleZ = convert(anim.scaleZ);
-            const rotationZ = convert(anim.rotationZ);
-            const translationZ = convert(anim.translationZ);
-
-            jointAnimationEntries.push({
-                scaleX, rotationX, translationX,
-                scaleY, rotationY, translationY,
-                scaleZ, rotationZ, translationZ,
-            });
-        }
-
-        const loopMode = anf1.loopMode;
-        const duration = anf1.duration;
-    
-        return { loopMode, duration, jointAnimationEntries };
-    }
 }
 //#endregion
 

--- a/src/Common/JSYSTEM/J3D/J3DLoader.ts
+++ b/src/Common/JSYSTEM/J3D/J3DLoader.ts
@@ -1710,6 +1710,136 @@ export class BCK {
 }
 //#endregion
 
+//#region J3DAnmTransformFull
+export interface ANF1JointAnimationEntry {
+    scaleX: number[];
+    rotationX: number[];
+    translationX: number[];
+    scaleY: number[];
+    rotationY: number[];
+    translationY: number[];
+    scaleZ: number[];
+    rotationZ: number[];
+    translationZ: number[];
+}
+
+export interface ANF1 extends AnimationBase {
+    jointAnimationEntries: ANF1JointAnimationEntry[];
+}
+
+function readANF1Chunk(buffer: ArrayBufferSlice): ANF1 {
+    const view = buffer.createDataView();
+    const loopMode: LoopMode = view.getUint8(0x08);
+    //const rotationDecimal = view.getInt8(0x09);
+    const duration = view.getUint16(0x0A);
+    const jointAnimationTableCount = view.getUint16(0x0C);
+    const sCount = view.getUint16(0x0E);
+    const rCount = view.getUint16(0x10);
+    const tCount = view.getUint16(0x12);
+    const jointAnimationTableOffs = view.getUint32(0x14);
+    const sTableOffs = view.getUint32(0x18);
+    const rTableOffs = view.getUint32(0x1C);
+    const tTableOffs = view.getUint32(0x20);
+
+    const rotationScale = Math.PI / 0x7FFF;
+
+    const sTable = buffer.createTypedArray(Float32Array, sTableOffs, sCount, Endianness.BIG_ENDIAN);
+    const rTable = buffer.createTypedArray(Int16Array, rTableOffs, rCount, Endianness.BIG_ENDIAN);
+    const tTable = buffer.createTypedArray(Float32Array, tTableOffs, tCount, Endianness.BIG_ENDIAN);
+
+    let animationTableIdx = jointAnimationTableOffs;
+
+    function readAnimationTrack(data: Int16Array | Float32Array, scale: number): number[] {
+        const count = view.getUint16(animationTableIdx + 0x00);
+        const index = view.getUint16(animationTableIdx + 0x02);
+        animationTableIdx += 0x04;
+
+        const frames: number[] = [];
+
+        for (let i = 0; i < count; i++) {
+            frames.push(data[index + i] * scale);
+        }
+
+        return frames;
+    }
+
+    const jointAnimationEntries: ANF1JointAnimationEntry[] = [];
+
+    for (let i = 0; i < jointAnimationTableCount; i++) {
+        const scaleX = readAnimationTrack(sTable, 1);
+        const rotationX = readAnimationTrack(rTable, rotationScale);
+        const translationX = readAnimationTrack(tTable, 1);
+        const scaleY = readAnimationTrack(sTable, 1);
+        const rotationY = readAnimationTrack(rTable, rotationScale);
+        const translationY = readAnimationTrack(tTable, 1);
+        const scaleZ = readAnimationTrack(sTable, 1);
+        const rotationZ = readAnimationTrack(rTable, rotationScale);
+        const translationZ = readAnimationTrack(tTable, 1);
+
+        jointAnimationEntries.push({
+            scaleX, rotationX, translationX,
+            scaleY, rotationY, translationY,
+            scaleZ, rotationZ, translationZ,
+        });
+    }
+
+    return { loopMode, duration, jointAnimationEntries };
+}
+
+export class BCA {
+    public static parse(buffer: ArrayBufferSlice): ANF1 {
+        const j3d = new JSystemFileReaderHelper(buffer);
+        assert(j3d.magic === 'J3D1bca1');
+
+        return readANF1Chunk(j3d.nextChunk('ANF1'));
+    }
+
+    public static toBCK(anf1: ANF1): ANK1 {
+        const jointAnimationEntries: ANK1JointAnimationEntry[] = [];
+        
+        for (const anim of anf1.jointAnimationEntries) {
+            const convert = (fullFrames: number[]) => {
+                const frames: AnimationKeyframe[] = [];
+                
+                for (let i = 0; i < fullFrames.length; i++) {                
+                    const time = i;
+                    const value = fullFrames[i];
+                    const tangentIn = 0;
+                    const tangentOut = 0;
+    
+                    frames.push({time, value, tangentIn, tangentOut });
+                }
+
+                return { frames };
+            }
+
+            const scaleX = convert(anim.scaleX);
+            const rotationX = convert(anim.rotationX);
+            const translationX = convert(anim.translationX);
+
+            const scaleY = convert(anim.scaleY);
+            const rotationY = convert(anim.rotationY);
+            const translationY = convert(anim.translationY);
+
+            const scaleZ = convert(anim.scaleZ);
+            const rotationZ = convert(anim.rotationZ);
+            const translationZ = convert(anim.translationZ);
+
+            jointAnimationEntries.push({
+                scaleX, rotationX, translationX,
+                scaleY, rotationY, translationY,
+                scaleZ, rotationZ, translationZ,
+            });
+        }
+
+        const loopMode = anf1.loopMode;
+        const duration = anf1.duration;
+    
+        return { loopMode, duration, jointAnimationEntries };
+    }
+}
+//#endregion
+
 //#region J3DAnmTexPattern
 export interface TPT1AnimationEntry {
     materialName: string;

--- a/src/SuperMarioGalaxy/Animation.ts
+++ b/src/SuperMarioGalaxy/Animation.ts
@@ -6,7 +6,7 @@ import ArrayBufferSlice from "../ArrayBufferSlice";
 
 import { J3DModelInstance, J3DModelData, JointMatrixCalc, ShapeInstanceState } from "../Common/JSYSTEM/J3D/J3DGraphBase";
 import { AnimationBase, VAF1, TRK1, TTK1, TPT1, ANK1, LoopMode, Joint, JointTransformInfo, J3DLoadFlags } from "../Common/JSYSTEM/J3D/J3DLoader";
-import { J3DFrameCtrl, VAF1_getVisibility, entryTevRegAnimator, removeTevRegAnimator, entryTexMtxAnimator, removeTexMtxAnimator, entryTexNoAnimator, removeTexNoAnimator, J3DFrameCtrl__UpdateFlags, calcJointAnimationTransform, calcJointMatrixFromTransform } from "../Common/JSYSTEM/J3D/J3DGraphAnimator";
+import { J3DFrameCtrl, VAF1_getVisibility, entryTevRegAnimator, removeTevRegAnimator, entryTexMtxAnimator, removeTexMtxAnimator, entryTexNoAnimator, removeTexNoAnimator, J3DFrameCtrl__UpdateFlags, calcANK1JointAnimationTransform, calcJointMatrixFromTransform } from "../Common/JSYSTEM/J3D/J3DGraphAnimator";
 
 import { JMapInfoIter, createCsvParser } from "./JMapInfo";
 import { ResTable } from "./Main";
@@ -219,7 +219,7 @@ export class XanimeCore implements JointMatrixCalc {
         if (this.ank1 !== null) {
             const entry = this.ank1.jointAnimationEntries[i];
 
-            calcJointAnimationTransform(scratchTransform, entry, this.curAnmTime, this.curAnmTime1);
+            calcANK1JointAnimationTransform(scratchTransform, entry, this.curAnmTime, this.curAnmTime1);
 
             if (this.updateFrozenJoints)
                 xj.xformFrozen.copy(xj.xformAnm);

--- a/src/WindWaker/m_do_ext.ts
+++ b/src/WindWaker/m_do_ext.ts
@@ -1,5 +1,5 @@
 
-import { J3DFrameCtrl, J3DFrameCtrl__UpdateFlags, entryTexMtxAnimator, entryTevRegAnimator, entryTexNoAnimator, VAF1_getVisibility, entryJointAnimator, calcJointMatrixFromTransform, calcJointAnimationTransform } from "../Common/JSYSTEM/J3D/J3DGraphAnimator";
+import { J3DFrameCtrl, J3DFrameCtrl__UpdateFlags, entryTexMtxAnimator, entryTevRegAnimator, entryTexNoAnimator, VAF1_getVisibility, entryJointAnimator, calcJointMatrixFromTransform, calcANK1JointAnimationTransform } from "../Common/JSYSTEM/J3D/J3DGraphAnimator";
 import { TTK1, LoopMode, TRK1, AnimationBase, TPT1, VAF1, ANK1, BCK, JointTransformInfo } from "../Common/JSYSTEM/J3D/J3DLoader";
 import { J3DModelInstance, J3DModelData, JointMatrixCalc, ShapeInstanceState } from "../Common/JSYSTEM/J3D/J3DGraphBase";
 import { GfxRenderInstManager } from "../gfx/render/GfxRenderer";
@@ -151,14 +151,14 @@ export class mDoExt_McaMorf implements JointMatrixCalc {
             const animFrame1 = this.frameCtrl.applyLoopMode(animFrame + 1);
 
             if (this.curMorf >= 1.0) {
-                calcJointAnimationTransform(dstTransform, this.anm.jointAnimationEntries[jointIndex], animFrame, animFrame1);
+                calcANK1JointAnimationTransform(dstTransform, this.anm.jointAnimationEntries[jointIndex], animFrame, animFrame1);
                 // callback1
             } else {
                 // callback1
                 let amt = (this.curMorf - this.prevMorf) / (1.0 - this.prevMorf);
 
                 if (amt > 0.0) {
-                    calcJointAnimationTransform(scratchTransform, this.anm.jointAnimationEntries[jointIndex], animFrame, animFrame1);
+                    calcANK1JointAnimationTransform(scratchTransform, this.anm.jointAnimationEntries[jointIndex], animFrame, animFrame1);
                     dstTransform.lerp(dstTransform, scratchTransform, amt);
                 }
             }

--- a/src/j3d/mkdd_scenes.ts
+++ b/src/j3d/mkdd_scenes.ts
@@ -132,12 +132,12 @@ function parseBOL(buffer: ArrayBufferSlice): BOL {
         const scaleX = view.getFloat32(objectTableIdx + 0x0C);
         const scaleY = view.getFloat32(objectTableIdx + 0x10);
         const scaleZ = view.getFloat32(objectTableIdx + 0x14);
-        const forwardX = view.getInt16(objectTableIdx + 0x18) / 10000;
-        const forwardY = view.getInt16(objectTableIdx + 0x1A) / 10000;
-        const forwardZ = view.getInt16(objectTableIdx + 0x1C) / 10000;
-        const upX = view.getInt16(objectTableIdx + 0x1E) / 10000;
-        const upY = view.getInt16(objectTableIdx + 0x20) / 10000;
-        const upZ = view.getInt16(objectTableIdx + 0x22) / 10000;
+        const forwardX = view.getInt16(objectTableIdx + 0x18);
+        const forwardY = view.getInt16(objectTableIdx + 0x1A);
+        const forwardZ = view.getInt16(objectTableIdx + 0x1C);
+        const upX = view.getInt16(objectTableIdx + 0x1E);
+        const upY = view.getInt16(objectTableIdx + 0x20);
+        const upZ = view.getInt16(objectTableIdx + 0x22);
         const id = view.getUint16(objectTableIdx + 0x24);
         const routeId = view.getInt16(objectTableIdx + 0x26);
         const settings = [];
@@ -147,8 +147,8 @@ function parseBOL(buffer: ArrayBufferSlice): BOL {
         }
 
         // Create rotation
-        const forward: vec3 = [forwardX, forwardY, forwardZ];
-        const up: vec3 = [upX, upY, upZ];
+        const forward = vec3.fromValues(forwardX / 10000, forwardY / 10000, forwardZ / 10000);
+        const up = vec3.fromValues(upX / 10000, upY / 10000, upZ / 10000);
 
         vec3.normalize(forward, forward);
         vec3.normalize(up, up);

--- a/src/j3d/mkdd_scenes.ts
+++ b/src/j3d/mkdd_scenes.ts
@@ -15,8 +15,8 @@ import { BCK, BMD, BTK, BRK, BTP } from '../Common/JSYSTEM/J3D/J3DLoader';
 import { SceneContext } from '../SceneBase';
 import { computeModelMatrixS } from '../MathHelpers';
 import { CameraController } from '../Camera';
-import { BKGeoNode } from '../BanjoKazooie/geo';
-import { findFileData } from '../oot3d/zar';
+
+import {  sampleAnimationData } from "../Common/JSYSTEM/J3D/J3DGraphAnimator";
 
 const id = "mkdd";
 const name = "Mario Kart: Double Dash!!";

--- a/src/j3d/mkdd_scenes.ts
+++ b/src/j3d/mkdd_scenes.ts
@@ -273,9 +273,6 @@ class MKDDSceneDesc implements Viewer.SceneDesc {
                 const scene = this.spawnBMD(device, renderer, rarc, basename, obj.modelMatrix);
                 renderer.addModelInstance(scene);
 
-                // Each object has code which decides what files to load
-                // For now just simply load common files
-
                 for (const anim of animNames) {
                     const fileData = assertExists(rarc.findFileData(anim));
 
@@ -304,6 +301,9 @@ class MKDDSceneDesc implements Viewer.SceneDesc {
 
             const bol = parseBOL(bolFile.buffer);
             
+            // Each object has code which decides what files to load
+            // For now just simply hardcode which object should load what files
+            // Objects: https://avsys.xyz/wiki/Mario_Kart_Double_Dash/Object
             for (const obj of bol.objects) {
                 switch (obj.id) {
                 case 0x0001:
@@ -340,8 +340,8 @@ class MKDDSceneDesc implements Viewer.SceneDesc {
                     break;
                 case 0x0D49:
                     // Sea.
-                    spawnObject(obj, 'objects/sea1_spc.bmd');
-                    spawnObject(obj, 'objects/sea2_tex.bmd');
+                    spawnObject(obj, 'objects/sea1_spc.bmd', ['objects/sea1_spc.btk']);
+                    spawnObject(obj, 'objects/sea2_tex.bmd', ['objects/sea2_tex.btk']);
                     spawnObject(obj, 'objects/sea3_dark.bmd');
                     spawnObject(obj, 'objects/sea4_nami.bmd');
                     spawnObject(obj, 'objects/sea5_sand.bmd');
@@ -434,14 +434,14 @@ class MKDDSceneDesc implements Viewer.SceneDesc {
                     spawnObject(obj, 'objects/testwall1.bmd');
                     break;
                 case 0x0E75:
-                    spawnObject(obj, 'objects/mariotree1.bmd');
+                    spawnObject(obj, 'objects/mariotree1.bmd', ['objects/mariotree1_wait.bck']); // both BCA and BCK exist
                     break;
                 case 0x0E77:
                     spawnObject(obj, 'objects/marioflower1.bmd', ['objects/marioflower1.bck']);
                     break;
                 case 0x0E78:
                     // Chain chomp. Looks awful, don't spawn.
-                    // spawnObject(obj, 'objects/wanwan1.bmd'); break;
+                    //spawnObject(obj, 'objects/wanwan1.bmd'); break;
                     break;
                 case 0x0E7E:
                     spawnObject(obj, 'objects/skyship1.bmd');
@@ -602,7 +602,7 @@ class MKDDSceneDesc implements Viewer.SceneDesc {
 }
 
 // Courses named and organized by Starschulz
-// Other added by Wexos
+// Extra courses added by Wexos
 const sceneDescs = [
     "Mushroom Cup",
     new MKDDSceneDesc(`Luigi Circuit`, 'Luigi.arc'),

--- a/src/j3d/mkdd_scenes.ts
+++ b/src/j3d/mkdd_scenes.ts
@@ -10,7 +10,7 @@ import { BasicRenderTarget, standardFullClearRenderPassDescriptor } from '../gfx
 import { GXRenderHelperGfx, fillSceneParamsDataOnTemplate } from '../gx/gx_render';
 import { GfxDevice, GfxHostAccessPass, GfxRenderPass, GfxFrontFaceMode } from '../gfx/platform/GfxPlatform';
 import { J3DModelData } from '../Common/JSYSTEM/J3D/J3DGraphBase';
-import { J3DModelInstanceSimple } from '../Common/JSYSTEM/J3D/J3DGraphSimple';
+import { bindTTK1MaterialInstance, J3DModelInstanceSimple } from '../Common/JSYSTEM/J3D/J3DGraphSimple';
 import { BCK, BMD, BTK, BRK, BTP, BCA } from '../Common/JSYSTEM/J3D/J3DLoader';
 import { SceneContext } from '../SceneBase';
 import { computeModelMatrixS, Vec3Zero } from '../MathHelpers';
@@ -235,7 +235,13 @@ class MKDDSceneDesc implements Viewer.SceneDesc {
                 const btkFileData = rarc.findFileData(BTKFileName);
 
                 if (btkFileData !== null) {
-                    courseModelInstance.bindTTK1(BTK.parse(btkFileData));
+                    const btk = BTK.parse(btkFileData);
+
+                    for (const materialInstance of courseModelInstance.materialInstances) {
+                        if (btk.uvAnimationEntries.findIndex((x) => x.materialName == materialInstance.name) != -1) {
+                            bindTTK1MaterialInstance(materialInstance, courseModelInstance.animationController, btk);
+                        }
+                    }
                 }
             }
     

--- a/src/j3d/mkdd_scenes.ts
+++ b/src/j3d/mkdd_scenes.ts
@@ -16,8 +16,6 @@ import { SceneContext } from '../SceneBase';
 import { computeModelMatrixS } from '../MathHelpers';
 import { CameraController } from '../Camera';
 
-import {  sampleAnimationData } from "../Common/JSYSTEM/J3D/J3DGraphAnimator";
-
 const id = "mkdd";
 const name = "Mario Kart: Double Dash!!";
 

--- a/src/j3d/mkdd_scenes.ts
+++ b/src/j3d/mkdd_scenes.ts
@@ -189,13 +189,13 @@ class MKDDSceneDesc implements Viewer.SceneDesc {
         this.id = this.path;
     }
 
-    private spawnBMD(device: GfxDevice, renderer: MKDDRenderer, rarc: RARC.JKRArchive, basename: string, modelMatrix: mat4 | null = null): J3DModelInstanceSimple {
-        const bmdFileData = assertExists(rarc.findFileData(`${basename}.bmd`));
+    private spawnBMD(device: GfxDevice, renderer: MKDDRenderer, rarc: RARC.JKRArchive, bmdName: string, modelMatrix: mat4 | null = null): J3DModelInstanceSimple {
+        const bmdFileData = assertExists(rarc.findFileData(bmdName));
         const bmdModel = new J3DModelData(device, renderer.renderHelper.renderInstManager.gfxRenderCache, BMD.parse(bmdFileData));
 
         const modelInstance = new J3DModelInstanceSimple(bmdModel);
 
-        modelInstance.name = basename;
+        modelInstance.name = bmdName;
         if (modelMatrix !== null)
             mat4.copy(modelInstance.modelMatrix, modelMatrix);
 
@@ -208,25 +208,27 @@ class MKDDSceneDesc implements Viewer.SceneDesc {
 
         return dataFetcher.fetchData(path).then((buffer) => {
             const rarc = RARC.parse(buffer);
-            const courseName = this.path.replace('.arc', '').toLowerCase();
-            
+
+            const courseName = this.path === "Luigi2.arc" ? "luigi" : this.path.replace('.arc', '').toLowerCase();            
             const renderer = new MKDDRenderer(device);
 
             const bolFileName = `${courseName}_course.bol`;
 
             const courseFileName = `${courseName}_course`;
+            const courseBMDFileName = `${courseFileName}.bmd`;
             const courseBTKFilNames = [ `${courseFileName}.btk`, `${courseFileName}_02.btk`, `${courseFileName}__03.btk` ];
             const courseBTPFileName = `${courseFileName}.btp`;
             const courseBRKFileName = `${courseName}.brk`;
             
             const skyFileName = `${courseName}_sky`;
+            const skyBMDFileName = `${skyFileName}.bmd`;
             const skyBTKFileName = `${skyFileName}.btk`;
             const skyBRKFileName = `${skyFileName}.brk`;
 
             const bolFile = assertExists(rarc.files.find((f) => f.name === bolFileName));
 
             // Find all course files
-            const courseModelInstance = this.spawnBMD(device, renderer, rarc, courseFileName);
+            const courseModelInstance = this.spawnBMD(device, renderer, rarc, courseBMDFileName);
             renderer.addModelInstance(courseModelInstance);
 
             for (const BTKFileName of courseBTKFilNames) {
@@ -250,8 +252,8 @@ class MKDDSceneDesc implements Viewer.SceneDesc {
             }
 
             // Find all skybox files
-            if (rarc.findFile(`${skyFileName}.bmd`)) {
-                const skyModelInstance = this.spawnBMD(device, renderer, rarc, skyFileName);
+            if (rarc.findFile(skyBMDFileName)) {
+                const skyModelInstance = this.spawnBMD(device, renderer, rarc, skyBMDFileName);
                 renderer.addModelInstance(skyModelInstance);
 
                 const btkFileData = rarc.findFileData(skyBTKFileName);
@@ -301,66 +303,292 @@ class MKDDSceneDesc implements Viewer.SceneDesc {
             };
 
             const bol = parseBOL(bolFile.buffer);
-            console.log(courseName, rarc, bol);
+            
             for (const obj of bol.objects) {
                 switch (obj.id) {
                 case 0x0001:
+                    break;
+                case 0x0003:
+                    spawnObject(obj, 'objects/njump.bmd');
+                    break;
+                case 0x0007:
+                    //spawnObject(obj, 'objects/hbmarutalope');
+                    break;
                 case 0x0009:
-                    // Item box.
+                    break;
+                case 0x000A:
+                    break;
+                case 0x000E:
+                    break;
+                case 0x0010:
+                    break;
+                case 0x0011:
+                    spawnObject(obj, 'objects/sun.bmd', ['objects/sun.btk']);
+                    break;
+                case 0x0013:
+                    break;
+                case 0x0014:
+                    break;
+                case 0x0CE5:
+                    spawnObject(obj, 'objects/babykanran.bmd');
+                    break;
+                case 0x0CE6:
+                    spawnObject(obj, 'objects/babyjet_body.bmd'); // more
                     break;
                 case 0x0CE8:
-                    spawnObject(obj, 'objects/yoshihelib');
+                    spawnObject(obj, 'objects/yoshihelib.bmd', ['objects/yoshihelib.btk']);
                     break;
                 case 0x0D49:
                     // Sea.
-                    spawnObject(obj, 'objects/sea1_spc');
-                    spawnObject(obj, 'objects/sea2_tex');
-                    spawnObject(obj, 'objects/sea3_dark');
-                    spawnObject(obj, 'objects/sea4_nami');
-                    spawnObject(obj, 'objects/sea5_sand');
+                    spawnObject(obj, 'objects/sea1_spc.bmd');
+                    spawnObject(obj, 'objects/sea2_tex.bmd');
+                    spawnObject(obj, 'objects/sea3_dark.bmd');
+                    spawnObject(obj, 'objects/sea4_nami.bmd');
+                    spawnObject(obj, 'objects/sea5_sand.bmd');
                     break;
                 case 0x0D4A:
-                    spawnObject(obj, 'objects/poihana1');
+                    spawnObject(obj, 'objects/poihana1.bmd', ['objects/poihana1_wait.bck']); // more
+                    break;
+                case 0x0D4B:
                     break;
                 case 0x0D4D:
-                    spawnObject(obj, 'objects/peachtree1');
+                    spawnObject(obj, 'objects/peachtree1.bmd', ['objects/peachtree1_wait.bck']);
                     break;
                 case 0x0D4E:
-                    spawnObject(obj, 'objects/peachfountain');
+                    spawnObject(obj, 'objects/peachfountain.bmd', ['objects/peachfountain.btk']);
                     break;
                 case 0x0D4F:
-                    spawnObject(obj, 'objects/marel_a');
+                    spawnObject(obj, 'objects/marel_a.bmd', ['objects/marel_a_clap1.bck']); // more
+                    break;
+                case 0x0D50:
+                    spawnObject(obj, 'objects/marel_b.bmd', ['objects/marel_a_clap1.bck']); // more
+                    break;
+                case 0x0D51:
+                    spawnObject(obj, 'objects/marel_c.bmd', ['objects/marel_a_clap1.bck']); // more
+                    break;
+                case 0x0D52:
+                    spawnObject(obj, 'objects/monl_a.bmd', ['objects/monl_a_clap1.bck']); // more
+                    break;
+                case 0x0D53:
+                    spawnObject(obj, 'objects/monl_b.bmd', ['objects/monl_a_clap1.bck']); // more
+                    break;
+                case 0x0D54:
+                    spawnObject(obj, 'objects/monl_c.bmd', ['objects/monl_a_clap1.bck']); // more
+                    break;
+                case 0x0D55:
+                    spawnObject(obj, 'objects/uklele_monte.bmd', ['objects/uklele_monte.bck']);
+                    break;
+                case 0x0D56:
+                    spawnObject(obj, 'objects/monf_a.bmd', ['objects/monf_a_dance.bck']); // more
+                    break;
+                case 0x0D57:
+                    spawnObject(obj, 'objects/monf_b.bmd', ['objects/monf_a_dance.bck']); // more
+                    break;
+                case 0x0D58:
+                    spawnObject(obj, 'objects/monl_d.bmd', ['objects/monl_a_clap1.bck']); // more
+                    break;
+                case 0x0D59:
+                    spawnObject(obj, 'objects/monl_e.bmd', ['objects/monl_a_clap1.bck']); // more
+                    break;
+                case 0x0D5A:
+                    spawnObject(obj, 'objects/marew_a.bmd', ['objects/marew_a_dance.bck']);
+                    break;
+                case 0x0D5B:
+                    spawnObject(obj, 'objects/marew_b.bmd', ['objects/marew_a_dance.bck']);
+                    break;
+                case 0x0D5C:
+                    spawnObject(obj, 'objects/marew_c.bmd', ['objects/marew_a_dance.bck']);
+                    break;
+                case 0x0D5D:
+                    spawnObject(obj, 'objects/marem_a.bmd', ['objects/marem_a.bck']);
+                    break;
+                case 0x0D66:
+                    break;
+                case 0x0D7A:
+                    break;
+                case 0x0D7B:
+                    spawnObject(obj, 'objects/demo_k_body.bmd');
+                    break;
+                case 0x0D7C:
+                    spawnObject(obj, 'objects/kinojii.bmd', ['objects/kinojii_drive.bca', 'objects/kinojii_wink.btp']);
+                    break;
+                case 0x0D7D:
+                    spawnObject(obj, 'objects/dpeachfountain.bmd', ['objects/dpeachfountain.btk']);
+                    break;
+                case 0x0D7E:
+                    break;
+                case 0x0D7F:
+                    spawnObject(obj, 'objects/peachtree2.bmd', ['objects/peachtree2_wait.bck']);
+                    break;
+                case 0x0DAE:
+                    break;                    
+                case 0x0DAF:
+                    spawnObject(obj, 'objects/pool.bmd', ['objects/pool.btk']);
+                    break;                    
+                case 0x0DB1:
+                    spawnObject(obj, 'objects/fan1.bmd');
+                    break;
+                case 0x0E0E:
+                    break;
+                case 0x0E0F:
+                    spawnObject(obj, 'objects/testwall1.bmd');
                     break;
                 case 0x0E75:
-                    spawnObject(obj, 'objects/mariotree1');
+                    spawnObject(obj, 'objects/mariotree1.bmd');
                     break;
                 case 0x0E77:
-                    spawnObject(obj, 'objects/marioflower1', ['objects/marioflower1.bck']);
+                    spawnObject(obj, 'objects/marioflower1.bmd', ['objects/marioflower1.bck']);
                     break;
                 case 0x0E78:
                     // Chain chomp. Looks awful, don't spawn.
-                    // spawnObject(obj, 'objects/wanwan1'); break;
+                    // spawnObject(obj, 'objects/wanwan1.bmd'); break;
                     break;
                 case 0x0E7E:
-                    spawnObject(obj, 'objects/skyship1');
+                    spawnObject(obj, 'objects/skyship1.bmd');
                     break;
                 case 0x0E7F:
-                    spawnObject(obj, 'objects/kuribo1');
+                    spawnObject(obj, 'objects/kuribo1.bmd'); // ['objects/kuribo1_l.bca', 'objects/kuribo1_r.bca']
                     break;
                 case 0x0E80:
-                    spawnObject(obj, 'objects/pakkun');
+                    spawnObject(obj, 'objects/pakkun.bmd', ['objects/pakkun_wait.bca']); // more
+                    break;
+                case 0x0E82:
+                    spawnObject(obj, 'objects/mash_balloon.bmd');
+                    break;
+                case 0x0ED9:
+                    spawnObject(obj, 'objects/yoshiheli.bmd', ['objects/yoshiheli.btk']); // uses two models, how?
+                    break;
+                case 0x0FA1:
+                    spawnObject(obj, 'objects/car_public1.bmd', ['objects/car_public1.btk']); // more
+                    break;
+                case 0x0FA2:
+                    spawnObject(obj, 'objects/car_bus1.bmd', ['objects/car_bus1.btk']); // more
+                    break;
+                case 0x0FA3:
+                    spawnObject(obj, 'objects/car_truck1.bmd', ['objects/car_truck1.btk']); // more
                     break;
                 case 0x0FA4:
-                    spawnObject(obj, 'objects/signal1', ['objects/signal1.brk']);
+                    spawnObject(obj, 'objects/signal1.bmd', ['objects/signal1.brk']);
+                    break;
+                case 0x0FA5:
+                    spawnObject(obj, 'objects/car_bomb1.bmd', ['objects/car_bomb1.btk']); // more
+                    break;
+                case 0x0FA6:
+                    spawnObject(obj, 'objects/car_kinoko1.bmd', ['objects/car_kinoko1.btk']); // more
+                    break;
+                case 0x0FA8:
+                    spawnObject(obj, 'objects/car_item1.bmd', ['objects/car_item1.btk']);
+                    break;
+                case 0x0FA9:
+                    spawnObject(obj, 'objects/car_hana1.bmd'); // more
+                    break;
+                case 0x1069:
+                    spawnObject(obj, 'objects/firebar1.bmd'); // more
+                    break;
+                case 0x106B:
+                    break;
+                case 0x106D:
+                    spawnObject(obj, 'objects/wl_screen1.bmd');
+                    break;
+                case 0x106E:
+                    spawnObject(obj, 'objects/wl_wall1.bmd', ['objects/wl_wall1.bca']);
+                    break;
+                case 0x106F:
+                    spawnObject(obj, 'objects/wlarrow1.bmd', ['objects/wlarrow1.bck', 'objects/wlarrow1.btk']);
+                    break;
+                case 0x1070:
+                    spawnObject(obj, 'objects/wl_dokan1.bmd');
+                    break;
+                case 0x1071:
+                    break;
+                case 0x1072:
+                    spawnObject(obj, 'objects/wa_search1.bmd', ['objects/wa_search1.bck']);
                     break;
                 case 0x1195:
-                    //spawnObject(obj, 'objects/cannon1');
+                    if (obj.settings[2] == 0)
+                    {
+                        spawnObject(obj, 'objects/cannon1.bmd');
+                    }
+                    break;
+                case 0x1196:
+                    break;
+                case 0x1098:
+                    spawnObject(obj, 'objects/donkytree1.bmd', ['objects/donkytree1_wait.bck']);
+                    break;
+                case 0x1099:
+                    spawnObject(obj, 'objects/donkywood.bmd');
                     break;
                 case 0x119A:
-                    // Butterflies.
+                    break;
+                case 0x119C:
+                    break;
+                case 0x119E:
+                    spawnObject(obj, 'objects/geyser1.bmd', ['objects/geyser1.btk', 'objects/geyser12.bca']); // more
+                    break;                    
+                case 0x11A1:
+                    spawnObject(obj, 'objects/nossie.bmd', ['objects/nossie.bca']); // more
+                    break;
+                case 0x11A4:
+                    spawnObject(obj, 'objects/dinotree1.bmd', ['objects/dinotree1_wait.bck']);
+                    break;                    
+                case 0x11A5:
+                    spawnObject(obj, 'objects/swimnossie.bmd', ['objects/swimnossie.bca']); // more
+                    break;
+                case 0x11A6:
+                    spawnObject(obj, 'objects/ptera.bmd', ['objects/pteraflya.bck']); // more
                     break;
                 case 0x125D:
-                    spawnObject(obj, 'objects/dossun1');
+                    spawnObject(obj, 'objects/dossun1.bmd'); // ['objects/dossun1.btp']
+                    break;
+                case 0x125E:
+                    spawnObject(obj, 'objects/bubble1.bmd', ['objects/bubble1.btk']);
+                    break;
+                case 0x125F:
+                    spawnObject(obj, 'objects/kpfire1.bmd', ['objects/kpfire1.bck']); // more
+                    break;
+                case 0x1261:
+                    spawnObject(obj, 'objects/kpgear1.bmd', ['objects/kpgear1.bck']);
+                    break;
+                case 0x1262:
+                    //spawnObject(obj, 'objects/kpfirebar1.bmd', ['objects/kpfirebar1.bck']); // more
+                    break;                    
+                case 0x1327:
+                    //spawnObject(obj, 'objects/geostar.bmd');
+                    break;
+                case 0x1389:
+                    spawnObject(obj, 'objects/sanbo1.bmd'); // more
+                    break;                    
+                case 0x138B:
+                    spawnObject(obj, 'objects/tornado.bmd', ['objects/tornado.bca', 'objects/tornado.btk']);
+                    break;
+                case 0x138C:
+                    spawnObject(obj, 'objects/deballoon1.bmd'); // more
+                    break;
+                case 0x138F:
+                    spawnObject(obj, 'objects/antlion.bmd', ['objects/antlion_eat.bck']);
+                    break;
+                case 0x1390:
+                    break;
+                case 0x1391:
+                    break;
+                case 0x1392:
+                    spawnObject(obj, 'objects/deserttree1.bmd');
+                    break;
+                case 0x13ED:
+                    spawnObject(obj, 'objects/snowrock1.bmd');
+                    break;
+                case 0x13EE:
+                    spawnObject(obj, 'objects/heyho1.bmd', ['objects/heyho1.bca']); // more
+                    break;
+                case 0x13F0:
+                    spawnObject(obj, 'objects/snowman1.bmd');
+                    break;
+                case 0x13F3:
+                    spawnObject(obj, 'objects/lights1.bmd');
+                    break;
+                case 0x13F4:
+                    break;
+                case 0x26B2:
                     break;
                 default:
                     console.warn(`Unknown object ID ${obj.id.toString(16)}`);
@@ -374,6 +602,7 @@ class MKDDSceneDesc implements Viewer.SceneDesc {
 }
 
 // Courses named and organized by Starschulz
+// Other added by Wexos
 const sceneDescs = [
     "Mushroom Cup",
     new MKDDSceneDesc(`Luigi Circuit`, 'Luigi.arc'),
@@ -402,6 +631,9 @@ const sceneDescs = [
     new MKDDSceneDesc(`Nintendo GameCube`, 'Mini2.arc'),
     new MKDDSceneDesc(`Pipe Plaza`, 'Mini8.arc'),
     new MKDDSceneDesc(`Tilt-a-Kart`, 'Mini5.arc'),
-];
+    "Extra",
+    new MKDDSceneDesc(`Award`, 'Award.arc'),
+    new MKDDSceneDesc(`Luigi Circuit (Time Trials)`, 'Luigi2.arc')
+]
 
 export const sceneGroup: Viewer.SceneGroup = { id, name, sceneDescs };


### PR DESCRIPTION
First time writing in TypeScript... I have changed some stuff for MKDD.
* Added support for BCA animations (probably bad implementation).
* Implemented BOL rotation correctly (very wrong before, even though it worked most of the times). I also added reading for object settings.
* Changed how files are loaded from the RARC course. It uses a more similar way of reading data which the original game does. It also reads all supported animations of both course BMD and skybox BMD.
* Changed how objects are loaded. They now must specify both the BMD name and what animations to load.
* Added a lot more objects. The object loading is simplified, only the BMD and in some cases, animation files, are loaded. Nothing else has been done (no moving etc). The file names are hardcoded in a giant switch statement. I have also added objects which doesn't use any models to the switch, but they currently do nothing. Also, objects which are stored in MRAM.arc are currently not loaded. Don't really like the giant switch, but until better object replication is done, this is all that's needed I guess.
* Added two extra courses, Award.arc and Luigi2.arc.

There is one problem, which also was a problem before. I have not found a way to bind multiple BTK animations to the same BMD. The course BMD can be animated by three different BTK files. As far as I understand, the current implementation does not support this. This means currently, only the last loaded course BTK file be animated.