### PR TITLE
wow: use clipped frustums to cull exterior

### DIFF
--- a/rust/src/util.rs
+++ b/rust/src/util.rs
@@ -1,3 +1,4 @@
+use wasm_bindgen::prelude::*;
 
 // http://www.mindcontrol.org/~hplus/graphics/expand-bits.html
 pub fn expand_n_to_8(v: u8, n: u8) -> u8 {
@@ -87,4 +88,12 @@ pub fn get_uint24_be(src: &[u8], offs: usize) -> u32 {
 
 pub fn get_uint32_be(src: &[u8], offs: usize) -> u32 {
     ((src[offs] as u32) << 24) | ((src[offs+1] as u32) << 16) | ((src[offs+1] as u32) << 8) | (src[offs+1] as u32)
+}
+
+#[wasm_bindgen]
+extern "C" {
+    // Use `js_namespace` here to bind `console.log(..)` instead of just
+    // `log(..)`
+    #[wasm_bindgen(js_namespace = console)]
+    pub fn log(s: &str);
 }

--- a/src/SourceEngine/BSPFile.ts
+++ b/src/SourceEngine/BSPFile.ts
@@ -1302,7 +1302,7 @@ export class BSPFile {
                 continue;
 
             const lightofs = facelist.getInt32(idx + 0x14, true);
-            const m_LightmapTextureSizeInLuxels = nArray(2, (i) => facelist.getUint32(idx + 0x24 + i * 4, true));
+            const m_LightmapTextureSizeInLuxels = nArray(2, (i) => facelist!.getUint32(idx + 0x24 + i * 4, true));
 
             // Lighting styles
             const styles: number[] = [];
@@ -1568,8 +1568,8 @@ export class BSPFile {
             const surfaceFogVolumeID = facelist.getUint16(idx + 0x0E, true);
 
             const area = facelist.getFloat32(idx + 0x18, true);
-            const m_LightmapTextureMinsInLuxels = nArray(2, (i) => facelist.getInt32(idx + 0x1C + i * 4, true));
-            const m_LightmapTextureSizeInLuxels = nArray(2, (i) => facelist.getUint32(idx + 0x24 + i * 4, true));
+            const m_LightmapTextureMinsInLuxels = nArray(2, (i) => facelist!.getInt32(idx + 0x1C + i * 4, true));
+            const m_LightmapTextureSizeInLuxels = nArray(2, (i) => facelist!.getUint32(idx + 0x24 + i * 4, true));
             const origFace = facelist.getUint32(idx + 0x2C, true);
             const m_NumPrimsRaw = facelist.getUint16(idx + 0x30, true);
             const m_NumPrims = m_NumPrimsRaw & 0x7FFF;
@@ -1824,7 +1824,7 @@ export class BSPFile {
             vec2.set(overlayInfo.planePoints[1], vecUVPoint1X, vecUVPoint1Y);
             vec2.set(overlayInfo.planePoints[2], vecUVPoint2X, vecUVPoint2Y);
             vec2.set(overlayInfo.planePoints[3], vecUVPoint3X, vecUVPoint3Y);
- 
+
             const center = vec3.create();
             const tex = texinfos[nTexinfo];
 

--- a/src/WorldOfWarcraft/data.ts
+++ b/src/WorldOfWarcraft/data.ts
@@ -505,6 +505,7 @@ export class ParticleEmitter {
 }
 
 export class ModelData {
+    private scratchMat4 = mat4.create();
     public skins: SkinData[] = [];
     public blps: BlpData[] = [];
     public vertexBuffer: Uint8Array;
@@ -686,7 +687,7 @@ export class ModelData {
             mat4.fromRotationTranslationScaleOrigin(dst, rot, trans, scale, [0.5, 0.5, 0]);
         }
 
-        const localBoneTransform = mat4.create();
+        const localBoneTransform = this.scratchMat4;
         for (let i = 0; i < this.numBones; i++) {
             const bone = this.boneData[i];
             assert(bone.parentBoneId < i, "bone parent > bone");
@@ -929,6 +930,9 @@ export class WmoData {
 
         for (const fileId of this.wmo.group_file_ids) {
             this.groupDescriptors.push(this.wmo.get_group_descriptor(fileId));
+            if (this.groupDescriptors[this.groupDescriptors.length - 1].antiportal) {
+                console.log('antiportal detected!!!', fileId);
+            }
         }
 
         this.vertex_buffer = this.wmo.take_vertex_data();
@@ -1687,9 +1691,6 @@ export class AdtData {
             i += 1;
         }
         renderResult.free();
-
-        let adtCenter = vec3.create();
-        this.worldSpaceAABB.centerPoint(adtCenter);
 
         this.inner!.free();
         this.inner = null;

--- a/src/WorldOfWarcraft/debug.ts
+++ b/src/WorldOfWarcraft/debug.ts
@@ -1,0 +1,41 @@
+import { mat4, vec3 } from "gl-matrix";
+import { drawWorldSpaceLine, drawWorldSpaceText, getDebugOverlayCanvas2D } from "../DebugJunk.js";
+import { WmoData, WmoDefinition } from "./data.js";
+import { WdtScene } from "./scenes.js";
+import { Color } from "../Color.js";
+
+function getClipFromWorldMatrix(): mat4 {
+    return (window.main.scene as WdtScene).mainView.clipFromWorldMatrix;
+}
+
+export function drawDebugPortals(wmo: WmoData, def: WmoDefinition, groupId: number, color?: Color, offsY?: number) {
+    const portalVerts = wmo.wmo.dbg_get_portal_verts(groupId);
+    let i = 0;
+    while (i < portalVerts.length) {
+        const len = portalVerts[i++];
+        const verts = portalVerts.slice(i, i + len * 3);
+        i += len * 3;
+        for (let j = 0; j < len; j++) {
+            const v0: vec3 = verts.slice(j * 3, (j + 1) * 3);
+            const bStart = (j + 1) % len;
+            const v1: vec3 = verts.slice(bStart * 3, (bStart + 1) * 3);
+            vec3.transformMat4(v0, v0, def.modelMatrix);
+            vec3.transformMat4(v1, v1, def.modelMatrix);
+            drawWorldSpaceText(
+                getDebugOverlayCanvas2D(),
+                getClipFromWorldMatrix(),
+                v0,
+                `${j} (${groupId})`,
+                offsY,
+                color,
+            );
+            drawWorldSpaceLine(
+                getDebugOverlayCanvas2D(),
+                getClipFromWorldMatrix(),
+                v0,
+                v1,
+                color,
+            );
+        }
+    }
+}


### PR DESCRIPTION
When we clip a frustum through a WMO group's portal, use that clipped
frustum to cull things outside. Also, perform the group membership check
in rust, which is both more convenient and faster.

Fixes a couple bugs also