### PR TITLE
wow: Fix WMOs with shared doodads

### DIFF
--- a/rust/src/wow/wmo.rs
+++ b/rust/src/wow/wmo.rs
@@ -192,25 +192,8 @@ impl Wmo {
         refs
     }
 
-    pub fn get_doodad_set(&self, mut doodad_set_id: u16) -> Vec<DoodadDef> {
-        let mut doodads = self.get_default_doodad_set();
-        if doodad_set_id as usize >= self.doodad_sets.len() {
-            doodad_set_id = 0;
-        }
-        if doodad_set_id != 0 {
-            let set = &self.doodad_sets[doodad_set_id as usize];
-            let start = set.start_index as usize;
-            let end = start + set.count as usize;
-            doodads.extend(self.doodad_defs[start..end].to_vec());
-        }
-        doodads
-    }
-
-    pub fn get_default_doodad_set(&self) -> Vec<DoodadDef> {
-        let default_set = &self.doodad_sets[0];
-        let start = default_set.start_index as usize;
-        let end = start + default_set.count as usize;
-        self.doodad_defs[start..end].to_vec()
+    pub fn get_doodad_defs(&self) -> Vec<DoodadDef> {
+        self.doodad_defs.clone()
     }
 }
 
@@ -310,7 +293,6 @@ impl WmoGroup {
             }
         }
 
-        assert!(num_uv_bufs > 0);
         let mut maybe_liquids: Option<Vec<WmoLiquid>> = None;
         if !liquids.is_empty() {
             maybe_liquids = Some(liquids);

--- a/src/DefaultSaveStates.json
+++ b/src/DefaultSaveStates.json
@@ -6456,5 +6456,8 @@
     "SaveState_WorldOfWarcraft/Untextured canyon, Emerald Dream-780817/1": "ShareData=AYx6BUY_qw8:;8*UHVWSWr4dl6d{TwUi5=)UL~]EVXauH9IiJB9Q2)iUhwA(Wq",
     "SaveState_WorldOfWarcraft/PvP Zone 02 (\"Azshara Crater\")-861092/1": "ShareData=AYhd~90}ww84?6c9R(}CW-iu05n}FQUdHQj8$+^CV?[!|UMnGN8}c179x~+FWq",
     "SaveState_WorldOfWarcraft/Shattrath-828395": "ShareData=AF_D*9QzgNUHuL:UvU/yW_h(?Qt9AvUZ|N:9KaJZVGBw99r6(t81K+J9Vt!JWq",
+    "SaveState_WorldOfWarcraftWOTLK/Icecrown Citadel, Icecrown-822688": "ShareData=ALNpLUMl[fUmuX3UYqnMW2ql}R4hV7UmmUm90u3nV_bgZ90W0UUS*hxUDU^zWq",
+    "SaveState_WorldOfWarcraftWOTLK/Dalaran, Crystalsong Forest-822688": "ShareData=ADJ:h9j,(-UK7!XUV_*yW3;vSRc:s=Ud}FF9Vc:JV@ha+96V4q9S9pX91s,6Wq",
+    "SaveState_WorldOfWarcraftWOTLK/Wyrmrest Temple, Dragonblight-822688": "ShareData=AawT/91&Zu8)UL$9xotfW9D7bR4TOAUbA669X9LVVeNR0Uq]M89SvGH9o}m6Wq",
     "SaveState_WorldOfWarcraft/Mauradon-788656/1": "ShareData=AAo@!9O=vs86WZLUk&7qWORD06X!HUUV*5BT,llX+XN:f9wZemTw9W)9Q!f?+^"
 }

