### PR TITLE
glover: fix weather sprite depth sorting

### DIFF
--- a/src/Glover/sprite.ts
+++ b/src/Glover/sprite.ts
@@ -831,14 +831,14 @@ export class GloverWeatherRenderer {
                 continue;
             }
             mat4.fromTranslation(this.drawMatrixScratch,
-                [singleDebris.pos[0], singleDebris.pos[1], 0]);
+                [singleDebris.pos[0], singleDebris.pos[1], -1]);
             mat4.scale(this.drawMatrixScratch, this.drawMatrixScratch,
                 [singleDebris.scale[0]/screenWidth, -singleDebris.scale[1]/screenWidth, 1]);
             this.spriteRenderer.prepareToRender(device, renderInstManager, viewerInput, this.drawMatrixScratch, singleDebris.curAlpha);
         }
 
         if (this.lightningColor.a > 0) {
-            mat4.fromTranslation(this.drawMatrixScratch, [0, 0, 0]);
+            mat4.fromTranslation(this.drawMatrixScratch, [0, 0, -1]);
             mat4.scale(this.drawMatrixScratch, this.drawMatrixScratch, [640, 480, 1]);
             this.lightningRenderer.primColor = this.lightningColor
             this.lightningRenderer.prepareToRender(device, renderInstManager, viewerInput, this.drawMatrixScratch);


### PR DESCRIPTION
at some point the sprites for glover weather rendering ended up behind the 3D scene instead of in front of it. i screwed with with the sort keys for a bit, but ultimately what fixed the regression was bringing the sprites to z coordinate -1. not entirely sure what changed or why this fixes it, but life's short and i've got Ripley to watch