### PR TITLE
Studio UI Fixes

### DIFF
--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -524,6 +524,8 @@ export class StudioCameraController extends FPSCameraController {
             if (inputManager.isKeyDownEventTriggered('Escape')) {
                 this.stopAnimation();
             }
+            // Set result to unchanged to prevent needless savestate creation during playback.
+            result = CameraUpdateResult.Unchanged;
         } else {
             if (!this.isOnKeyframe && inputManager.isKeyDownEventTriggered('Enter')) {
                 this.animationManager.addNextKeyframe(mat4.clone(this.camera.worldMatrix));

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1848,10 +1848,25 @@ class StudioPanel extends FloatingPanel {
         };
         this.elem.style.opacity = '0.8';
         this.setTitle(CLAPBOARD_ICON, 'Studio');
+        document.head.insertAdjacentHTML('beforeend', `
+        <style>
+            button.SettingsButton {
+                font: 16px monospace;
+                font-weight: bold;
+                border: none;
+                width: 100%;
+                color: inherit;
+                padding: 0.15rem;
+                text-align: center;
+                background-color: rgb(64, 64, 64);
+            }
+        </style>
+        `);
         this.contents.insertAdjacentHTML('beforeend', `
         <div style="display: grid; grid-template-columns: 3fr 1fr 1fr; align-items: center;">
             <div class="SettingsHeader">Studio Mode</div>
-            <div id="enableStudioBtn" class="SettingsButton EnableStudioMode">Enable</div><div id="disableStudioBtn" class="SettingsButton DisableStudioMode">Disable</div>
+            <button id="enableStudioBtn" class="SettingsButton EnableStudioMode">Enable</button>
+            <button id="disableStudioBtn" class="SettingsButton DisableStudioMode">Disable</button>
         </div>
         <div id="studioPanelContents" hidden></div>
         `);
@@ -1959,14 +1974,6 @@ class StudioPanel extends FloatingPanel {
             #playbackControls {
                 padding: 0 5rem 1rem;
                 border-top: 1px solid #444;
-            }
-            button.SettingsButton {
-                font: 16px monospace;
-                font-weight: bold;
-                border: none;
-                width: 100%;
-                color: inherit;
-                padding: 0.15rem;
             }
         </style>
         `);
@@ -2533,7 +2540,7 @@ class StudioPanel extends FloatingPanel {
         keyframeListItem.dataset.name = keyframeListItem.innerText;
         keyframeListItem.onclick = (e: MouseEvent) => this.selectKeyframeListItem(e);
         const clearButton = document.createElement('button');
-        clearButton.textContent = '🗙';
+        clearButton.textContent = '×';
         clearButton.type = 'button';
         clearButton.style.color = 'white';
         clearButton.style.position = 'absolute';
@@ -2546,7 +2553,7 @@ class StudioPanel extends FloatingPanel {
         clearButton.style.cursor = 'pointer';
         clearButton.style.backgroundColor = 'transparent';
         clearButton.style.border = '0';
-        clearButton.style.fontSize = '16px';
+        clearButton.style.fontSize = '24px';
         clearButton.style.padding = '0';
         clearButton.style.fontWeight = 'bold';
         clearButton.onclick = e => {


### PR DESCRIPTION
Just a couple quick fixes for some UI stuff in the Studio panel.

- Fixed some button styling. I was borrowing some styling from other UI buttons, a class that was lost somewhere in the mix. Now the buttons are styled on their own.
- Changed the delete keyframe button from an emoji to a Unicode multiplication sign. Should hopefully fix the missing glyph character that was appearing for some folks.
- Refactored `StudioCameraController` to stop creating savestates during animation playback.