### PR TITLE
Source Engine: Changes to support Infra maps

### DIFF
--- a/src/SourceEngine/BSPFile.ts
+++ b/src/SourceEngine/BSPFile.ts
@@ -836,7 +836,7 @@ export class BSPFile {
         assertExists(readString(buffer, 0x00, 0x04) === 'VBSP');
         const view = buffer.createDataView();
         this.version = view.getUint32(0x04, true);
-        assert(this.version === 19 || this.version === 20 || this.version === 21);
+        assert(this.version === 19 || this.version === 20 || this.version === 21  || this.version === 22);
 
         function getLumpDataEx(lumpType: LumpType): [ArrayBufferSlice, number] {
             const lumpsStart = 0x08;
@@ -1545,12 +1545,22 @@ export class BSPFile {
                 indexCount = getTriangleIndexCountForTopologyIndexCount(GfxTopology.TRIFAN, numedges);
                 const indexData = indexBuffer.addUint32(indexCount);
                 if (m_NumPrims !== 0) {
-                    const primOffs = firstPrimID * 0x0A;
-                    const primType = primitives.getUint8(primOffs + 0x00);
-                    const primFirstIndex = primitives.getUint16(primOffs + 0x02, true);
-                    const primIndexCount = primitives.getUint16(primOffs + 0x04, true);
-                    const primFirstVert = primitives.getUint16(primOffs + 0x06, true);
-                    const primVertCount = primitives.getUint16(primOffs + 0x08, true);
+                    let primType, primFirstIndex, primIndexCount, primFirstVert, primVertCount;
+                    if (this.version === 22) {
+                        const primOffs = firstPrimID * 0x10;
+                        primType = primitives.getUint8(primOffs + 0x00);
+                        primFirstIndex = primitives.getUint32(primOffs + 0x04, true);
+                        primIndexCount = primitives.getUint32(primOffs + 0x08, true);
+                        primFirstVert = primitives.getUint16(primOffs + 0x0C, true);
+                        primVertCount = primitives.getUint16(primOffs + 0x0E, true);
+                    } else {
+                        const primOffs = firstPrimID * 0x0A;
+                        primType = primitives.getUint8(primOffs + 0x00);
+                        primFirstIndex = primitives.getUint16(primOffs + 0x02, true);
+                        primIndexCount = primitives.getUint16(primOffs + 0x04, true);
+                        primFirstVert = primitives.getUint16(primOffs + 0x06, true);
+                        primVertCount = primitives.getUint16(primOffs + 0x08, true);
+                    }
                     if (primVertCount !== 0) {
                         // Dynamic mesh. Skip for now.
                         continue;

--- a/src/SourceEngine/EntitySystem.ts
+++ b/src/SourceEngine/EntitySystem.ts
@@ -215,7 +215,6 @@ export class BaseEntity {
 
     private playseqindex(index: number): void {
         if (index < 0) {
-            debugger;
             index = 0;
         }
 

--- a/src/SourceEngine/Scenes.ts
+++ b/src/SourceEngine/Scenes.ts
@@ -2,9 +2,9 @@
 import { SourceFileSystem, SourceRenderer, SkyboxRenderer, BSPRenderer, SourceRenderContext } from "./Main";
 import { SceneContext } from "../SceneBase";
 import { BSPFile } from "./BSPFile";
-import { assert } from "../util";
+import { assertExists } from "../util";
 
-export async function createScene(context: SceneContext, filesystem: SourceFileSystem, mapId: string, mapPath: string, renderContext: SourceRenderContext | null = null): Promise<SourceRenderer> {
+export async function createScene(context: SceneContext, filesystem: SourceFileSystem, mapId: string, mapPath: string, loadMapFromVpk: boolean = false, renderContext: SourceRenderContext | null = null): Promise<SourceRenderer> {
     // Clear out old filesystem pakfile.
     filesystem.pakfiles.length = 0;
 
@@ -13,7 +13,7 @@ export async function createScene(context: SceneContext, filesystem: SourceFileS
     const renderer = new SourceRenderer(context, renderContext);
 
     const bspFile = await context.dataShare.ensureObject(`SourceEngine/${mapPath}`, async () => {
-        const bsp = await context.dataFetcher.fetchData(mapPath);
+        const bsp = loadMapFromVpk ? assertExists(await filesystem.fetchFileData(mapPath)) : await context.dataFetcher.fetchData(mapPath);
         return new BSPFile(bsp, mapId);
     });
 

--- a/src/SourceEngine/Scenes_Infra.ts
+++ b/src/SourceEngine/Scenes_Infra.ts
@@ -1,0 +1,108 @@
+
+import { GfxDevice } from "../gfx/platform/GfxPlatform";
+import { SceneContext, SceneDesc, SceneGroup } from "../SceneBase";
+import { SourceFileSystem } from "./Main";
+import { createScene } from "./Scenes";
+
+class InfraSceneDesc implements SceneDesc {
+    constructor(public id: string, public name: string = id) {
+    }
+
+    public async createScene(device: GfxDevice, context: SceneContext) {
+        const filesystem = await context.dataShare.ensureObject(`${pathBase}/SourceFileSystem`, async () => {
+            const filesystem = new SourceFileSystem(context.dataFetcher);
+            await Promise.all([
+                filesystem.createVPKMount(`${pathBase}/pak01`),
+                filesystem.createVPKMount(`${pathBase}/pak02`),
+                filesystem.createVPKMount(`HalfLife2/hl2_textures`),
+                filesystem.createVPKMount(`HalfLife2/hl2_misc`),
+            ]);
+            return filesystem;
+        });
+
+        return createScene(context, filesystem, this.id, `maps/${this.id}.bsp`, true);
+    }
+}
+
+const pathBase = `Infra`;
+
+const id = 'Infra';
+const name = 'Infra';
+const sceneDescs = [
+    "Main Menu Background",
+    new InfraSceneDesc('main_menu'),
+
+    "Preparations",
+    new InfraSceneDesc('infra_c1_m1_office'),
+
+    "Just Another Day at Work",
+    new InfraSceneDesc('infra_c2_m1_reserve1'),
+    new InfraSceneDesc('infra_c2_m2_reserve2'),
+    new InfraSceneDesc('infra_c2_m3_reserve3'),
+
+    "Forgotten World",
+    new InfraSceneDesc('infra_c3_m1_tunnel'),
+    new InfraSceneDesc('infra_c3_m2_tunnel2'),
+    new InfraSceneDesc('infra_c3_m3_tunnel3'),
+    new InfraSceneDesc('infra_c3_m4_tunnel4'),
+
+    "Heavy Industry of the Past",
+    new InfraSceneDesc('infra_c4_m2_furnace'),
+    new InfraSceneDesc('infra_c4_m3_tower'),
+
+    "Fresh Water",
+    new InfraSceneDesc('infra_c5_m1_watertreatment'),
+    new InfraSceneDesc('infra_c5_m2_sewer'),
+    new InfraSceneDesc('infra_c5_m2b_sewer2'),
+
+    "Public Transport",
+    new InfraSceneDesc('infra_c6_m1_sewer3'),
+    new InfraSceneDesc('infra_c6_m2_metro'),
+    new InfraSceneDesc('infra_c6_m3_metroride'),
+    new InfraSceneDesc('infra_c6_m4_waterplant'),
+    new InfraSceneDesc('infra_c6_m5_minitrain'),
+    new InfraSceneDesc('infra_c6_m6_central'),
+
+    "Working Overtime",
+    new InfraSceneDesc('infra_c7_m1_servicetunnel'),
+    new InfraSceneDesc('infra_c7_m1b_skyscraper'),
+    new InfraSceneDesc('infra_c7_m2_bunker'),
+    new InfraSceneDesc('infra_c7_m3_stormdrain'),
+    new InfraSceneDesc('infra_c7_m4_cistern'),
+    new InfraSceneDesc('infra_c7_m5_powerstation'),
+
+    "Late for a Meeting",
+    new InfraSceneDesc('infra_c8_m1_powerstation2'),
+    new InfraSceneDesc('infra_c8_m3_isle1'),
+    new InfraSceneDesc('infra_c8_m4_isle2'),
+    new InfraSceneDesc('infra_c8_m5_isle3'),
+    new InfraSceneDesc('infra_c8_m6_business'),
+    new InfraSceneDesc('infra_c8_m7_business2'),
+    new InfraSceneDesc('infra_c8_m8_officeblackout'),
+
+    "To Save a City",
+    new InfraSceneDesc('infra_c9_m1_rails'),
+    new InfraSceneDesc('infra_c9_m2_tenements'),
+    new InfraSceneDesc('infra_c9_m3_river'),
+    new InfraSceneDesc('infra_c9_m4_villa'),
+    new InfraSceneDesc('infra_c9_m5_field'),
+
+    "Redemption",
+    new InfraSceneDesc('infra_c10_m1_npp'),
+    new InfraSceneDesc('infra_c10_m2_reactor'),
+    new InfraSceneDesc('infra_c10_m3_roof'),
+
+    "Epilogue",
+    new InfraSceneDesc('infra_c11_ending_1'),
+    new InfraSceneDesc('infra_c11_ending_2'),
+    new InfraSceneDesc('infra_c11_ending_3'),
+
+    "Easter Eggs",
+    new InfraSceneDesc('infra_ee_binary'),
+    new InfraSceneDesc('infra_ee_city_gates'),
+    new InfraSceneDesc('infra_ee_cubes'),
+    new InfraSceneDesc('infra_ee_hallway'),
+    new InfraSceneDesc('infra_ee_wasteland'),
+];
+
+export const sceneGroup: SceneGroup = { id, name, sceneDescs };

--- a/src/SourceEngine/Scenes_Portal.ts
+++ b/src/SourceEngine/Scenes_Portal.ts
@@ -37,7 +37,7 @@ class PortalSceneDesc implements SceneDesc {
 
         const renderContext = new SourceRenderContext(context.device, filesystem);
         this.registerEntityFactories(renderContext.entityFactoryRegistry);
-        return createScene(context, filesystem, this.id, `${pathBase}/maps/${this.id}.bsp`, renderContext);
+        return createScene(context, filesystem, this.id, `${pathBase}/maps/${this.id}.bsp`, false, renderContext);
     }
 }
 

--- a/src/SourceEngine/Scenes_Portal2.ts
+++ b/src/SourceEngine/Scenes_Portal2.ts
@@ -196,7 +196,7 @@ class Portal2SceneDesc implements SceneDesc {
 
     public async createScene(device: GfxDevice, context: SceneContext) {
         const renderContext = await createPortal2SourceRenderContext(context);
-        return createScene(context, renderContext.filesystem, this.id, `${pathBase}/portal2/maps/${this.id}.bsp`, renderContext);
+        return createScene(context, renderContext.filesystem, this.id, `${pathBase}/portal2/maps/${this.id}.bsp`, false, renderContext);
     }
 }
 
@@ -249,7 +249,7 @@ class Portal2WorkshopSceneDesc implements SceneDesc {
 
     public async createScene(device: GfxDevice, context: SceneContext) {
         const renderContext = await createPortal2SourceRenderContext(context);
-        return createScene(context, renderContext.filesystem, this.id, this.url, renderContext);
+        return createScene(context, renderContext.filesystem, this.id, this.url, false, renderContext);
     }
 }
 

--- a/src/SourceEngine/StaticDetailObject.ts
+++ b/src/SourceEngine/StaticDetailObject.ts
@@ -493,7 +493,7 @@ export function deserializeGameLump_sprp(buffer: ArrayBufferSlice, version: numb
         // TF2's 7-10 seem to use this below, which is 8 bytes.
         // The version 10 that CS:GO and Portal 2 use (bspfile version 21) is very different.
 
-        if (bspVersion === 21) {
+        if (bspVersion === 21 || bspVersion === 22) {
             // CS:GO, Portal 2
 
             if (version >= 7) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,6 +71,7 @@ import * as Scenes_TeamFortress2 from './SourceEngine/Scenes_TeamFortress2';
 import * as Scenes_Portal from './SourceEngine/Scenes_Portal';
 import * as Scenes_Portal2 from './SourceEngine/Scenes_Portal2';
 import * as Scenes_TheStanleyParable from './SourceEngine/Scenes_TheStanleyParable';
+import * as Scenes_Infra from './SourceEngine/Scenes_Infra';
 import * as Scenes_BeetleAdventureRacing from './BeetleAdventureRacing/Scenes';
 import * as Scenes_TheWitness from './TheWitness/Scenes_TheWitness';
 import * as Scenes_FFX from './FinalFantasyX/scenes';
@@ -192,6 +193,7 @@ const sceneGroups = [
     Scenes_HalfLife2Ep2.sceneGroup,
     Scenes_MarioKart8Deluxe.sceneGroup,
     Scenes_TheStanleyParable.sceneGroup,
+    Scenes_Infra.sceneGroup,
     Scenes_JetSetRadio.sceneGroup,
 ];
 


### PR DESCRIPTION
* Infra scene groups
* Branches in BSP loader for version 22
* HDR sky materials (only method A right now)
* All remaining `CalcDetail` combine modes present in 2013