### PR TITLE
NNS_G3D: Fix inconsistent model colours

### DIFF
--- a/src/nns_g3d/render.ts
+++ b/src/nns_g3d/render.ts
@@ -48,7 +48,7 @@ class MaterialInstance {
     public visible = true;
 
     constructor(cache: GfxRenderCache, tex0: TEX0, private model: MDL0Model, public material: MDL0Material) {
-        this.baseCtx = { color: White, alpha: this.material.alpha };
+        this.baseCtx = { color: colorNewCopy(White), alpha: this.material.alpha };
 
         const device = cache.device;
         const texture = this.translateTexture(device, tex0, this.material.textureName, this.material.paletteName);


### PR DESCRIPTION
This change ensures that material instance colours are copied rather than assigned to the const variable White by reference. This previously resulted in models being drawn with inconsistent colours whenever this const value was reassigned in [cmd_COLOR](https://github.com/magcius/noclip.website/blob/fab1b8590a51a05b19b1fc99d51b593d692674c0/src/SuperMario64DS/nitro_gx.ts#L54) (with the most striking example being these erroneously blue cars in [MKDS's Shroom Ridge](https://noclip.website/#mkds/ridge_course).)