### PR TITLE
BFBB: Fix sky rendering bug

### DIFF
--- a/src/SpongeBobBFBB/render.ts
+++ b/src/SpongeBobBFBB/render.ts
@@ -851,7 +851,7 @@ export class EntRenderer extends BaseRenderer {
         if (this.color.a === 0) return;
 
         super.prepareToRender(renderState);
-        if (this.isCulled || (!this.visible && !renderState.hacks.invisibleEntities)) return;
+        if (this.isCulled || (!this.visible && !renderState.hacks.invisibleEntities) || (this.isSkydome && !renderState.hacks.skydome)) return;
 
         if (this.isSkydome)
             renderState.instManager.setCurrentRenderInstList(renderState.renderInstListSky);

--- a/src/SpongeBobBFBB/render.ts
+++ b/src/SpongeBobBFBB/render.ts
@@ -477,8 +477,6 @@ export class BaseRenderer {
             this.isCulled = true;
             return;
         }
-
-        renderState.instManager.setCurrentRenderInstList(renderState.renderInstListMain);
     }
 
     public destroy(device: GfxDevice) {
@@ -863,6 +861,8 @@ export class EntRenderer extends BaseRenderer {
             modelRenderer.color = this.color;
             modelRenderer.prepareToRender(renderState);
         }
+
+        renderState.instManager.setCurrentRenderInstList(renderState.renderInstListMain);
     }
 
     public override destroy(device: GfxDevice) {
@@ -1061,6 +1061,8 @@ export class BFBBRenderer implements Viewer.SceneGfx {
         else
             offs += fillConstant(mapped, offs, 0, LIGHTKIT_SIZE);
 
+        renderState.instManager.setCurrentRenderInstList(renderState.renderInstListMain);
+        
         for (let i = 0; i < this.renderers.length; i++)
             this.renderers[i].prepareToRender(renderState);
 


### PR DESCRIPTION
This fixes a bug where all skydome entities were going into the main pass instead of the sky pass, causing them to draw over other objects in the scene. This was because EntRenderer would set the render inst list to the sky one but then it would get reset back to the main one when EntRenderer called prepareToRender on each of its models. The solution is to not reset the render inst list in BaseRenderer, but instead reset it once at the beginning of the scene and once after rendering each entity.