--- a/src/WorldOfWarcraft/data.ts
+++ b/src/WorldOfWarcraft/data.ts
@@ -567,7 +567,7 @@ export class BspTree {
   }
 
   public query(pos: ReadonlyVec3, nodes: WowWmoBspNode[], i = 0) {
-    if (i < 0) {
+    if (i < 0 || this.nodes.length === 0) {
       return undefined;
     }
     assert(i < this.nodes.length);

--- a/src/WorldOfWarcraft/data.ts
+++ b/src/WorldOfWarcraft/data.ts
@@ -1505,29 +1505,27 @@ export class WmoDefinition {
       this.liquidVisibility.push(true);
     }
 
-    // keep track of which doodads belong in which group for culling purposes
-    const doodadRefs = wmo.wmo.get_doodad_set_refs(this.doodadSet);
+    // filter out doodads not present in the current doodadSet, and keep track
+    // of which doodads belong in which group
+    const doodadSetRefs = wmo.wmo.get_doodad_set_refs(this.doodadSet);
     for (let group of wmo.groups) {
       for (let ref of group.doodadRefs) {
-        const index = doodadRefs.indexOf(ref);
-        if (index !== -1) {
-          this.groupIdToDoodadIndices.append(group.fileId, index);
-          this.doodadIndexToGroupIds.append(index, group.fileId);
+        if (doodadSetRefs.includes(ref)) {
+          this.groupIdToDoodadIndices.append(group.fileId, ref);
+          this.doodadIndexToGroupIds.append(ref, group.fileId);
         }
       }
     }
 
-    const doodads = wmo.wmo.get_doodad_set(this.doodadSet);
+    const doodads = wmo.wmo.get_doodad_defs();
     if (doodads) {
-      for (let i=0; i<doodads.length; i++) {
-        const wmoDoodad = doodads[i];
+      for (const ref of doodadSetRefs) {
+        const wmoDoodad = doodads[ref];
         if (wmoDoodad.name_index === -1) {
           console.warn('skipping WMO doodad w/ name_index === -1');
           this.doodads.push(undefined);
           continue;
         }
-        const groupIds = this.doodadIndexToGroupIds.get(i)!;
-        const group = wmo.getGroup(groupIds[0])!;
         const doodad = DoodadData.fromWmoDoodad(wmoDoodad, wmo.modelIds, this.modelMatrix);
         const modelData = wmo.models.get(doodad.modelId)!;
         doodad.setBoundingBoxFromModel(modelData);
@@ -1535,14 +1533,29 @@ export class WmoDefinition {
         doodad.worldAABB.centerPoint(p);
         vec3.transformMat4(p, p, this.invModelMatrix);
 
-        let bspAmbientColor: vec4 | undefined = undefined;
-        for (const groupId of groupIds) {
-          const groupCandidate = wmo.getGroup(groupId)!;
-          bspAmbientColor = groupCandidate.getVertexColorForModelSpacePoint(p);
-          if (bspAmbientColor !== undefined) {
-            break;
+        // for some reason, the same doodad can exist in multiple groups. if
+        // that's the case, select the closest group (by AABB centerpoint) for
+        // lighting purposes
+        const groupIds = this.doodadIndexToGroupIds.get(ref)!;
+        let group: WmoGroupData;
+        if (groupIds.length > 1) {
+          let closestGroupId;
+          let closestDist = Infinity;
+          for (let i=0; i<groupIds.length; i++) {
+            const groupId = groupIds[i];
+            const groupAABB = this.wmo.groupDefAABBs.get(groupId)!;
+            const groupDist = groupAABB.distanceVec3(p);
+            if (groupDist < closestDist) {
+              closestDist = groupDist;
+              closestGroupId = groupId;
+            }
           }
+          group = wmo.getGroup(closestGroupId!)!;
+        } else {
+          group = wmo.getGroup(groupIds[0])!;
         }
+
+        let bspAmbientColor = group.getVertexColorForModelSpacePoint(p);
 
         if (group.flags.interior && !group.flags.exterior_lit) {
           const groupAmbientColor = this.groupAmbientColors.get(group.fileId)!;

--- a/src/WorldOfWarcraft/render.ts
+++ b/src/WorldOfWarcraft/render.ts
@@ -278,7 +278,7 @@ export class WmoRenderer {
           const batch = this.batches[i][j];
           if (!batch.visible) continue;
           const renderInst = renderInstManager.newRenderInst();
-          let offset = renderInst.allocateUniformBuffer(WmoProgram.ub_BatchParams, 4 * 4);
+          let offset = renderInst.allocateUniformBuffer(WmoProgram.ub_BatchParams, 5 * 4);
           const uniformBuf = renderInst.mapUniformBufferF32(WmoProgram.ub_BatchParams);
           offset += fillVec4(uniformBuf, offset,
             batch.vertexShader,
@@ -290,7 +290,13 @@ export class WmoRenderer {
             batch.material.blend_mode,
             applyInteriorLight ? 1 : 0,
             applyExteriorLight ? 1 : 0,
-            0
+            batch.materialFlags.unlit ? 1 : 0,
+          );
+          offset += fillVec4(uniformBuf, offset,
+            batch.materialFlags.unfogged ? 1 : 0,
+            batch.materialFlags.exterior_light ? 1 : 0,
+            batch.materialFlags.sidn ? 1 : 0,
+            batch.materialFlags.window ? 1 : 0,
           );
           offset += fillVec4v(uniformBuf, offset, ambientColor);
           offset += fillVec4v(uniformBuf, offset, [0, 0, 0, 0]);

--- a/src/WorldOfWarcraft/scenes.ts
+++ b/src/WorldOfWarcraft/scenes.ts
@@ -970,7 +970,9 @@ const wotlkSceneDescs = [
     new WdtSceneDesc("Arena: The Ring of Valor", 789925, 618),
 
     "Northrend",
-    new ContinentSceneDesc("???", 822688, 31, 28, 571),
+    new ContinentSceneDesc("Icecrown Citadel, Icecrown", 822688, 27, 20, 571), // ;ShareData=ALNpLUMl[fUmuX3UYqnMW2ql}R4hV7UmmUm90u3nV_bgZ90W0UUS*hxUDU^zWq
+    new ContinentSceneDesc("Dalaran, Crystalsong Forest", 822688, 30, 20, 571), // ;ShareData=ADJ:h9j,(-UK7!XUV_*yW3;vSRc:s=Ud}FF9Vc:JV@ha+96V4q9S9pX91s,6Wq
+    new ContinentSceneDesc("Wyrmrest Temple, Dragonblight", 822688, 31, 24, 571), // ;ShareData=AawT/91&Zu8)UL$9xotfW9D7bR4TOAUbA669X9LVVeNR0Uq]M89SvGH9o}m6Wq
 ];
 
 export const vanillaSceneGroup: Viewer.SceneGroup = {

--- a/src/WorldOfWarcraft/scenes.ts
+++ b/src/WorldOfWarcraft/scenes.ts
@@ -765,7 +765,7 @@ class WdtSceneDesc implements Viewer.SceneDesc {
 class ContinentSceneDesc implements Viewer.SceneDesc {
   public id: string;
 
-  constructor(public name: string, public fileId: number, public startX: number, public startY: number, public lightdbMapId: number) {
+  constructor(public name: string, public fileId: number, public startX: number, public startY: number, public lightdbMapId: number, public adtRadius = 2) {
     this.id = `${name}-${fileId}`;
   }
 
@@ -779,7 +779,7 @@ class ContinentSceneDesc implements Viewer.SceneDesc {
     });
     const renderHelper = new GfxRenderHelper(device);
     rust.init_panic_hook();
-    const wdt = new LazyWorldData(this.fileId, [this.startX, this.startY], 2, cache, this.lightdbMapId);
+    const wdt = new LazyWorldData(this.fileId, [this.startX, this.startY], this.adtRadius, cache, this.lightdbMapId);
     console.time('loading wdt')
     await wdt.load();
     console.timeEnd('loading wdt')
@@ -970,9 +970,9 @@ const wotlkSceneDescs = [
     new WdtSceneDesc("Arena: The Ring of Valor", 789925, 618),
 
     "Northrend",
-    new ContinentSceneDesc("Icecrown Citadel, Icecrown", 822688, 27, 20, 571), // ;ShareData=ALNpLUMl[fUmuX3UYqnMW2ql}R4hV7UmmUm90u3nV_bgZ90W0UUS*hxUDU^zWq
-    new ContinentSceneDesc("Dalaran, Crystalsong Forest", 822688, 30, 20, 571), // ;ShareData=ADJ:h9j,(-UK7!XUV_*yW3;vSRc:s=Ud}FF9Vc:JV@ha+96V4q9S9pX91s,6Wq
-    new ContinentSceneDesc("Wyrmrest Temple, Dragonblight", 822688, 31, 24, 571), // ;ShareData=AawT/91&Zu8)UL$9xotfW9D7bR4TOAUbA669X9LVVeNR0Uq]M89SvGH9o}m6Wq
+    new ContinentSceneDesc("Icecrown Citadel, Icecrown", 822688, 27, 20, 571),
+    new ContinentSceneDesc("Dalaran, Crystalsong Forest", 822688, 30, 20, 571),
+    new ContinentSceneDesc("Wyrmrest Temple, Dragonblight", 822688, 31, 24, 571),
 ];
 
 export const vanillaSceneGroup: Viewer.SceneGroup = {


### PR DESCRIPTION
The waterwheel in Warsong Gulch is currently all-black due to the weird case of WMO groups which share the same doodad. I couldn't find any docs on how this is handled, and didn't really see where WowWebViewer handles it, so simply choose the group that's closest to the doodad as its group for the purposes of lighting.