### PR TITLE
JetSetRadio: Extractor Changes + Additional stages

### DIFF
--- a/src/JetSetRadio/Ninja.ts
+++ b/src/JetSetRadio/Ninja.ts
@@ -2,6 +2,7 @@
 import ArrayBufferSlice from "../ArrayBufferSlice";
 import { vec2, vec3, vec4 } from "gl-matrix";
 import { Color, colorNewFromRGBA, TransparentBlack, White } from "../Color";
+import { hexzero0x } from "../util";
 
 function colorNewFromARGB8(n: number): Color {
     const a = ((n >>> 24) & 0xFF) / 0xFF;
@@ -807,7 +808,10 @@ function parseNjsObject(buffer: ArrayBufferSlice, baseOffset: number, offset: nu
 	const scale:    vec3 = readVec3(view, offset + 0x20, true);
 
     const modelOffset = parseOffset(view.getUint32(offset + 0x04, true), baseOffset);
-    const model = parseNjsModel(buffer, baseOffset, modelOffset);
+   
+    let model 
+    if (modelOffset > 0) 
+        model = parseNjsModel(buffer, baseOffset, modelOffset);   
 
     return { flags, index, parent, child, sibling, position, rotation, scale, model };
 }

--- a/src/JetSetRadio/Scenes.ts
+++ b/src/JetSetRadio/Scenes.ts
@@ -253,6 +253,7 @@ class ModelCache {
             return this.modelData.get(id)!;
 
         const model = this.stageData.Models[id];
+        //console.warn(`${hexzero0x(id)}`)
         const binData = this.getAFSRef(model);
         const stageLoadAddr = 0x8CB00000;
         const objects = Ninja.parseNjsObjects(binData, stageLoadAddr, model.Offset);
@@ -308,6 +309,8 @@ export const id = 'JetSetRadio';
 export const name = "Jet Set Radio";
 export const sceneDescs = [
     new JetSetRadioSceneDesc('Stage1'),
+	new JetSetRadioSceneDesc('Stage2'),
+	new JetSetRadioSceneDesc('Stage3'),
 ];
 
 export const sceneGroup: SceneGroup = { id, name, sceneDescs, hidden: true };

--- a/src/JetSetRadio/tools/extractor.ts
+++ b/src/JetSetRadio/tools/extractor.ts
@@ -266,20 +266,20 @@ function extractTexLoadTable(texChunk: TexChunk, execBuffer: ArrayBufferSlice, t
         const texPackTableAddr = view.getUint32(tableOffs + 0x0C, true);
         let texListType = view.getUint32(tableOffs + 0x10, true);
         tableOffs += 0x20;
-        if (texPackTableAddr == 0x00000000 && afsFileID==0 && afsIndex==0 && texListType==0 && texLoadAddr==0)
+        if (texPackTableAddr === 0x00000000 && afsFileID===0 && afsIndex===0 && texListType===0 && texLoadAddr===0)
             break;
-        if (texPackTableAddr==0) 
+        if (texPackTableAddr===0) 
             continue;
         if (texLoadOverride > 0)
             texLoadAddr = texLoadOverride;
         // xayrga: will we ever load the segalogo?
-        if (afsFileID==0)
+        if (afsFileID===0)
             continue;
         const afsFilename = filenames[afsFileID];
         if (!afsFilename)
             continue;
         const txpFile = afsLoad(afsFilename, afsIndex);
-        if (texListType==0)
+        if (texListType===0)
             continue;
         if (textableFormatOverride > 0)
             texListType = textableFormatOverride;
@@ -579,14 +579,9 @@ function extractStage2(dstFilename: string, execBuffer: ArrayBufferSlice): void 
 function extractStage3(dstFilename: string, execBuffer: ArrayBufferSlice): void {
     const texChunk = new TexChunk();
 
-
-   //extractTexLoadTable(texChunk, execBuffer, 0x8c1b3f28, 0x8cDA0000, 1, 2);
-   // extractTexLoadTable(texChunk, execBuffer, 0x8c1b3f88, 0x8CDA0000, 1, 2);
     extractTexLoadTable(texChunk, execBuffer, 0x8c1c7350,0x8cf00000, 1, 4);
     extractTexLoadTable(texChunk, execBuffer, 0x8c185db0);
-    
     extractTexLoadTable(texChunk, execBuffer, 0x8c1c6430, 0x8Cf00000,1,5);
-    //
     extractTexLoadTable(texChunk, execBuffer, 0x8c1c7290, 0x8Cf00000,1);
     const SCENE_FILE = afsLoad('STAGE3.AFS', 0);
 

--- a/src/JetSetRadio/tools/extractor.ts
+++ b/src/JetSetRadio/tools/extractor.ts
@@ -39,6 +39,8 @@ interface ObjectData {
     ModelID: number;
     Translation: [number, number, number];
     Rotation: [number, number, number];
+    Scale: [number,number,number];
+    Flags: number;
 }
 
 interface StageSliceData {
@@ -128,6 +130,9 @@ function extractFilenameTable(execBuffer: ArrayBufferSlice, tableAddr: number = 
 
 function extractTexPackTable_01(dst: TexChunk, execBuffer: ArrayBufferSlice, txpFile: AFSReference, tableAddr: number, texLoadAddr: number): void {
     const view = execBuffer.createDataView();
+    
+    console.log(`01 EXEC ARC  ${txpFile.afsFilename} ${txpFile.afsIndex} ${hexzero0x(tableAddr)}`);
+
 
     const getTexlist = (addr: number) => {
         let existing = dst.texlists.find((v) => v.addr === addr);
@@ -150,15 +155,17 @@ function extractTexPackTable_01(dst: TexChunk, execBuffer: ArrayBufferSlice, txp
         const refTableAddr = view.getUint32(tableOffs + 0x00, true);
         const txpAddr = view.getUint32(tableOffs + 0x04, true);
 
+
         tableOffs += 0x08;
-        if (refTableAddr === 0x00000000 && txpAddr === 0xFFFFFFFF)
+        if (refTableAddr === 0x00000000 && (txpAddr === 0xFFFFFFFF || txpAddr === 0x00000000 ))
             break;
         if (txpAddr === 0x00000000)
             continue;
 
         const txpOffs = txpAddr - texLoadAddr;
-        assert(txpOffs >= 0);
 
+        assert(txpOffs >= 0);
+    
         const texDataIndex = dst.textures.push({ ... txpFile.getRefData(), Offset: txpOffs }) - 1;
 
         const refTable = parseTexlistRefTable(execBuffer, refTableAddr);
@@ -171,7 +178,7 @@ function extractTexPackTable_02(dst: TexChunk, execBuffer: ArrayBufferSlice, txp
     const view = execBuffer.createDataView();
 
     let tableOffs = tableAddr - EXECUTABLE_ALLOCATION_ADDRESS;
-    // console.log(`02 ${txpFile.afsFilename} ${txpFile.afsIndex} ${hexzero0x(tableAddr)} ${hexzero0x(tableOffs)}`);
+    
 
     const texlistAddr = view.getUint32(tableOffs + 0x00, true);
     const texlistOffs = texlistAddr - EXECUTABLE_ALLOCATION_ADDRESS;
@@ -184,7 +191,9 @@ function extractTexPackTable_02(dst: TexChunk, execBuffer: ArrayBufferSlice, txp
     const entries: number[] = [];
     dst.texlists.push({ addr: texlistAddr, entries });
 
+
     for (let i = 0; i < texlistCount; i++) {
+       
         const txpAddr = view.getUint32(texdataOffs + 0x00, true);
         texdataOffs += 0x04;
 
@@ -238,26 +247,42 @@ function extractTexPackTable_03(dst: TexChunk, execBuffer: ArrayBufferSlice, txp
     }
 }
 
-function extractTexLoadTable(texChunk: TexChunk, execBuffer: ArrayBufferSlice, tableAddr: number): void {
+function extractTexLoadTable(texChunk: TexChunk, execBuffer: ArrayBufferSlice, tableAddr: number , texLoadOverride: number = 0, textableFormatOverride : number = 0, maxDepth: number = 0): void {
     const filenames = extractFilenameTable(execBuffer);
 
     const view = execBuffer.createDataView();
-
+    let depth = 0;
     let tableOffs = tableAddr - EXECUTABLE_ALLOCATION_ADDRESS;
     while (true) {
-        const afsFileID = view.getUint32(tableOffs + 0x00, true);
-        const afsIndex = view.getUint32(tableOffs + 0x04, true);
-        const texLoadAddr = view.getUint32(tableOffs + 0x08, true);
-        const texPackTableAddr = view.getUint32(tableOffs + 0x0C, true);
-        const texListType = view.getUint32(tableOffs + 0x10, true);
-        tableOffs += 0x20;
-
-        if (texPackTableAddr == 0x00000000)
+        if (depth==maxDepth&&maxDepth!=0)
             break;
 
-        const afsFilename = filenames[afsFileID];
-        const txpFile = afsLoad(afsFilename, afsIndex);
+        depth++;
+    
+        const afsFileID = view.getUint32(tableOffs + 0x00, true);
+        const afsIndex = view.getUint32(tableOffs + 0x04, true);
+        let texLoadAddr = view.getUint32(tableOffs + 0x08, true);
 
+        const texPackTableAddr = view.getUint32(tableOffs + 0x0C, true);
+        let texListType = view.getUint32(tableOffs + 0x10, true);
+        tableOffs += 0x20;
+        if (texPackTableAddr == 0x00000000 && afsFileID==0 && afsIndex==0 && texListType==0 && texLoadAddr==0)
+            break;
+        if (texPackTableAddr==0) 
+            continue;
+        if (texLoadOverride > 0)
+            texLoadAddr = texLoadOverride;
+        // xayrga: will we ever load the segalogo?
+        if (afsFileID==0)
+            continue;
+        const afsFilename = filenames[afsFileID];
+        if (!afsFilename)
+            continue;
+        const txpFile = afsLoad(afsFilename, afsIndex);
+        if (texListType==0)
+            continue;
+        if (textableFormatOverride > 0)
+            texListType = textableFormatOverride;
         if (texListType === 0x01)
             extractTexPackTable_01(texChunk, execBuffer, txpFile, texPackTableAddr, texLoadAddr);
         else if (texListType === 0x02)
@@ -265,7 +290,7 @@ function extractTexLoadTable(texChunk: TexChunk, execBuffer: ArrayBufferSlice, t
         else if (texListType === 0x03 || texListType === 0x04 || texListType === 0x05)
             extractTexPackTable_03(texChunk, execBuffer, txpFile, texPackTableAddr, 0x8CDA0000);
         else
-            throw "whoops";
+            throw `Invalid texlist format ${texListType}`;
     }
 }
 
@@ -292,7 +317,7 @@ function extractModelTable(execBuffer: ArrayBufferSlice, texlists: Texlist[], af
 
 const rotToRadians = Math.PI / 0x8000;
 
-function extractObjectInstance(stageBuffer: ArrayBufferSlice, instanceAddr: number): ObjectData {
+function extractObjectInstance_01(stageBuffer: ArrayBufferSlice, instanceAddr: number): ObjectData {
     const stageView = stageBuffer.createDataView();
 
     const instanceOffs = instanceAddr - STAGE_ALLOCATION_ADDRESS;
@@ -308,6 +333,38 @@ function extractObjectInstance(stageBuffer: ArrayBufferSlice, instanceAddr: numb
         ModelID: modelID,
         Translation: [translationX, translationY, translationZ],
         Rotation: [rotationX, rotationY, rotationZ],
+        Scale: [1,1,1], //xayrga: is there actually scale in this struct? 
+        Flags: 0
+    };
+}
+
+
+
+function extractObjectInstance_02(stageBuffer: ArrayBufferSlice, instanceAddr: number, dataSize:number = 0x24): ObjectData {
+    const stageView = stageBuffer.createDataView();
+    //console.warn(`Instance ${hexzero0x(instanceAddr)}`)
+    const instanceOffs = instanceAddr - STAGE_ALLOCATION_ADDRESS;
+    const modelID = stageView.getUint32(instanceOffs + 0x00, true);
+
+    const translationX = stageView.getFloat32(instanceOffs + 0x04, true);
+    const translationY = stageView.getFloat32(instanceOffs + 0x08, true);
+    const translationZ = stageView.getFloat32(instanceOffs + 0x0C, true);
+    const rotationX = rotToRadians * stageView.getInt16(instanceOffs + 0x10, true);
+    const rotationY = rotToRadians * stageView.getInt16(instanceOffs + 0x14, true);
+    const rotationZ = rotToRadians * stageView.getInt16(instanceOffs + 0x18, true);
+    const scaleX = stageView.getFloat32(instanceOffs + 0x1C, true);
+    const scaleY = stageView.getFloat32(instanceOffs + 0x20, true);
+    const scaleZ = stageView.getFloat32(instanceOffs + 0x24, true);
+    let flags = 0;
+    if (dataSize >= 0x28)
+        flags = stageView.getFloat32(instanceOffs + 0x28, true);
+
+    return {
+        ModelID: modelID,
+        Translation: [translationX, translationY, translationZ],
+        Rotation: [rotationX, rotationY, rotationZ],
+        Scale: [scaleX,scaleY,scaleZ], //xayrga: is there actually scale in this struct? 
+        Flags: flags
     };
 }
 
@@ -326,7 +383,7 @@ function extractObjectTableGrouped(execBuffer: ArrayBufferSlice, afsFile: AFSRef
             const instanceAddr = stageView.getUint32(instanceListOffs + 0x00, true);
             if (((instanceAddr & 0xF0000000) >>> 0) !== 0x80000000)
                 break;
-            const object = extractObjectInstance(afsFile.buffer, instanceAddr);
+            const object = extractObjectInstance_01(afsFile.buffer, instanceAddr);
             if (object.ModelID === 0xFFFFFFFF)
                 continue;
             objects.push(object);
@@ -345,7 +402,7 @@ function extractObjectTableSingles(execBuffer: ArrayBufferSlice, afsFile: AFSRef
         if (instanceAddr === 0)
             continue;
         for (;; instanceAddr += 0x28) {
-            const object = extractObjectInstance(afsFile.buffer, instanceAddr);
+            const object = extractObjectInstance_01(afsFile.buffer, instanceAddr);
             if (object.ModelID === 0xFFFFFFFF) {
                 continue;
             } else if (object.ModelID === 0xFFFFFFFE) {
@@ -356,6 +413,31 @@ function extractObjectTableSingles(execBuffer: ArrayBufferSlice, afsFile: AFSRef
     }
     return objects;
 }
+
+
+function extractObjectTableSinglesSize(execBuffer: ArrayBufferSlice, afsFile: AFSReference, tableAddr: number, tableCount: number, significantDataSize: number): ObjectData[] {
+    const tableOffs = tableAddr - EXECUTABLE_ALLOCATION_ADDRESS;
+    const objGroupPtrs = execBuffer.createTypedArray(Uint32Array, tableOffs, tableCount);
+
+    const objects: ObjectData[] = [];
+    for (let i = 0; i < tableCount; i++) {
+        let instanceAddr = objGroupPtrs[i];
+        if (instanceAddr === 0)
+            continue;
+        for (;; instanceAddr += significantDataSize) {
+            const object = extractObjectInstance_02(afsFile.buffer, instanceAddr, significantDataSize);
+            if (object.ModelID === 0xFFFFFFFF) {
+                continue;
+            } else if (object.ModelID === 0xFFFFFFFE) {
+                break;
+            }
+            objects.push(object);
+        }
+    }
+    return objects;
+}
+
+
 
 function packStageData(texChunk: TexChunk, slices: StageSliceData[]): StageData {
     const TexlistData = packTexListData(texChunk);
@@ -408,7 +490,7 @@ function extractStage1(dstFilename: string, execBuffer: ArrayBufferSlice): void 
         const TEXTURE_TABLE_ADDRESS = 0x8c106ed4;
         const OBJECT_TABLE_ADDRESS = 0x8c105f94;
         const ASSET_COUNT = 49;
-        const OBJECT_COUNT = 50;
+        const OBJECT_COUNT = 63;
 
         const Models = extractModelTable(execBuffer, texChunk.texlists, SCENE_FILE, ASSET_TABLE_ADDRESS, TEXTURE_TABLE_ADDRESS, ASSET_COUNT);
         const Objects = extractObjectTableGrouped(execBuffer, SCENE_FILE, OBJECT_TABLE_ADDRESS, OBJECT_COUNT);
@@ -435,9 +517,131 @@ function extractStage1(dstFilename: string, execBuffer: ArrayBufferSlice): void 
     saveStageData(dstFilename, crg1);
 }
 
+function extractStage2(dstFilename: string, execBuffer: ArrayBufferSlice): void {
+    const texChunk = new TexChunk();
+
+
+    extractTexLoadTable(texChunk, execBuffer, 0x8c1b3f28, 0x8cDA0000, 1, 2);
+    extractTexLoadTable(texChunk, execBuffer, 0x8c1b3f88, 0x8CDA0000, 1, 2);
+    extractTexLoadTable(texChunk, execBuffer, 0x8c186c38);
+    extractTexLoadTable(texChunk, execBuffer, 0x8c186530);
+
+    const SCENE_FILE = afsLoad('STAGE2.AFS', 0);
+
+    function extractSlice1() {
+        const ASSET_TABLE_ADDRESS = 0x8c1086a0;
+        const TEXTURE_TABLE_ADDRESS = 0x8c108834;
+        const OBJECT_TABLE_ADDRESS = 0x8c107d2c;
+        const ASSET_COUNT = 101;
+        const OBJECT_COUNT = 114;
+        const OBJECTDATA_SIZE = 0x34;
+    
+        const Models = extractModelTable(execBuffer, texChunk.texlists, SCENE_FILE, ASSET_TABLE_ADDRESS, TEXTURE_TABLE_ADDRESS, ASSET_COUNT);
+        const Objects = extractObjectTableSinglesSize(execBuffer, SCENE_FILE, OBJECT_TABLE_ADDRESS, OBJECT_COUNT, OBJECTDATA_SIZE);
+        return { Models, Objects };
+    }
+
+    function extractSlice2() {
+        const ASSET_TABLE_ADDRESS = 0x8c108cf0;
+        const TEXTURE_TABLE_ADDRESS = 0x8c10920c;
+        const OBJECT_TABLE_ADDRESS = 0x8c107ef4;
+        const ASSET_COUNT = 327;
+        const OBJECT_COUNT = 114;
+        const OBJECTDATA_SIZE = 0x28;
+
+        const Models = extractModelTable(execBuffer, texChunk.texlists, SCENE_FILE, ASSET_TABLE_ADDRESS, TEXTURE_TABLE_ADDRESS, ASSET_COUNT);
+        const Objects = extractObjectTableSinglesSize(execBuffer, SCENE_FILE, OBJECT_TABLE_ADDRESS, OBJECT_COUNT, OBJECTDATA_SIZE);
+        return { Models, Objects };
+    }
+
+    function extractSlice3() {
+        const ASSET_TABLE_ADDRESS = 0x8c109728;
+        const TEXTURE_TABLE_ADDRESS = 0x8c10985c;
+        const OBJECT_TABLE_ADDRESS = 0x8c1080bc;
+        const ASSET_COUNT = 80;
+        const OBJECT_COUNT = 21;
+        const OBJECTDATA_SIZE = 0x34;
+    
+        const Models = extractModelTable(execBuffer, texChunk.texlists, SCENE_FILE, ASSET_TABLE_ADDRESS, TEXTURE_TABLE_ADDRESS, ASSET_COUNT);
+        const Objects = extractObjectTableSinglesSize(execBuffer, SCENE_FILE, OBJECT_TABLE_ADDRESS, OBJECT_COUNT, OBJECTDATA_SIZE);
+        return { Models, Objects };
+    }
+
+    const slice1 = extractSlice1();
+    const slice2 = extractSlice2();
+    const slice3 = extractSlice3();
+
+    const crg1 = packStageData(texChunk, [slice1 , slice2, slice3]);
+    saveStageData(dstFilename, crg1);
+}
+
+
+function extractStage3(dstFilename: string, execBuffer: ArrayBufferSlice): void {
+    const texChunk = new TexChunk();
+
+
+   //extractTexLoadTable(texChunk, execBuffer, 0x8c1b3f28, 0x8cDA0000, 1, 2);
+   // extractTexLoadTable(texChunk, execBuffer, 0x8c1b3f88, 0x8CDA0000, 1, 2);
+    extractTexLoadTable(texChunk, execBuffer, 0x8c1c7350,0x8cf00000, 1, 4);
+    extractTexLoadTable(texChunk, execBuffer, 0x8c185db0);
+    
+    extractTexLoadTable(texChunk, execBuffer, 0x8c1c6430, 0x8Cf00000,1,5);
+    //
+    extractTexLoadTable(texChunk, execBuffer, 0x8c1c7290, 0x8Cf00000,1);
+    const SCENE_FILE = afsLoad('STAGE3.AFS', 0);
+
+    function extractSlice1() {
+        const ASSET_TABLE_ADDRESS = 0x8c1bab40;
+        const TEXTURE_TABLE_ADDRESS = 0x8c1bad0c;
+        const OBJECT_TABLE_ADDRESS = 0x8c1ba6f0;
+        const ASSET_COUNT = 115;
+        const OBJECT_COUNT = 46;
+        const OBJECTDATA_SIZE = 0x28;
+    
+        const Models = extractModelTable(execBuffer, texChunk.texlists, SCENE_FILE, ASSET_TABLE_ADDRESS, TEXTURE_TABLE_ADDRESS, ASSET_COUNT);
+        const Objects = extractObjectTableSinglesSize(execBuffer, SCENE_FILE, OBJECT_TABLE_ADDRESS, OBJECT_COUNT, OBJECTDATA_SIZE);
+        return { Models, Objects };
+    }
+
+    function extractSlice2() {
+        const ASSET_TABLE_ADDRESS = 0x8c1bb270;
+        const TEXTURE_TABLE_ADDRESS = 0x8c1bb3d0;
+        const OBJECT_TABLE_ADDRESS = 0x8c1ba7a8;
+        const ASSET_COUNT = 88;
+        const OBJECT_COUNT = 46;
+        const OBJECTDATA_SIZE = 0x28;
+
+        const Models = extractModelTable(execBuffer, texChunk.texlists, SCENE_FILE, ASSET_TABLE_ADDRESS, TEXTURE_TABLE_ADDRESS, ASSET_COUNT);
+        const Objects = extractObjectTableSinglesSize(execBuffer, SCENE_FILE, OBJECT_TABLE_ADDRESS, OBJECT_COUNT, OBJECTDATA_SIZE);
+        return { Models, Objects };
+    }
+
+    function extractSlice3() {
+        const ASSET_TABLE_ADDRESS = 0x8c1bb530;
+        const TEXTURE_TABLE_ADDRESS = 0x8c1bb8ec;
+        const OBJECT_TABLE_ADDRESS = 0x8c1ba860;
+        const ASSET_COUNT = 239;
+        const OBJECT_COUNT = 5;
+        const OBJECTDATA_SIZE = 0x34;
+    
+        const Models = extractModelTable(execBuffer, texChunk.texlists, SCENE_FILE, ASSET_TABLE_ADDRESS, TEXTURE_TABLE_ADDRESS, ASSET_COUNT);
+        const Objects = extractObjectTableSinglesSize(execBuffer, SCENE_FILE, OBJECT_TABLE_ADDRESS, OBJECT_COUNT, OBJECTDATA_SIZE);
+        return { Models, Objects };
+    }
+
+    const slice1 = extractSlice1();
+    const slice2 = extractSlice2();
+    const slice3 = extractSlice3();
+
+    const crg1 = packStageData(texChunk, [slice1, slice2, slice3]);
+    saveStageData(dstFilename, crg1);
+}
+
 function main() {
     const exec = fetchDataSync(`${pathBaseIn}/1ST_READ.BIN`);
-    extractStage1(`${pathBaseOut}/Stage1.crg1`, exec);
+    //extractStage1(`${pathBaseOut}/Stage1.crg1`, exec);
+    //extractStage2(`${pathBaseOut}/Stage2.crg1`, exec);
+    extractStage3(`${pathBaseOut}/Stage3.crg1`, exec);
 }
 
 main();

--- a/src/JetSetRadio/tools/extractor.ts
+++ b/src/JetSetRadio/tools/extractor.ts
@@ -131,7 +131,7 @@ function extractFilenameTable(execBuffer: ArrayBufferSlice, tableAddr: number = 
 function extractTexPackTable_01(dst: TexChunk, execBuffer: ArrayBufferSlice, txpFile: AFSReference, tableAddr: number, texLoadAddr: number): void {
     const view = execBuffer.createDataView();
     
-    console.log(`01 EXEC ARC  ${txpFile.afsFilename} ${txpFile.afsIndex} ${hexzero0x(tableAddr)}`);
+    //console.log(`01 EXEC ARC  ${txpFile.afsFilename} ${txpFile.afsIndex} ${hexzero0x(tableAddr)}`);
 
 
     const getTexlist = (addr: number) => {
@@ -308,7 +308,7 @@ function extractModelTable(execBuffer: ArrayBufferSlice, texlists: Texlist[], af
         const modelOffs = modelAddr - STAGE_ALLOCATION_ADDRESS;
         const texlistAddr = texlistTable[i];
         const texlistIndex = findTexlistIndex(texlists, texlistAddr);
-        if (texlistIndex < 0)
+        if (texlistIndex < 0 && texlistAddr!=0)
             console.warn(`Model ${hexzero0x(modelTableAddr)} / ${hexzero0x(i, 2)} (NJ addr ${hexzero0x(modelAddr)}) could not find texlist with addr: ${hexzero0x(texlistAddr)}`);
         models.push({ ... afsFile.getRefData(), Offset: modelOffs, TexlistIndex: texlistIndex });
     }
@@ -333,7 +333,7 @@ function extractObjectInstance_01(stageBuffer: ArrayBufferSlice, instanceAddr: n
         ModelID: modelID,
         Translation: [translationX, translationY, translationZ],
         Rotation: [rotationX, rotationY, rotationZ],
-        Scale: [1,1,1], //xayrga: is there actually scale in this struct? 
+        Scale: [1,1,1], 
         Flags: 0
     };
 }
@@ -352,7 +352,7 @@ function extractObjectInstance_02(stageBuffer: ArrayBufferSlice, instanceAddr: n
     const rotationX = rotToRadians * stageView.getInt16(instanceOffs + 0x10, true);
     const rotationY = rotToRadians * stageView.getInt16(instanceOffs + 0x14, true);
     const rotationZ = rotToRadians * stageView.getInt16(instanceOffs + 0x18, true);
-    const scaleX = stageView.getFloat32(instanceOffs + 0x1C, true);
+    const scaleX = stageView.getFloat32(instanceOffs + 0x1C, true); // xayrga: todo, figure out why these are 0 on a lot of objects.
     const scaleY = stageView.getFloat32(instanceOffs + 0x20, true);
     const scaleZ = stageView.getFloat32(instanceOffs + 0x24, true);
     let flags = 0;
@@ -363,8 +363,8 @@ function extractObjectInstance_02(stageBuffer: ArrayBufferSlice, instanceAddr: n
         ModelID: modelID,
         Translation: [translationX, translationY, translationZ],
         Rotation: [rotationX, rotationY, rotationZ],
-        Scale: [scaleX,scaleY,scaleZ], //xayrga: is there actually scale in this struct? 
-        Flags: flags
+        Scale: [scaleX,scaleY,scaleZ], //xayrga: todo, confirm if this is actually scaling in the data
+        Flags: flags // xayrga: todo, confirm if this actually functions as a flag.
     };
 }
 
@@ -639,8 +639,8 @@ function extractStage3(dstFilename: string, execBuffer: ArrayBufferSlice): void 
 
 function main() {
     const exec = fetchDataSync(`${pathBaseIn}/1ST_READ.BIN`);
-    //extractStage1(`${pathBaseOut}/Stage1.crg1`, exec);
-    //extractStage2(`${pathBaseOut}/Stage2.crg1`, exec);
+    extractStage1(`${pathBaseOut}/Stage1.crg1`, exec);
+    extractStage2(`${pathBaseOut}/Stage2.crg1`, exec);
     extractStage3(`${pathBaseOut}/Stage3.crg1`, exec);
 }
 


### PR DESCRIPTION
Changes the binextractor's API a bit to be more 'comfortable' with the variable data structures between stages.

Also adds STAGE2.AFS and STAGE3.AFS

Stage 2+3 has some positioning problems, but they are recognizable. 

Fixes a bug where NJS_OBJECTS would assume that it has a model and try to load it from an invalid address
