### PR TITLE
NNS_G3D: Fix some node rotation matrices

### DIFF
--- a/src/nns_g3d/NNS_G3D.ts
+++ b/src/nns_g3d/NNS_G3D.ts
@@ -145,22 +145,22 @@ function parseNode(buffer: ArrayBufferSlice, name: string): MDL0Node {
                 jointMatrix[5] = A;
                 jointMatrix[6] = B;
 
-                jointMatrix[9] = 0;
-                jointMatrix[10] = C;
-                jointMatrix[11] = D;
+                jointMatrix[8] = 0;
+                jointMatrix[9] = C;
+                jointMatrix[10] = D;
             } else if (pivotIdx === 2) {
                 // Top right
                 jointMatrix[0] = 0;
-                jointMatrix[1] = A;
-                jointMatrix[2] = B;
+                jointMatrix[1] = 0;
+                jointMatrix[2] = pivotValue;
 
-                jointMatrix[4] = 0;
-                jointMatrix[5] = C;
-                jointMatrix[6] = D;
+                jointMatrix[4] = A;
+                jointMatrix[5] = B;
+                jointMatrix[6] = 0;
 
-                jointMatrix[9] = pivotValue;
+                jointMatrix[8] = C;
+                jointMatrix[9] = D;
                 jointMatrix[10] = 0;
-                jointMatrix[11] = 0;
             } else if (pivotIdx === 4) {
                 // Center center
                 jointMatrix[0] = A;


### PR DESCRIPTION
This commit changes how joint matrices are constructed for NSBMD nodes with pivotIdx values of 1 and 2. (Rotation data was being written outside of the 3x3 rotation matrix for both nodes, and the rotation encoded for a pivotIdx of 2 appeared incorrect.)

Not many scenes live on the site use these nodes, but a few look better after this: [a bowser statue flips upright](https://noclip.website/#mkds/old_koopa_agb;ShareData=AT-9*92S&Q8|f+B9R6n^=/vfZ6W!oFUfyRn9RXJT=u=CBURjbL9a-&{9i\)Z~=2), [a building's shadows in Pokemon Platinum](https://noclip.website/#pkmnpl/0;ShareData=AO2S~UmPkuT!d,89o=?1X21RyP^}AZUt{,[T12svW~F^WUg!9e8{v]NUp\(pkXL) no longer extend to the heavens, and [one room in Pokemon HGSS](https://noclip.website/#pkmnsslvr/301;ShareData=AX:-JUV_DRS,RfB7(*Vh=uuM=P,GM}UmSe)Ui8aqW+PSWTLFCw9huAlUbKGRWq) gains lights.