### PR TITLE
UI: Extended layer panel for grouping light/dark MP2 maps

### DIFF
--- a/src/metroid_prime/render.ts
+++ b/src/metroid_prime/render.ts
@@ -464,6 +464,7 @@ export class MREARenderer {
     public overrideSky: CMDLRenderer | null = null;
     public modelMatrix = mat4.create();
     public needSky: boolean = false;
+    public layerGroup: string = 'Light';
     public visible: boolean = true;
 
     constructor(private device: GfxDevice, private modelCache: ModelCache, private cache: GfxRenderCache, public textureHolder: RetroTextureHolder, public name: string, public mrea: MREA, private resourceSystem: ResourceSystem) {
@@ -591,6 +592,9 @@ export class MREARenderer {
                             this.overrideSky.isSkybox = true;
                         }
                     }
+
+                    if (areaAttributes.darkWorld)
+                        this.layerGroup = 'Dark';
                 }
             }
         }

--- a/src/metroid_prime/scenes.ts
+++ b/src/metroid_prime/scenes.ts
@@ -6,6 +6,7 @@ import { CMDLRenderer, ModelCache, MREARenderer, RetroPass, RetroTextureHolder }
 
 import * as Viewer from '../viewer';
 import * as UI from '../ui';
+import { GroupLayerPanel } from './ui';
 import { assert, assertExists } from '../util';
 import { GfxDevice } from '../gfx/platform/GfxPlatform';
 import { makeBackbufferDescSimple, opaqueBlackFullClearRenderPassDescriptor, pushAntialiasingPostProcessPass } from '../gfx/helpers/RenderGraphHelpers';
