### PR TITLE
Cancel dragging over ScrollSelects if mouse buttons are up.

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -358,6 +358,8 @@ export abstract class ScrollSelect implements Widget {
                     this.isDragging = false;
                 };
                 outer.onmouseover = (e) => {
+                    if (e.buttons === 0)
+                        this.isDragging = false;
                     if (this.isDragging)
                         outer.focus();
                 };


### PR DESCRIPTION
Various things can cause dragging to end without us registering a mouseup event, such as another window popping up, an exception or breakpoint, or leaving the window area. While this might be the right use case for ondragleave etc. I couldn't get that to work.

This just does the obvious thing and stops dragging if the mouse buttons are up, which handles the annoying cases like the Portal 2 workshop window without impacting normal dragging too much.