### PR TITLE
Studio: Bank Rotation Improvement, Cleanup, and Bug Fixes

### DIFF
--- a/src/Studio.ts
+++ b/src/Studio.ts
@@ -1139,7 +1139,7 @@ interface studioSettings {
 
 export class StudioPanel extends FloatingPanel {
     static readonly FULL_TIMELINE_BG: string = 'repeating-linear-gradient(#494949, #494949 20px, #2f2f2f 20px, #2f2f2f 40px, #494949 40px, #494949 59px, #a5a5a5 59px, #a5a5a5 61px, #2f2f2f 61px, #2f2f2f 80px, #494949 80px, #494949 100px, #2f2f2f 100px, #2f2f2f 119px, #a5a5a5 119px, #a5a5a5 121px)';
-    static DEFAULT_TIMELINE_BG: string = 'repeating-linear-gradient(#494949, #494949 20px, #2f2f2f 20px, #2f2f2f 40px)';
+    static readonly DEFAULT_TIMELINE_BG: string = 'repeating-linear-gradient(#494949, #494949 20px, #2f2f2f 20px, #2f2f2f 40px)';
     static readonly PREVIEW_STEP_TIME_MS: number = 16;
 
     private animationManager: CameraAnimationManager;
@@ -1175,7 +1175,6 @@ export class StudioPanel extends FloatingPanel {
     private recordPlaybackBtn: HTMLButtonElement;
 
     private timeLineContainerElement: HTMLElement;
-    private timelineControlsContainer: HTMLElement;
     private snapBtn: HTMLButtonElement;
     private playheadTimePositionInput: HTMLInputElement;
     private timelineLengthInput: HTMLInputElement;
@@ -1210,7 +1209,6 @@ export class StudioPanel extends FloatingPanel {
     private easeInSlider: Slider;
     private easeOutSlider: Slider;
 
-    private customValuesContainer: HTMLElement;
     private posXValueInputContainer: HTMLElement;
     private posYValueInputContainer: HTMLElement;
     private posZValueInputContainer: HTMLElement;
@@ -1857,7 +1855,6 @@ export class StudioPanel extends FloatingPanel {
         this.recordPlaybackBtn.onclick = () => this.playAnimation(true);
 
         this.timeLineContainerElement = this.contents.querySelector('#timelineContainer') as HTMLElement;
-        this.timelineControlsContainer = this.contents.querySelector('#timelineControlsContainer') as HTMLElement;
 
         this.positionLookAtBankLabels = this.contents.querySelector('#positionLookAtBankLabels') as HTMLElement;
         this.fullLabels = this.contents.querySelector('#fullLabels') as HTMLElement;
@@ -1972,7 +1969,6 @@ export class StudioPanel extends FloatingPanel {
         this.selectKeyframeMsg = this.contents.querySelector('#selectKeyframeMsg') as HTMLElement;
         this.interpolationTab = this.contents.querySelector('#interpolationTab') as HTMLElement;
 
-        this.customValuesContainer = this.contents.querySelector('#customValuesContainer') as HTMLElement;
         this.posXValueInputContainer = this.contents.querySelector('#posXValueInputContainer') as HTMLElement;
         this.posYValueInputContainer = this.contents.querySelector('#posYValueInputContainer') as HTMLElement;
         this.posZValueInputContainer = this.contents.querySelector('#posZValueInputContainer') as HTMLElement;

--- a/src/Studio.ts
+++ b/src/Studio.ts
@@ -2335,10 +2335,10 @@ export class StudioPanel extends FloatingPanel {
 
                     countdownCtx.beginPath();
                     countdownCtx.save();
-                    countdownCtx.translate(x,y);
+                    countdownCtx.translate(x + 3, y + 3);
                     countdownCtx.rotate(-Math.PI / 2);
-                    countdownCtx.translate(-x,-y);
-                    countdownCtx.arc(x - 3, y + 4, 100, 0, ((countdownMs % 1000) / 1000) * (2*Math.PI));
+                    countdownCtx.translate(-(x + 3),-(y + 3));
+                    countdownCtx.arc(x + 3, y + 3, 100, 0, ((countdownMs % 1000) / 1000) * (2*Math.PI));
                     countdownCtx.stroke();
                     countdownCtx.restore();
                     countdownCtx.fillText(Math.ceil(seconds).toFixed(0), x + 3, y + 3);

--- a/src/Studio.ts
+++ b/src/Studio.ts
@@ -585,12 +585,13 @@ class Timeline {
         targetX = clamp(targetX, Playhead.HALF_WIDTH, this.width - Playhead.HALF_WIDTH);
         targetX -= Playhead.HALF_WIDTH;
 
-        const snappingEnabled = this.snappingEnabled || e.shiftKey;
+        const prevSnapping = this.snappingEnabled;
+        this.snappingEnabled = this.snappingEnabled || e.shiftKey;
 
         if (this.playheadGrabbed) {
             const snapKfIndex = this.getClosestSnappingIconIndex(targetX);
             if (snapKfIndex > -1) {
-                if (snappingEnabled)
+                if (this.snappingEnabled)
                     targetX = this.keyframeIcons[snapKfIndex].getX();
 
                 // If the playhead is directly on a keyframe, highlight it and any others at the same position.
@@ -615,12 +616,12 @@ class Timeline {
                     targetX = clamp(targetX, this.keyframeIcons[0].getX() + Timeline.SNAP_DISTANCE_PX, this.keyframeIcons[this.keyframeIcons.length - 1].getX() - Timeline.SNAP_DISTANCE_PX);
                 }
 
-                if (snappingEnabled && Math.abs(targetX - this.playhead.getX()) < Timeline.SNAP_DISTANCE_PX)
+                if (this.snappingEnabled && Math.abs(targetX - this.playhead.getX()) < Timeline.SNAP_DISTANCE_PX)
                     this.updateKeyframeIconPosition(this.selectedKeyframeIcons[0], this.playhead.getX());
                 else
                     this.updateKeyframeIconPosition(this.selectedKeyframeIcons[0], targetX);
             } else {
-                if (snappingEnabled && Math.abs(targetX - this.playhead.getX()) < Timeline.SNAP_DISTANCE_PX)
+                if (this.snappingEnabled && Math.abs(targetX - this.playhead.getX()) < Timeline.SNAP_DISTANCE_PX)
                     targetX = this.playhead.getX();
                 // Moving multiple icons. Check if moving all of them will cause
                 // any of them to be in an illegal position.
@@ -681,6 +682,7 @@ class Timeline {
                 
             }
         }
+        this.snappingEnabled = prevSnapping;
 
         this.draw();
     }

--- a/src/Studio.ts
+++ b/src/Studio.ts
@@ -964,7 +964,7 @@ class Timeline {
 
     public playheadIsOnIcon(): boolean {
         for (const kfIcon of this.keyframeIcons) {
-            if (this.playhead.getX() === kfIcon.getX())
+            if (this.playhead.getT() === kfIcon.getT())
                 return true;
         }
         return false;
@@ -3139,6 +3139,8 @@ export class StudioPanel extends FloatingPanel {
                 }
                 
                 kfIcon.keyframesMap.forEach((kf, track) => {
+                    if ((tracks & track) === 0)
+                        return;
                     tracks ^= track;
                     if (track === KeyframeTrackType.posXTrack)
                         kf.value = posXKf.value;


### PR DESCRIPTION
This PR introduces an enhancement and fixes a few more issues with Studio Mode:

- Bank rotation now uses absolute values, inferred by adding the smallest-magnitude value to the previous rotation to achieve the rotation of the keyframe at the time of its creation. Loops are handled by modulo-ing out any full rotations between the last keyframe and the loop keyframe. Thanks to @PFedak for cleaning up my spaghetti here.
- The bank rotation value display now shows an arc tracing the path between the previous bank rotation value and the current one. Doesn't work properly for value changes greater than 360 degrees in magnitude, but that would typically only happen if 
- Removed the logic forcing all Start/Loop End keyframes to be selected simultaneously, allowing different interpolation settings for separate tracks.
- Fixed a bug allowing keyframes to be created after the Loop End-frame position. If the playhead is placed after the Loop End keyframe position, we now shift them to a few seconds after the new keyframe(s).
- Fixed a bug where editing a keyframe while having another keyframe selected on a locked track would produce a duplicate keyframe icon on the locked track.
- Updated the Shift snapping hotkey to enable snapping when aligning keyframes across tracks.
- A bit of code cleanup. Removed a couple unused functions and consolidated functions that were only called once.