### PR TITLE
Battle for Bikini Bottom: RenderWare improvements

### DIFF
--- a/src/HeavyIron/HIEntPickup.ts
+++ b/src/HeavyIron/HIEntPickup.ts
@@ -83,7 +83,7 @@ export class HIEntPickupManager {
     }
     
     public render(scene: HIScene, rw: RwEngine) {
-        scene.lightKitManager.enable(null, rw.world, scene);
+        scene.lightKitManager.enable(null, scene);
 
         const src = this.pickupOrientation;
         for (const pkup of this.pickups) {

--- a/src/HeavyIron/HIModelBucket.ts
+++ b/src/HeavyIron/HIModelBucket.ts
@@ -114,7 +114,7 @@ export class HIModelBucketManager {
         for (const bucket of this.bucketList) {
             let minst = bucket.list;
             while (minst) {
-                scene.lightKitManager.enable(minst.lightKit, rw.world, scene);
+                scene.lightKitManager.enable(minst.lightKit, scene);
 
                 const oldHack = scene.modelManager.hackDisablePrelight;
                 if ((minst.pipeFlags & HIPipeFlags.LIGHTING_MASK) === HIPipeFlags.LIGHTING_KITPRELIGHT) {
@@ -172,7 +172,7 @@ export class HIModelBucketManager {
             const oldData = minst.data;
             minst.data = bucket.data!;
 
-            scene.lightKitManager.enable(minst.lightKit, rw.world, scene);
+            scene.lightKitManager.enable(minst.lightKit, scene);
 
             const oldHack = scene.modelManager.hackDisablePrelight;
             if ((minst.pipeFlags & HIPipeFlags.LIGHTING_MASK) === HIPipeFlags.LIGHTING_KITPRELIGHT) {

--- a/src/HeavyIron/HIModelBucket.ts
+++ b/src/HeavyIron/HIModelBucket.ts
@@ -219,9 +219,9 @@ export class HIModelBucketManager {
                 minst.renderSingle(scene, rw);
             } else if ((minst.pipeFlags & HIPipeFlags.ZBUFFER_MASK) === HIPipeFlags.ZBUFFER_ZFIRST) {
                 // RenderWare has no API to set the color mask, so the game sets it using platform-specific code
-                rw.renderState.megaStateFlags.attachmentsState![0].channelWriteMask = GfxChannelWriteMask.None;
+                rw.renderState.channelWriteMask = GfxChannelWriteMask.None;
                 minst.renderSingle(scene, rw);
-                rw.renderState.megaStateFlags.attachmentsState![0].channelWriteMask = GfxChannelWriteMask.AllChannels;
+                rw.renderState.channelWriteMask = GfxChannelWriteMask.AllChannels;
                 minst.renderSingle(scene, rw);
             } else {
                 minst.renderSingle(scene, rw);

--- a/src/HeavyIron/HIScene.ts
+++ b/src/HeavyIron/HIScene.ts
@@ -494,7 +494,7 @@ export class HIScene implements SceneGfx {
 
         this.camera.begin(this.rw);
 
-        this.lightKitManager.enable(null, this.rw.world, this);
+        this.lightKitManager.enable(null, this);
         
         this.renderStateManager.set(HIRenderState.SkyBack, this.camera, this.rw);
         this.skydomeManager.render(this, this.rw);
@@ -505,7 +505,7 @@ export class HIScene implements SceneGfx {
         this.renderStateManager.set(HIRenderState.OpaqueModels, this.camera, this.rw);
         this.modelBucketManager.begin();
         for (const ent of this.entList) {
-            this.lightKitManager.enable(ent.lightKit, this.rw.world, this);
+            this.lightKitManager.enable(ent.lightKit, this);
             ent.render(this, this.rw);
         }
 

--- a/src/HeavyIron/rw/rpworld.ts
+++ b/src/HeavyIron/rw/rpworld.ts
@@ -305,9 +305,15 @@ export const enum RpLightType {
     //SPOTSOFT
 }
 
+export const enum RpLightFlag {
+    LIGHTATOMICS = 0x1,
+    LIGHTWORLD = 0x2,
+}
+
 export class RpLight {
     public frame = new RwFrame();
     public color = White;
+    public flags = RpLightFlag.LIGHTATOMICS | RpLightFlag.LIGHTWORLD;
 
     constructor(public type: RpLightType) {
         this.frame.matrix = mat4.create();


### PR DESCRIPTION
This addresses/implements the suggestions from #629.

- Lone float uniforms are now grouped together in a vec4 to avoid float packing issues.
- Lighting state is now cached as part of the atomic pipeline shared across all RpAtomic instances. All lights are static in BFBB, so currently the cache is only rebuilt whenever any lights have been enabled/disabled or added/removed from the world (this does happen a handful of times per frame).
- Lighting is done in world-space instead of eye-space now. This eliminates having to transform the lights into eye-space, but it does add an extra matrix multiplication to the shader (model and view matrices have to be separate now). I'm not quite sure if this is faster.
- Texture filter modes now convert to the correct Gfx equivalents.
- It's possible to change the filter/address mode on textures at runtime, but afaik BFBB doesn't do this, so I've removed the code that supports this for now.
- RwRenderState only stores Rw variants of enums now and the conversion to Gfx is done in rendering pipelines. RwRenderState still maintains its own texture filter/address mode as well as a reference to a RwRaster, to be used by the immediate mode pipeline (plan to implement soon).
- I may consider generating shader variants instead of branching on uniforms soon, especially when it comes time to support changing the alpha test comparison operator (I don't imagine branching on an enum in the fragment shader would be very efficient).
- Bitflags are now packed into a single float in the uniform buffers.
- I'm now using a vec3 and getMatrixAxisZ() for the light direction caching.

I want to separate more Gfx stuff from RenderWare's public types, e.g. RwTexture/RwRaster should not contain a GfxTexture/GfxSampler/etc. I'm considering adding a "RwGfx" helper class to RwEngine that holds all the Gfx-specific data and helper functions that can be reused across multiple RenderWare pipelines.