### PR TITLE
Fix GoldSrc lightmap coordinates

### DIFF
--- a/src/GoldSrc/BSPFile.ts
+++ b/src/GoldSrc/BSPFile.ts
@@ -237,8 +237,8 @@ export class BSPFile {
                 vertexData[dstOffsVertex++] = 0;
                 vertexData[dstOffsVertex++] = 0;
 
-                minTexCoordS = Math.min(minTexCoordS, texCoordS);
-                minTexCoordT = Math.min(minTexCoordT, texCoordT);
+                minTexCoordS = Math.min(minTexCoordS, Math.round(texCoordS));
+                minTexCoordT = Math.min(minTexCoordT, Math.round(texCoordT));
                 maxTexCoordS = Math.max(maxTexCoordS, texCoordS);
                 maxTexCoordT = Math.max(maxTexCoordT, texCoordT);
             }
@@ -264,8 +264,8 @@ export class BSPFile {
                 const texCoordS = vertexData[offs++];
                 const texCoordT = vertexData[offs++];
 
-                const lightmapCoordS = lightmapData.pagePosX + (texCoordS - Math.floor(minTexCoordS)) / 16;
-                const lightmapCoordT = lightmapData.pagePosY + (texCoordT - Math.floor(minTexCoordT)) / 16;
+                const lightmapCoordS = lightmapData.pagePosX + (texCoordS - Math.floor(minTexCoordS) + 8) / 16;
+                const lightmapCoordT = lightmapData.pagePosY + (texCoordT - Math.floor(minTexCoordT) + 8) / 16;
                 vertexData[offs++] = lightmapCoordS;
                 vertexData[offs++] = lightmapCoordT;
             }


### PR DESCRIPTION
There is lightmap coordinate problem on goldsrc. As far as I investigate that the problem is caused from the minTexCoordS. This pull will fix majority problem but there is minor problem still exists, you can see compared images below. Mainly compared from (https://github.com/skyrim/hlviewer.js) , but it has same problem. There is a project is working perfectly, you can check out: (https://github.com/UnrealKaraulov/newbspguy)

![compare](https://user-images.githubusercontent.com/48884110/216452203-8b30afa5-c2ae-408b-a1ff-fe6cc7b5018d.png)