@@ -39,7 +40,7 @@ export class RetroSceneRenderer implements Viewer.SceneGfx {
     public showAllActors: boolean = false;
     public suitModel: number = 0;
     private suitModelButtons: UI.RadioButtons;
-    private layersPanel: UI.LayerPanel;
+    private groupLayerPanel: GroupLayerPanel;
 
     public onstatechanged!: () => void;
 
@@ -162,11 +163,11 @@ export class RetroSceneRenderer implements Viewer.SceneGfx {
     }
 
     public createPanels(): UI.Panel[] {
-        this.layersPanel = new UI.LayerPanel(this.areaRenderers);
-        this.layersPanel.onlayertoggled = () => {
+        this.groupLayerPanel = new GroupLayerPanel(this.areaRenderers);
+        this.groupLayerPanel.layerPanel.onlayertoggled = () => {
             this.onstatechanged();
         };
-        return [this.layersPanel, this.createRenderHacksPanel()];
+        return [this.groupLayerPanel, this.createRenderHacksPanel()];
     }
 
     public serializeSaveState(dst: ArrayBuffer, offs: number): number {
@@ -188,7 +189,7 @@ export class RetroSceneRenderer implements Viewer.SceneGfx {
             const b = new BitMap(this.areaRenderers.length);
             offs = bitMapDeserialize(view, offs, b);
             layerVisibilitySyncFromBitMap(this.areaRenderers, b);
-            this.layersPanel.syncLayerVisibility();
+            this.groupLayerPanel.layerPanel.syncLayerVisibility();
         }
         if (offs + 1 <= byteLength) {
             this.showAllActors = view.getUint8(offs) !== 0;

--- a/src/metroid_prime/script.ts
+++ b/src/metroid_prime/script.ts
@@ -159,6 +159,7 @@ export class Entity {
 export class AreaAttributes extends Entity {
     public needSky: boolean = false;
     public overrideSky: CMDL | null = null;
+    public darkWorld: boolean = false;
 
     public override readProperty_MP2(stream: InputStream, resourceSystem: ResourceSystem, propertyID: number) {
         switch (propertyID) {
@@ -168,6 +169,10 @@ export class AreaAttributes extends Entity {
 
         case 0xD208C9FA:
             this.overrideSky = resourceSystem.loadAssetByID<CMDL>(stream.readAssetID(), 'CMDL');
+            break;
+
+        case 0xB24FDE1A:
+            this.darkWorld = stream.readBool();
             break;
         }
     }

--- a/src/metroid_prime/ui.ts
+++ b/src/metroid_prime/ui.ts
@@ -1,0 +1,76 @@
+import { COOL_BLUE_COLOR, Layer, LAYER_ICON, LayerPanel, Panel, RadioButtons } from '../ui';
+
+export interface GroupLayer extends Layer {
+    layerGroup?: string;
+}
+
+export class GroupLayerPanel extends Panel {
+    public layerPanel: LayerPanel = new LayerPanel();
+    private groupRadios: RadioButtons;
+    private groupLayers: Layer[][] = [];
+
+    private _constructGroupRadios(optionNames: string[]) {
+        this.groupRadios = new RadioButtons('', optionNames);
+        this.groupRadios.elem.style.gridGap = '4px';
+        for (const option of this.groupRadios.options) {
+            option.style.lineHeight = '32px';
+        }
+    }
+
+    constructor(layers: GroupLayer[] | null = null) {
+        super();
+        this.customHeaderBackgroundColor = COOL_BLUE_COLOR;
+        this.setTitle(LAYER_ICON, 'Layers');
+        this._constructGroupRadios([]);
+        this.contents.appendChild(this.groupRadios.elem);
+        this.contents.appendChild(this.layerPanel.multiSelect.elem);
+        if (layers !== null)
+            this.setLayers(layers);
+    }
+
+    private _classifyLayerGroups(layers: GroupLayer[]): Map<string|null, Layer[]> {
+        const defaultGroup: Layer[] = [];
+        const groups = new Map<string|null, Layer[]>();
+        groups.set(null, defaultGroup);
+        for (const layer of layers) {
+            if (layer.layerGroup === undefined) {
+                defaultGroup.push(layer);
+            } else {
+                let group = groups.get(layer.layerGroup);
+                if (group === undefined) {
+                    group = [];
+                    groups.set(layer.layerGroup, group);
+                }
+                group.push(layer);
+            }
+        }
+        return groups;
+    }
+
+    public setLayers(layers: GroupLayer[]): void {
+        const groups = this._classifyLayerGroups(layers);
+        const optionNames: string[] = [];
+        this.groupLayers = [];
+        for (const [groupName, layers] of groups) {
+            if (layers.length) {
+                optionNames.push(groupName !== null ? groupName : 'Default');
+                this.groupLayers.push(layers);
+            }
+        }
+        const oldGroupRadios = this.groupRadios;
+        this._constructGroupRadios(optionNames);
+        this.contents.replaceChild(this.groupRadios.elem, oldGroupRadios.elem);
+        this.groupRadios.onselectedchange = () => {
+            const layers = this.groupLayers[this.groupRadios!.selectedIndex];
+            this.layerPanel.setLayers(layers);
+        };
+        this.groupRadios.setVisible(optionNames.length > 1);
+        if (optionNames.length > 0) {
+            this.groupRadios.setSelectedIndex(0);
+            this.layerPanel.setLayers(this.groupLayers[0]);
+            this.setVisible(true);
+        } else {
+            this.setVisible(false);
+        }
+    }
+}

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1517,15 +1517,16 @@ export class RadioButtons implements Widget {
 
         this.elem.style.display = 'grid';
 
-        const fr = `${optionNames.length}fr ${optionNames.map(() => '1fr').join(' ')}`;
+        const fr = (title.length ? `${optionNames.length}fr ` : ``) + `${optionNames.map(() => '1fr').join(' ')}`;
         this.elem.style.gridTemplateColumns = fr;
         this.elem.style.alignItems = 'center';
 
-        const header = document.createElement('div');
-        header.style.fontWeight = 'bold';
-        header.textContent = title;
-
-        this.elem.appendChild(header);
+        if (title.length) {
+            const header = document.createElement('div');
+            header.style.fontWeight = 'bold';
+            header.textContent = title;
+            this.elem.appendChild(header);
+        }
 
         optionNames.forEach((optionName, i) => {
             const option = document.createElement('div');
@@ -1541,6 +1542,10 @@ export class RadioButtons implements Widget {
             this.elem.appendChild(option);
             this.options.push(option);
         });
+    }
+
+    public setVisible(v: boolean) {
+        this.elem.style.display = v ? 'grid' : 'none';
     }
 
     private sync(): void {
@@ -2224,7 +2229,7 @@ export interface Layer {
 }
 
 export class LayerPanel extends Panel {
-    private multiSelect: MultiSelect;
+    public multiSelect: MultiSelect;
     private layers: Layer[] = [];
     public onlayertoggled: (() => void) | null = null;
 


### PR DESCRIPTION
Adds `UI.GroupLayerPanel` which functions like `UI.LayerPanel` by default, but in the presence of two or more unique `layerGroup` fields, displays layer group tabs.

It has been applied to MP2's light/dark maps like so:

![image](https://user-images.githubusercontent.com/505536/162630344-e443d9d8-8b37-4174-8c21-0c64632dad2c.png)
