### PR TITLE
Fix studio camera path visualization

### DIFF
--- a/src/DebugJunk.ts
+++ b/src/DebugJunk.ts
@@ -140,7 +140,7 @@ export function getDebugOverlayCanvas2D(): CanvasRenderingContext2D {
         canvas.style.left = '0';
         canvas.style.pointerEvents = 'none';
 
-        document.body.appendChild(canvas);
+        window.main.toplevel.insertBefore(canvas, window.main.canvas);
         _debugOverlayCanvas = ctx;
 
         prepareFrameDebugOverlayCanvas2D();


### PR DESCRIPTION
Fixes https://github.com/magcius/noclip.website/issues/448#issuecomment-1621592596
The studio camera path visualization was drawing over UI elements due to it being appended after the main drawing canvas.