### PR TITLE
getAnimFrame could get stuck in an infinite loop

### DIFF
--- a/src/rres/brres.ts
+++ b/src/rres/brres.ts
@@ -1289,7 +1289,7 @@ function getAnimFrame(anim: AnimationBase, frame: number): number {
             frame = lastFrame;
         return frame;
     } else if (anim.loopMode === LoopMode.REPEAT) {
-        while (frame > lastFrame)
+        while (lastFrame > 0 && frame > lastFrame)
             frame -= lastFrame;
         return frame;
     } else {


### PR DESCRIPTION
For some reason, when dropping custom files (such as Mario Kart Wii custom tracks) on the website, the page could freeze. It appear that the value "lastFrame" in "getAnimFrame" would be equal to 0, and if the loop mode is on repeat, the website would end up on an infinite loop.

Tested with this custom track : 
https://drive.google.com/file/d/1kttPIdbj6LF-Qdz9tFAbVC3k2YR9Lesv/view?usp=sharing