### PR TITLE
Use node's `createRequire()` to get the `require` function for `loadRustLib()`

### DIFF
--- a/src/rustlib.ts
+++ b/src/rustlib.ts
@@ -1,9 +1,12 @@
 
 import init, * as rust from '../rust/pkg/noclip_support';
+import { createRequire } from 'node:module';
 
 export { rust };
 
 declare const process: unknown;
+
+const require = createRequire(import.meta.url);
 
 export async function loadRustLib() {
     if (typeof process !== 'undefined') {
@@ -12,10 +15,9 @@ export async function loadRustLib() {
         // want this code to run in tools mode on node.js.
         // https://github.com/nodejs/undici/issues/2751
 
-        const requireX: any = (globalThis as any)['require']; 
-        const fs = requireX('fs');
-        const path = requireX('path');
-        const url = requireX('url');
+        const fs = require('fs');
+        const path = require('path');
+        const url = require('url');
         const wasmPath = path.join(path.dirname(url.fileURLToPath(import.meta.url)), '../rust/pkg/noclip_support_bg.wasm');
         const wasm = fs.readFileSync(wasmPath);
         rust.initSync(wasm);


### PR DESCRIPTION
`require` does not exist in the global namespace, at least on my machine. According to the node.js docs, it shouldn't. This uses a builtin node function to generate the `require` function for use within ES modules.

Without this change, I can't run tools such as zww_extractor.ts

See https://nodejs.org/api/esm.html#no-require-exports-or-moduleexports