### PR TITLE
J2D: Implement JSystem 2D rendering library, use it display Wind Waker place names 

### DIFF
--- a/src/Common/JSYSTEM/J2D.ts
+++ b/src/Common/JSYSTEM/J2D.ts
@@ -221,7 +221,8 @@ export class J2DGrafContext {
     sceneParams = new SceneParams();
 
     constructor(device: GfxDevice) {
-        projectionMatrixForCuboid(this.sceneParams.u_Projection, 0, 1, 0, 1, -1, 0);
+        // @NOTE: The y axis is inverted by this ortho matrix. Gamecube origin is top-left, ours is bottom left.  
+        projectionMatrixForCuboid(this.sceneParams.u_Projection, 0, 1, 1, 0, -1, 0);
         const clipSpaceNearZ = device.queryVendorInfo().clipSpaceNearZ;
         projectionMatrixConvertClipSpaceNearZ(this.sceneParams.u_Projection, clipSpaceNearZ, GfxClipSpaceNearZ.NegativeOne);
     }
@@ -267,7 +268,7 @@ export class J2DPane {
         if (this.data.visible && boundsValid) {
             // Src data is in GameCube pixels (640x480), convert to normalized screen coordinates [0-1]. 
             vec2.set(this.drawPos, this.data.x / 640, this.data.y / 480);
-            vec2.set(this.drawDimensions, this.data.w / 480 /* TODO: Multiply by aspect */, this.data.h / 480);
+            vec2.set(this.drawDimensions, this.data.w / 480, this.data.h / 480);
             this.drawAlpha = this.data.alpha / 0xFF;
 
             if (this.parent) {
@@ -405,15 +406,16 @@ export class J2DPicture extends J2DPane {
         this.sdraw.setVtxDesc(GX.Attr.TEX0, true);
         this.sdraw.setVtxDesc(GX.Attr.CLR0, true);
 
+        // @NOTE: Y positions are inverted, to account for the projection matrix Y-flip. Gamecube origin is top-left, ours is bottom left.  
         this.sdraw.beginDraw(this.cache);
         this.sdraw.begin(GX.Command.DRAW_QUADS, 4);
         this.sdraw.position3f32(0, 0, 0);
         this.sdraw.color4color(GX.Attr.CLR0, colorNewFromRGBA8(this.data.colorCorners[0]));
         this.sdraw.texCoord2f32(GX.Attr.TEX0, u0, v1);
-        this.sdraw.position3f32(0, 1, 0);
+        this.sdraw.position3f32(0, -1, 0);
         this.sdraw.color4color(GX.Attr.CLR0, colorNewFromRGBA8(this.data.colorCorners[1]));
         this.sdraw.texCoord2f32(GX.Attr.TEX0, u0, v0);
-        this.sdraw.position3f32(1, 1, 0);
+        this.sdraw.position3f32(1, -1, 0);
         this.sdraw.color4color(GX.Attr.CLR0, colorNewFromRGBA8(this.data.colorCorners[3]));
         this.sdraw.texCoord2f32(GX.Attr.TEX0, u1, v0);
         this.sdraw.position3f32(1, 0, 0);

--- a/src/Common/JSYSTEM/J2D.ts
+++ b/src/Common/JSYSTEM/J2D.ts
@@ -227,7 +227,7 @@ export class BLO {
     }
 }
 
-//#endregion J2Screen
+//#endregion Loading/J2Screen
 
 //#region J2DPane
 export class J2DPane {
@@ -445,4 +445,16 @@ export class J2DPicture extends J2DPane {
         this.materialHelper = new GXMaterialHelperGfx(mb.finish());
     }
 }
+//#endregion
+
+//#region J2DScreen
+export class J2DScreen extends J2DPane {
+    public color: Color
+
+    constructor(data: SCRN, cache: GfxRenderCache) {
+        super(data.panes[0], cache, null);
+        this.color = data.inf1.color;
+    }
+}
+
 //#endregion

--- a/src/Common/JSYSTEM/J2D.ts
+++ b/src/Common/JSYSTEM/J2D.ts
@@ -251,11 +251,10 @@ export class J2DPane {
 
             if(this.parent) {
                 // TODO: Handle parents offsets and alpha
-                this.makeMatrix();
             } else {
                 this.drawPos[0] += offsetX;
                 this.drawPos[1] += offsetY;
-                this.makeMatrix();
+                // this.makeMatrix();
                 this.drawAlpha = this.data.alpha;
             }
 

--- a/src/Common/JSYSTEM/J2D.ts
+++ b/src/Common/JSYSTEM/J2D.ts
@@ -333,7 +333,7 @@ export class J2DPicture extends J2DPane {
         if (this.data.timg.type !== 0 && this.data.timg.type !== 2) { console.warn('Untested J2D feature'); }
 
         if (this.data.tlut.type !== 0) { console.warn('Untested J2D feature'); }
-        if (this.data.uvBinding !== 15) { console.warn('Untested J2D feature'); } 
+        if (this.data.uvBinding !== 15) { console.warn('Untested J2D feature'); }
         if (this.data.flags !== 0) { console.warn('Untested J2D feature'); }
         if (this.data.colorBlack !== 0 || this.data.colorWhite !== 0xFFFFFFFF) { console.warn('Untested J2D feature'); }
         if (this.data.colorCorners[0] !== 0xFFFFFFFF || this.data.colorCorners[1] !== 0xFFFFFFFF
@@ -346,7 +346,7 @@ export class J2DPicture extends J2DPane {
     }
 
     public override drawSelf(renderInstManager: GfxRenderInstManager, viewerRenderInput: ViewerRenderInput, ctx2D: J2DGrafContext, offsetX: number, offsetY: number): void {
-        if(!this.tex) { return; }
+        if (!this.tex) { return; }
 
         renderInstManager.pushTemplate();
         const renderInst = renderInstManager.newRenderInst();

--- a/src/Common/JSYSTEM/J2D.ts
+++ b/src/Common/JSYSTEM/J2D.ts
@@ -54,7 +54,7 @@ enum J2DUVBinding {
 
 // TODO: Move and reorganize
 export class J2DGrafContext {
-    sceneParams = new SceneParams();
+    private sceneParams = new SceneParams();
 
     constructor(device: GfxDevice) {
         // @NOTE: The y axis is inverted by this ortho matrix. Gamecube origin is top-left, ours is bottom left.  

--- a/src/Common/JSYSTEM/J2D.ts
+++ b/src/Common/JSYSTEM/J2D.ts
@@ -255,7 +255,7 @@ export class J2DPane {
         if (this.data.rot !== 0) { console.warn('Untested J2D feature'); }
     }
 
-    // NOTE: Overwritten by child classes 
+    // NOTE: Overwritten by child classes which actually do some rendering, such as J2DPicture
     public drawSelf(renderInstManager: GfxRenderInstManager, viewerRenderInput: ViewerRenderInput, ctx2D: J2DGrafContext, offsetX: number, offsetY: number) { }
 
     public draw(renderInstManager: GfxRenderInstManager, viewerRenderInput: ViewerRenderInput, ctx2D: J2DGrafContext, offsetX: number = 0, offsetY: number = 0, clip: boolean = true): void {

--- a/src/Common/JSYSTEM/J2D.ts
+++ b/src/Common/JSYSTEM/J2D.ts
@@ -1,0 +1,218 @@
+import ArrayBufferSlice from "../../ArrayBufferSlice.js";
+import { JSystemFileReaderHelper } from "./J3D/J3DLoader.js";
+import { align, assert, readString } from "../../util.js";
+import { Color, colorNewFromRGBA8 } from "../../Color.js";
+
+export interface PaneBase {
+    parent: PaneBase | null
+}
+
+//#region  Helpers
+interface ResRef {
+    type: number;
+    name: string;
+}
+
+function parseResourceReference(dst: ResRef, buffer: ArrayBufferSlice, offset: number): number {
+    const dataView = buffer.createDataView();
+    dst.type = dataView.getUint8(offset + 0);
+    const nameLen = dataView.getUint8(offset + 1);
+    dst.name = readString(buffer, offset + 2, nameLen);
+
+    if (dst.type == 2 || dst.type == 3 || dst.type == 4) {
+        dst.name = "";
+    }
+
+    return nameLen + 2;
+}
+//#endregion
+
+//#region INF1
+export interface INF1 {
+    width: number;
+    height: number;
+    color: Color
+}
+
+function readINF1Chunk(buffer: ArrayBufferSlice): INF1 {
+    const view = buffer.createDataView();
+    const width = view.getUint16(8);
+    const height = view.getUint16(10);
+    const color = view.getUint32(12);
+    return {width, height, color: colorNewFromRGBA8(color)};
+}
+//#endregion
+
+//#region J2DPicture
+interface PIC1 extends PAN1 {
+    timg: ResRef;
+    tlut: ResRef;
+    binding: number;
+    flags: number;
+    colorBlack: Color;
+    colorWhite: Color;
+    colorCorner: Color;
+}
+
+function readPIC1Chunk(buffer: ArrayBufferSlice, parent: PaneBase | null): PIC1 {
+    const view = buffer.createDataView();
+    
+    const pane = readPAN1Chunk(buffer, parent);
+
+    let dataCount = view.getUint8(pane.offset + 0);
+    let offset = pane.offset + 1;
+
+    const timg = { type: 0, name: "" };
+    const tlut = { type: 0, name: "" };
+    offset += parseResourceReference(timg, buffer, offset);
+    offset += parseResourceReference(tlut, buffer, offset);
+    const binding = view.getUint8(offset);
+    offset += 1;
+    dataCount -= 3;
+
+    let flags = 0;
+    if (dataCount > 0) {
+        flags = view.getUint8(offset);
+        offset += 1;
+        dataCount -= 1;
+    }
+
+    if (dataCount > 0) {
+        offset += 1;
+        dataCount -= 1;
+    }
+
+    let colorBlack = 0x0;
+    if (dataCount > 0) {
+        colorBlack = view.getUint32(offset);
+        offset += 4;
+        dataCount -= 1;
+    }
+
+    let colorWhite = 0xFFFFFFFF;
+    if (dataCount > 0) {
+        colorWhite = view.getUint32(offset);
+        offset += 4;
+        dataCount -= 1;
+    }
+
+    let colorCorner = 0xFFFFFFFF;
+    if (dataCount > 0) {
+        colorCorner = view.getUint32(offset);
+        offset += 4;
+        dataCount -= 1;
+    }
+
+    return {...pane, timg, tlut, binding, flags, colorBlack: colorNewFromRGBA8(colorBlack), 
+        colorWhite: colorNewFromRGBA8(colorWhite), colorCorner: colorNewFromRGBA8(colorCorner) };
+}
+//#endregion J2DPicture
+
+//#region J2Pane
+interface PAN1 extends PaneBase {
+    visible: boolean;
+    tag: string;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    rot: number;
+    basePos: number;
+    alpha: number;
+    inheritAlpha: boolean;
+    
+    offset: number; // For parsing only
+}
+
+function readPAN1Chunk(buffer: ArrayBufferSlice, parent: PaneBase | null): PAN1 {
+    const view = buffer.createDataView();
+    let offset = 8;
+
+    let dataCount = view.getUint8(offset + 0);
+
+    const visible = !!view.getUint8(offset + 1);
+    const tag = readString(buffer, offset + 4, 4);
+    const x = view.getInt16(offset + 8);
+    const y = view.getInt16(offset + 10);
+    const w = view.getInt16(offset + 12);
+    const h = view.getInt16(offset + 14);
+    dataCount -= 6;
+    offset += 16;
+
+    let rot = 0;
+    if(dataCount > 0) {
+        rot = view.getUint16(offset);
+        offset += 2;
+        dataCount -= 1;
+    }
+
+    let basePos = 0;
+    if(dataCount > 0) {
+        basePos = view.getUint8(offset);
+        offset += 1;
+        dataCount -= 1;
+    }
+
+    let alpha = 0;
+    if(dataCount > 0) {
+        alpha = view.getUint8(offset);
+        offset += 1;
+        dataCount -= 1;
+    }
+
+    let inheritAlpha = true;
+    if(dataCount > 0) {
+        inheritAlpha = !!view.getUint8(offset);
+        offset += 1;
+        dataCount -= 1;
+    }
+
+    offset = align(offset, 4);
+    return { parent, visible, tag, x, y, w, h, rot, basePos, alpha, inheritAlpha, offset };
+}
+//#endregion J2Pane
+
+//#region J2Screen
+export interface SCRN {
+    inf1: INF1;
+    panes: PaneBase[];
+}
+
+export class BLO {
+    public static parse(buffer: ArrayBufferSlice): SCRN {
+        const j2d = new JSystemFileReaderHelper(buffer);
+        assert(j2d.magic === 'SCRNblo1');
+        
+        const inf1 = readINF1Chunk(j2d.nextChunk('INF1'))
+        const panes: PaneBase[] = [];
+
+        let parentStack: (PaneBase | null)[] = [null];
+        let shouldContinue = true;
+        while(shouldContinue) {
+            const magic = readString(buffer, j2d.offs, 4);
+            const chunkSize = j2d.view.getUint32(j2d.offs + 4);
+
+            switch(magic) {
+                // Panel Types
+                case 'PAN1': panes.push(readPAN1Chunk(j2d.nextChunk('PAN1'), parentStack[parentStack.length - 1])); break;
+                case 'PIC1': panes.push(readPIC1Chunk(j2d.nextChunk('PIC1'), parentStack[parentStack.length - 1])); break;
+                // case 'WIN1': readWIN1Chunk(j2d.nextChunk('WIN1')); break;
+                // case 'TBX1': readTBX1Chunk(j2d.nextChunk('TBX1')); break;
+
+                // Hierarchy
+                case 'EXT1': shouldContinue = false; break;
+                case 'BGN1': j2d.offs += chunkSize; parentStack.push(panes[panes.length - 1]); break;
+                case 'END1': j2d.offs += chunkSize; parentStack.pop(); break;
+
+                default:
+                    console.warn('Unsupported SCRN block:', magic);
+                    j2d.offs += chunkSize;
+                    break;
+            }
+        }
+
+        return { inf1, panes };
+    }
+}
+
+//#endregion J2Screen

--- a/src/Common/JSYSTEM/J2D.ts
+++ b/src/Common/JSYSTEM/J2D.ts
@@ -35,7 +35,7 @@ function parseResourceReference(dst: ResRef, buffer: ArrayBufferSlice, offset: n
     const nameLen = dataView.getUint8(offset + 1);
     dst.name = readString(buffer, offset + 2, nameLen);
 
-    if (dst.type == 2 || dst.type == 3 || dst.type == 4) {
+    if (dst.type === 2 || dst.type === 3 || dst.type === 4) {
         dst.name = "";
     }
 
@@ -255,8 +255,8 @@ export class J2DPane {
             }
         }
 
-        if (this.data.basePos != 0) { console.warn('Untested J2D feature'); }
-        if (this.data.rot != 0) { console.warn('Untested J2D feature'); }
+        if (this.data.basePos !== 0) { console.warn('Untested J2D feature'); }
+        if (this.data.rot !== 0) { console.warn('Untested J2D feature'); }
     }
 
     // NOTE: Overwritten by child classes 
@@ -300,11 +300,11 @@ export class J2DPane {
     }
 
     private makeMatrix() {
-        if (this.data.rot != 0) {
+        if (this.data.rot !== 0) {
             debugger; // Untested
             // TODO:
             // MTXTrans(stack1, -mBasePosition.x, -mBasePosition.y, 0.0f);
-            // f32 rot = mRotationAxis == ROTATE_Z ? -mRotation : mRotation;
+            // f32 rot = mRotationAxis === ROTATE_Z ? -mRotation : mRotation;
             // MTXRotDeg(stack2, mRotationAxis, rot);
             // MTXTrans(stack3, mBasePosition.x + x, mBasePosition.y + y, 0.0f);
             // MTXConcat(stack2, stack1, mMtx);
@@ -327,14 +327,14 @@ export class J2DPicture extends J2DPane {
     constructor(data: PAN1, private cache: GfxRenderCache, parent: J2DPane | null) {
         super(data, cache, parent);
         // @TODO: If the type > 4, load the image on construction
-        if (this.data.timg.type != 0 && this.data.timg.type != 2) { console.warn('Untested J2D feature'); }
+        if (this.data.timg.type !== 0 && this.data.timg.type !== 2) { console.warn('Untested J2D feature'); }
 
-        if (this.data.tlut.type != 0) { console.warn('Untested J2D feature'); }
-        if (this.data.uvBinding != 15) { console.warn('Untested J2D feature'); } 
-        if (this.data.flags != 0) { console.warn('Untested J2D feature'); }
-        if (this.data.colorBlack != 0 || this.data.colorWhite != 0xFFFFFFFF) { console.warn('Untested J2D feature'); }
-        if (this.data.colorCorners[0] != 0xFFFFFFFF || this.data.colorCorners[1] != 0xFFFFFFFF
-            || this.data.colorCorners[2] != 0xFFFFFFFF || this.data.colorCorners[3] != 0xFFFFFFFF) { console.warn('Untested J2D feature'); }
+        if (this.data.tlut.type !== 0) { console.warn('Untested J2D feature'); }
+        if (this.data.uvBinding !== 15) { console.warn('Untested J2D feature'); } 
+        if (this.data.flags !== 0) { console.warn('Untested J2D feature'); }
+        if (this.data.colorBlack !== 0 || this.data.colorWhite !== 0xFFFFFFFF) { console.warn('Untested J2D feature'); }
+        if (this.data.colorCorners[0] !== 0xFFFFFFFF || this.data.colorCorners[1] !== 0xFFFFFFFF
+            || this.data.colorCorners[2] !== 0xFFFFFFFF || this.data.colorCorners[3] !== 0xFFFFFFFF) { console.warn('Untested J2D feature'); }
     }
 
     public setTexture(tex: BTIData) {

--- a/src/Common/JSYSTEM/J2D.ts
+++ b/src/Common/JSYSTEM/J2D.ts
@@ -2,10 +2,25 @@ import ArrayBufferSlice from "../../ArrayBufferSlice.js";
 import { JSystemFileReaderHelper } from "./J3D/J3DLoader.js";
 import { align, assert, readString } from "../../util.js";
 import { Color, colorNewFromRGBA8 } from "../../Color.js";
+import { GfxRenderInst, GfxRenderInstManager } from "../../gfx/render/GfxRenderInstManager.js";
+import * as GX_Material from '../../gx/gx_material.js';
+import * as GX from '../../gx/gx_enum.js';
+import { DrawParams, fillSceneParamsData, GXMaterialHelperGfx, MaterialParams, SceneParams, ub_SceneParamsBufferSize } from "../../gx/gx_render.js";
+import { GfxClipSpaceNearZ, GfxDevice } from "../../gfx/platform/GfxPlatform.js";
+import { computeModelMatrixT, projectionMatrixForCuboid } from "../../MathHelpers.js";
+import { projectionMatrixConvertClipSpaceNearZ } from "../../gfx/helpers/ProjectionHelpers.js";
+import { TSDraw } from "../../SuperMarioGalaxy/DDraw.js";
+import { BTIData } from "./JUTTexture.js";
+import { GXMaterialBuilder } from "../../gx/GXMaterialBuilder.js";
+import { mat4, vec2, vec4 } from "gl-matrix";
+import { GfxRenderCache } from "../../gfx/render/GfxRenderCache.js";
 
-export interface PaneBase {
-    parent: PaneBase | null
-}
+//#region  Scratch
+const materialParams = new MaterialParams();
+const drawParams = new DrawParams();
+
+const scratchVec4a = vec4.create();
+//#endregion
 
 //#region  Helpers
 interface ResRef {
@@ -54,12 +69,12 @@ interface PIC1 extends PAN1 {
     colorCorner: Color;
 }
 
-function readPIC1Chunk(buffer: ArrayBufferSlice, parent: PaneBase | null): PIC1 {
+function readPIC1Chunk(buffer: ArrayBufferSlice, parent: PAN1 | null): PIC1 {
     const view = buffer.createDataView();
     
     const pane = readPAN1Chunk(buffer, parent);
 
-    let dataCount = view.getUint8(pane.offset + 0);
+    const dataCount = view.getUint8(pane.offset + 0);
     let offset = pane.offset + 1;
 
     const timg = { type: 0, name: "" };
@@ -68,40 +83,16 @@ function readPIC1Chunk(buffer: ArrayBufferSlice, parent: PaneBase | null): PIC1 
     offset += parseResourceReference(tlut, buffer, offset);
     const binding = view.getUint8(offset);
     offset += 1;
-    dataCount -= 3;
 
     let flags = 0;
-    if (dataCount > 0) {
-        flags = view.getUint8(offset);
-        offset += 1;
-        dataCount -= 1;
-    }
-
-    if (dataCount > 0) {
-        offset += 1;
-        dataCount -= 1;
-    }
-
     let colorBlack = 0x0;
-    if (dataCount > 0) {
-        colorBlack = view.getUint32(offset);
-        offset += 4;
-        dataCount -= 1;
-    }
-
     let colorWhite = 0xFFFFFFFF;
-    if (dataCount > 0) {
-        colorWhite = view.getUint32(offset);
-        offset += 4;
-        dataCount -= 1;
-    }
-
     let colorCorner = 0xFFFFFFFF;
-    if (dataCount > 0) {
-        colorCorner = view.getUint32(offset);
-        offset += 4;
-        dataCount -= 1;
-    }
+
+    if( dataCount >= 4) { flags = view.getUint8(offset + 0); }
+    if( dataCount >= 6) { colorBlack = view.getUint32(offset + 2); }
+    if( dataCount >= 7) { colorWhite = view.getUint32(offset + 6); }
+    if( dataCount >= 8) { colorCorner = view.getUint32(offset + 10); }
 
     return {...pane, timg, tlut, binding, flags, colorBlack: colorNewFromRGBA8(colorBlack), 
         colorWhite: colorNewFromRGBA8(colorWhite), colorCorner: colorNewFromRGBA8(colorCorner) };
@@ -109,7 +100,10 @@ function readPIC1Chunk(buffer: ArrayBufferSlice, parent: PaneBase | null): PIC1 
 //#endregion J2DPicture
 
 //#region J2Pane
-interface PAN1 extends PaneBase {
+interface PAN1 {
+    parent: PAN1 | null;
+    type: string;
+    children: PAN1[];
     visible: boolean;
     tag: string;
     x: number;
@@ -124,11 +118,12 @@ interface PAN1 extends PaneBase {
     offset: number; // For parsing only
 }
 
-function readPAN1Chunk(buffer: ArrayBufferSlice, parent: PaneBase | null): PAN1 {
+function readPAN1Chunk(buffer: ArrayBufferSlice, parent: PAN1 | null): PAN1 {
     const view = buffer.createDataView();
+    const type = readString(buffer, 0, 4);
     let offset = 8;
 
-    let dataCount = view.getUint8(offset + 0);
+    const dataCount = view.getUint8(offset + 0);
 
     const visible = !!view.getUint8(offset + 1);
     const tag = readString(buffer, offset + 4, 4);
@@ -136,46 +131,27 @@ function readPAN1Chunk(buffer: ArrayBufferSlice, parent: PaneBase | null): PAN1 
     const y = view.getInt16(offset + 10);
     const w = view.getInt16(offset + 12);
     const h = view.getInt16(offset + 14);
-    dataCount -= 6;
     offset += 16;
 
     let rot = 0;
-    if(dataCount > 0) {
-        rot = view.getUint16(offset);
-        offset += 2;
-        dataCount -= 1;
-    }
-
     let basePos = 0;
-    if(dataCount > 0) {
-        basePos = view.getUint8(offset);
-        offset += 1;
-        dataCount -= 1;
-    }
-
     let alpha = 0;
-    if(dataCount > 0) {
-        alpha = view.getUint8(offset);
-        offset += 1;
-        dataCount -= 1;
-    }
-
     let inheritAlpha = true;
-    if(dataCount > 0) {
-        inheritAlpha = !!view.getUint8(offset);
-        offset += 1;
-        dataCount -= 1;
-    }
+
+    if(dataCount >= 7) { rot = view.getUint16(offset); offset += 2; }
+    if(dataCount >= 8) { basePos = view.getUint8(offset); offset += 1; }
+    if(dataCount >= 9) { alpha = view.getUint8(offset); offset += 1; }
+    if(dataCount >= 10) { inheritAlpha = !!view.getUint8(offset); offset += 1; }
 
     offset = align(offset, 4);
-    return { parent, visible, tag, x, y, w, h, rot, basePos, alpha, inheritAlpha, offset };
+    return { parent, type, visible, tag, x, y, w, h, rot, basePos, alpha, inheritAlpha, offset, children: [] };
 }
 //#endregion J2Pane
 
 //#region J2Screen
 export interface SCRN {
     inf1: INF1;
-    panes: PaneBase[];
+    panes: PAN1[];
 }
 
 export class BLO {
@@ -184,9 +160,9 @@ export class BLO {
         assert(j2d.magic === 'SCRNblo1');
         
         const inf1 = readINF1Chunk(j2d.nextChunk('INF1'))
-        const panes: PaneBase[] = [];
+        const panes: PAN1[] = [];
 
-        let parentStack: (PaneBase | null)[] = [null];
+        let parentStack: (PAN1 | null)[] = [null];
         let shouldContinue = true;
         while(shouldContinue) {
             const magic = readString(buffer, j2d.offs, 4);
@@ -211,8 +187,218 @@ export class BLO {
             }
         }
 
+        // Generate 'children' lists for each pane
+        for( const pane of panes ) {
+            if( pane.parent ) {
+                pane.parent.children.push(pane);
+            }
+        }
+
         return { inf1, panes };
     }
 }
 
 //#endregion J2Screen
+// TODO: Move and reorganize
+export class J2DGrafContext {
+    sceneParams = new SceneParams();
+
+    constructor(device: GfxDevice) {
+        projectionMatrixForCuboid(this.sceneParams.u_Projection, 0, 1, 0, 1, 0, 1);
+        const clipSpaceNearZ = device.queryVendorInfo().clipSpaceNearZ;
+        projectionMatrixConvertClipSpaceNearZ(this.sceneParams.u_Projection, clipSpaceNearZ, GfxClipSpaceNearZ.NegativeOne);
+    }
+
+    public setOnRenderInst(renderInst: GfxRenderInst) {
+        const sceneParamsOffs = renderInst.allocateUniformBuffer(GX_Material.GX_Program.ub_SceneParams, ub_SceneParamsBufferSize);
+        fillSceneParamsData(renderInst.mapUniformBufferF32(GX_Material.GX_Program.ub_SceneParams), sceneParamsOffs, this.sceneParams);
+    }
+}
+
+//#region J2DPane
+export class J2DPane {
+    public children: J2DPane[] = []; // @TODO: Make private, provide search mechanism
+    private parent: J2DPane | null = null;
+
+    public drawMtx = mat4.create();
+    public drawAlpha = 1.0;
+    public drawPos = vec2.create();
+    public drawRange = vec2.create();
+
+    constructor(public data: PAN1, cache: GfxRenderCache, parent: J2DPane | null = null ) {
+        this.parent = parent;
+        for (const pane of data.children) {
+            switch (pane.type) {
+                case 'PAN1': this.children.push(new J2DPane(pane, cache, this)); break;
+                case 'PIC1': this.children.push(new J2DPicture(pane, cache, this)); break;
+                // case 'WIN1': this.children.push(new J2DWindow(pane)); break;
+                // case 'TBX1': this.children.push(new J2DTextbox(pane)); break;
+                default: console.warn('Unsupported J2D type:', pane.type); break;
+            }
+        }
+    }
+
+    // NOTE: Overwritten by child classes 
+    public drawSelf(renderInstManager: GfxRenderInstManager, offsetX: number, offsetY: number, ctx: J2DGrafContext) {}
+
+    public draw(ctx: J2DGrafContext, renderInstManager: GfxRenderInstManager, offsetX: number = 0, offsetY: number = 0, clip: boolean = true): void {
+        const boundsValid = this.data.w > 0 && this.data.h > 0;
+
+        if(this.data.visible && boundsValid) {
+            // Src data is in GameCube pixels (640x480, origin bottom left), convert to screen coordinates [0-1] origin upper left. 
+            vec2.set(this.drawPos, this.data.x / 640, 1.0 - this.data.y / 480);
+            vec2.set(this.drawRange, this.data.w / 480 /* TODO: Multiply by aspect */ , this.data.h / 480);
+
+            if(this.parent) {
+                // TODO: Handle parents offsets and alpha
+                this.makeMatrix();
+            } else {
+                this.drawPos[0] += offsetX;
+                this.drawPos[1] += offsetY;
+                this.makeMatrix();
+                this.drawAlpha = this.data.alpha;
+            }
+
+            if(this.drawRange[0] > 0 && this.drawRange[1] > 0) {
+                this.drawSelf(renderInstManager, offsetX, offsetY, ctx);
+                for (const pane of this.children) {
+                    pane.draw(ctx, renderInstManager, offsetX, offsetY, clip);
+                }
+            }
+        }
+
+        // JSUTree<J2DPane> * pParent = mPaneTree.getParent();
+        // J2DPane * pParentPane = NULL;
+        // if (pParent != NULL)
+        //     pParentPane = pParent->getObject();
+
+        // if (mVisible && mBounds.isValid()) {
+        //     mScreenBounds = mBounds;
+        //     mDrawBounds = mBounds;
+
+        //     if (pParentPane != NULL) {
+        //         JGeometry::TBox2<f32> screenBounds = pParentPane->mScreenBounds;
+        //         mScreenBounds.addPos(screenBounds.i.x, screenBounds.i.y);
+        //         MTXConcat(pParentPane->mDrawMtx, mMtx, mDrawMtx);
+
+        //         if (clip) {
+        //             JGeometry::TBox2<f32> screenBounds = pParentPane->mScreenBounds;
+        //             mDrawBounds.addPos(screenBounds.i.x, screenBounds.i.y);
+        //             mDrawBounds.intersect(pParentPane->mDrawBounds);
+        //         }
+
+        //         mDrawAlpha = mAlpha;
+        //         if (mInheritAlpha)
+        //             mDrawAlpha = (mAlpha * pParentPane->mDrawAlpha) / 0xFF;
+        //     } else {
+        //         mScreenBounds.addPos(x, y);
+        //         makeMatrix(mBounds.i.x + x, mBounds.i.y + y);
+        //         MTXCopy(mMtx, mDrawMtx);
+        //         mDrawBounds.set(mScreenBounds);
+        //         mDrawAlpha = mAlpha;
+        //     }
+
+        //     JGeometry::TBox2<f32> clipBounds(0.0f, 0.0f, 0.0f, 0.0f);
+        //     if (clip)
+        //         ((J2DOrthoGraph*)pCtx)->scissorBounds(&clipBounds, &mDrawBounds);
+
+        //     if (mDrawBounds.isValid() || !clip) {
+        //         ctx.place(mScreenBounds);
+        //         if (clip) {
+        //             ctx.scissor(clipBounds);
+        //             ctx.setScissor();
+        //         }
+        //         GXSetCullMode((GXCullMode)mCullMode);
+        //         drawSelf(x, y, &ctx.mPosMtx);
+
+        //         for (JSUTreeIterator<J2DPane> iter = mPaneTree.getFirstChild(); iter != mPaneTree.getEndChild(); ++iter)
+        //             iter->draw(0.0f, 0.0f, pCtx, clip);
+        //     }
+        // }
+    }
+
+    public destroy(device: GfxDevice): void {
+        // TODO: Destroy children
+    }
+
+    private makeMatrix() {
+        if (this.data.rot != 0) {
+            debugger; // Untested
+            // TODO:
+            // MTXTrans(stack1, -mBasePosition.x, -mBasePosition.y, 0.0f);
+            // f32 rot = mRotationAxis == ROTATE_Z ? -mRotation : mRotation;
+            // MTXRotDeg(stack2, mRotationAxis, rot);
+            // MTXTrans(stack3, mBasePosition.x + x, mBasePosition.y + y, 0.0f);
+            // MTXConcat(stack2, stack1, mMtx);
+            // MTXConcat(stack3, mMtx, mMtx);
+        } else {
+            computeModelMatrixT(this.drawMtx, this.drawPos[0], this.drawPos[1], -1 );
+            mat4.scale(this.drawMtx, this.drawMtx, [this.drawRange[0], this.drawRange[1], 1]);
+        }
+    }
+}
+//#endregion
+
+//#region J2DPicture
+export class J2DPicture extends J2DPane {
+    private sdraw = new TSDraw(); // TODO: Time to move TSDraw out of Mario Galaxy?
+    private materialHelper: GXMaterialHelperGfx;
+    public tex: BTIData; // TODO: Make private
+
+    constructor(data: PAN1, cache: GfxRenderCache, parent: J2DPane | null ) {
+        super(data, cache, parent);
+        
+        this.sdraw.setVtxDesc(GX.Attr.POS, true);
+        this.sdraw.setVtxDesc(GX.Attr.TEX0, true);
+
+        const size = 1;
+        this.sdraw.beginDraw(cache);
+        this.sdraw.begin(GX.Command.DRAW_QUADS, 4);
+        this.sdraw.position3f32(0, 0, 0);
+        this.sdraw.texCoord2f32(GX.Attr.TEX0, 0, 1);
+        this.sdraw.position3f32(0, size, 0);
+        this.sdraw.texCoord2f32(GX.Attr.TEX0, 0, 0);
+        this.sdraw.position3f32(size, size, 0);
+        this.sdraw.texCoord2f32(GX.Attr.TEX0, 1, 0);
+        this.sdraw.position3f32(size, 0, 0);
+        this.sdraw.texCoord2f32(GX.Attr.TEX0, 1, 1);
+        this.sdraw.end();
+        this.sdraw.endDraw(cache);
+
+        const mb = new GXMaterialBuilder('J2DPane');
+        mb.setTexCoordGen(GX.TexCoordID.TEXCOORD0, GX.TexGenType.MTX2x4, GX.TexGenSrc.TEX0, GX.TexGenMatrix.IDENTITY);
+        mb.setTevOrder(0, GX.TexCoordID.TEXCOORD0, GX.TexMapID.TEXMAP0, GX.RasColorChannelID.COLOR_ZERO);
+        mb.setTevColorIn(0, GX.CC.ZERO, GX.CC.ZERO, GX.CC.ZERO, GX.CC.TEXC);
+        mb.setTevColorOp(0, GX.TevOp.ADD, GX.TevBias.ZERO, GX.TevScale.SCALE_1, false, GX.Register.PREV);
+        mb.setTevAlphaIn(0, GX.CA.ZERO, GX.CA.ZERO, GX.CA.ZERO, GX.CA.TEXA);
+        mb.setTevAlphaOp(0, GX.TevOp.ADD, GX.TevBias.ZERO, GX.TevScale.SCALE_1, false, GX.Register.PREV);
+        mb.setZMode(true, GX.CompareType.LEQUAL, false);
+        mb.setBlendMode(GX.BlendMode.BLEND, GX.BlendFactor.SRCALPHA, GX.BlendFactor.INVSRCALPHA);
+        mb.setUsePnMtxIdx(false);
+        this.materialHelper = new GXMaterialHelperGfx(mb.finish());
+    }
+
+    public override drawSelf(renderInstManager: GfxRenderInstManager, offsetX: number, offsetY: number, ctx2D: J2DGrafContext): void {
+        renderInstManager.pushTemplate();
+        const renderInst = renderInstManager.newRenderInst();
+
+        ctx2D.setOnRenderInst(renderInst);
+        this.sdraw.setOnRenderInst(renderInst);
+        this.materialHelper.setOnRenderInst(renderInstManager.gfxRenderCache, renderInst);
+
+        this.tex.fillTextureMapping(materialParams.m_TextureMapping[0]);
+        this.materialHelper.allocateMaterialParamsDataOnInst(renderInst, materialParams);
+        renderInst.setSamplerBindingsFromTextureMappings(materialParams.m_TextureMapping);
+
+        mat4.copy(drawParams.u_PosMtx[0], this.drawMtx);
+        this.materialHelper.allocateDrawParamsDataOnInst(renderInst, drawParams);
+
+        renderInstManager.submitRenderInst(renderInst);
+        renderInstManager.popTemplate();
+    }
+
+    public override destroy(device: GfxDevice): void {
+        this.sdraw.destroy(device);
+    }
+}
+//#endregion

--- a/src/Common/JSYSTEM/J2Dv1.ts
+++ b/src/Common/JSYSTEM/J2Dv1.ts
@@ -60,7 +60,7 @@ export class J2DGrafContext {
     private sceneParams = new SceneParams();
 
     constructor(device: GfxDevice) {
-        // @NOTE: The y axis is inverted by this ortho matrix. Gamecube origin is top-left, ours is bottom left.  
+        // NOTE: Bottom is 1, Top is 0, to match the J2D convention
         projectionMatrixForCuboid(this.sceneParams.u_Projection, 0, 1, 1, 0, -1, 0);
         const clipSpaceNearZ = device.queryVendorInfo().clipSpaceNearZ;
         projectionMatrixConvertClipSpaceNearZ(this.sceneParams.u_Projection, clipSpaceNearZ, GfxClipSpaceNearZ.NegativeOne);
@@ -407,21 +407,20 @@ export class J2DPicture extends J2DPane {
         this.sdraw.setVtxDesc(GX.Attr.TEX0, true);
         this.sdraw.setVtxDesc(GX.Attr.CLR0, true);
 
-        // @NOTE: Y positions are inverted, to account for the projection matrix Y-flip. Gamecube origin is top-left, ours is bottom left.  
         this.sdraw.beginDraw(this.cache);
         this.sdraw.begin(GX.Command.DRAW_QUADS, 4);
         this.sdraw.position3f32(0, 0, 0);
         this.sdraw.color4color(GX.Attr.CLR0, colorNewFromRGBA8(this.data.colorCorners[0]));
-        this.sdraw.texCoord2f32(GX.Attr.TEX0, u0, v1);
-        this.sdraw.position3f32(0, -1, 0);
-        this.sdraw.color4color(GX.Attr.CLR0, colorNewFromRGBA8(this.data.colorCorners[1]));
-        this.sdraw.texCoord2f32(GX.Attr.TEX0, u0, v0);
-        this.sdraw.position3f32(1, -1, 0);
-        this.sdraw.color4color(GX.Attr.CLR0, colorNewFromRGBA8(this.data.colorCorners[3]));
-        this.sdraw.texCoord2f32(GX.Attr.TEX0, u1, v0);
+        this.sdraw.texCoord2f32(GX.Attr.TEX0, u0, v0); // 0
         this.sdraw.position3f32(1, 0, 0);
         this.sdraw.color4color(GX.Attr.CLR0, colorNewFromRGBA8(this.data.colorCorners[2]));
-        this.sdraw.texCoord2f32(GX.Attr.TEX0, u1, v1);
+        this.sdraw.texCoord2f32(GX.Attr.TEX0, u1, v0); // 1
+        this.sdraw.position3f32(1, 1, 0);
+        this.sdraw.color4color(GX.Attr.CLR0, colorNewFromRGBA8(this.data.colorCorners[3]));
+        this.sdraw.texCoord2f32(GX.Attr.TEX0, u1, v1); // 0
+        this.sdraw.position3f32(0, 1, 0);
+        this.sdraw.color4color(GX.Attr.CLR0, colorNewFromRGBA8(this.data.colorCorners[1]));
+        this.sdraw.texCoord2f32(GX.Attr.TEX0, u0, v1); // 0
         this.sdraw.end();
         this.sdraw.endDraw(this.cache);
 

--- a/src/Common/JSYSTEM/J2Dv1.ts
+++ b/src/Common/JSYSTEM/J2Dv1.ts
@@ -453,10 +453,11 @@ export class J2DPicture extends J2DPane {
 //#region J2DScreen
 export class J2DScreen extends J2DPane {
     public color: Color
-    private static defaultCtx: J2DGrafContext;
+    private defaultCtx: J2DGrafContext;
 
     constructor(data: SCRN, cache: GfxRenderCache) {
         super(data.panes[0], cache, null);
+        this.defaultCtx = new J2DGrafContext(cache.device, 0.0, 0.0, 640.0, 480.0, -1.0, 0.0);
         this.color = data.inf1.color;
     }
 
@@ -464,10 +465,7 @@ export class J2DScreen extends J2DPane {
         if (ctx2D !== null) {
             super.draw(renderInstManager, viewerRenderInput, ctx2D, offsetX, offsetY);
         } else {
-            if(!J2DScreen.defaultCtx) { 
-                J2DScreen.defaultCtx = new J2DGrafContext(renderInstManager.gfxRenderCache.device, 0.0, 0.0, 640.0, 480.0, -1.0, 0.0);
-            }
-            super.draw(renderInstManager, viewerRenderInput, J2DScreen.defaultCtx, offsetX, offsetY);
+            super.draw(renderInstManager, viewerRenderInput, this.defaultCtx, offsetX, offsetY);
         }
     }
 }

--- a/src/Common/JSYSTEM/J2Dv1.ts
+++ b/src/Common/JSYSTEM/J2Dv1.ts
@@ -1,3 +1,6 @@
+// Nintendo 2D rendering, version 1. Used by Wind Waker. 
+// Twilight Princess (and likely newer titles), use J2D version 2. 
+
 import ArrayBufferSlice from "../../ArrayBufferSlice.js";
 import { JSystemFileReaderHelper } from "./J3D/J3DLoader.js";
 import { align, assert, readString } from "../../util.js";

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -1053,7 +1053,6 @@ class DemoDesc extends SceneDesc implements Viewer.SceneDesc {
 // It has been reconstructed by cross-referencing each Room's lbnk section (which points to a Demo*.arc file for each layer),
 // the .stb files contained in each of those Objects/Demo*.arc files, and the FileName attribute from the event action.   
 const demoDescs = [
-    new DemoDesc("sea", "Departure", [44], "departure.stb", 10, [-200000.0, 0.0, 320000.0], 0.0, 204, 0),
     new DemoDesc("sea", "Pirate Zelda Fly", [44], "kaizoku_zelda_fly.stb", 0, [-200000.0, 0.0, 320000.0], 180.0, 0, 0),
     new DemoDesc("sea", "Zola Awakens", [13], "awake_zola.stb", 8, [200000.0, 0.0, -200000.0], 0, 227, 0),
     new DemoDesc("sea", "Get Komori Pearl", [13], "getperl_komori.stb", 9, [200000.0, 0.0, -200000.0], 0, 0, 0),
@@ -1133,6 +1132,7 @@ const sceneDescs = [
     new DemoDesc("sea_T", "Title Screen", [44], "title.stb", 0, [-220000.0, 0.0, 320000.0], 180.0, 0, 0),
     new DemoDesc("sea", "Awaken", [44], "awake.stb", 0, [-220000.0, 0.0, 320000.0], 0.0, 0, 0),
     new DemoDesc("sea", "Stolen Sister", [44], "stolensister.stb", 9, [0.0, 0.0, 20000.0], 0, 0, 0),
+    new DemoDesc("sea", "Departure", [44], "departure.stb", 10, [-200000.0, 0.0, 320000.0], 0.0, 204, 0),
 
     "Outset Island",
     new SceneDesc("sea_T", "Title Screen", [44]),

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -42,7 +42,7 @@ import { WoodPacket } from './d_wood.js';
 import { fopAcM_create, fopAcM_searchFromName, fopAc_ac_c } from './f_op_actor.js';
 import { cPhs__Status, fGlobals, fopDw_Draw, fopScn, fpcCt_Handler, fpcLy_SetCurrentLayer, fpcM_Management, fpcPf__Register, fpcSCtRq_Request, fpc_pc__ProfileList } from './framework.js';
 import { dDemo_manager_c, EDemoCamFlags, EDemoMode } from './d_demo.js';
-import { d_pn__RegisterConstructors, Placename, PlacenameState, updatePlaceName } from './d_place_name.js';
+import { d_pn__RegisterConstructors, Placename, PlacenameState, dPn__update } from './d_place_name.js';
 
 type SymbolData = { Filename: string, SymbolName: string, Data: ArrayBufferSlice };
 type SymbolMapData = { SymbolData: SymbolData[] };
@@ -798,7 +798,7 @@ class d_s_play extends fopScn {
         this.demo.update();
 
         // From d_menu_window::dMs_placenameMove()
-        updatePlaceName(globals);
+        dPn__update(globals);
 
         // From executeEvtManager() -> SpecialProcPackage()
         if (this.demo.getMode() === EDemoMode.Ended) {

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -1039,7 +1039,7 @@ class DemoDesc extends SceneDesc implements Viewer.SceneDesc {
         if (!demoData)
             demoData = globals.modelCache.resCtrl.getStageResByName(ResType.Stb, "Stage", this.stbFilename);
         
-        if( demoData ) { globals.scnPlay.demo.create(demoData, this.offsetPos, this.rotY / 180.0 * Math.PI, this.startFrame); }
+        if( demoData ) { globals.scnPlay.demo.create(this.id, demoData, this.offsetPos, this.rotY / 180.0 * Math.PI, this.startFrame); }
         else { console.warn('Failed to load demo data:', this.stbFilename); }
 
         return this.globals.renderer;

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -42,6 +42,7 @@ import { WoodPacket } from './d_wood.js';
 import { fopAcM_create, fopAcM_searchFromName, fopAc_ac_c } from './f_op_actor.js';
 import { cPhs__Status, fGlobals, fopDw_Draw, fopScn, fpcCt_Handler, fpcLy_SetCurrentLayer, fpcM_Management, fpcPf__Register, fpcSCtRq_Request, fpc_pc__ProfileList } from './framework.js';
 import { dDemo_manager_c, EDemoCamFlags, EDemoMode } from './d_demo.js';
+import { d_pn__RegisterConstructors, Placename, PlacenameState, updatePlaceName } from './d_place_name.js';
 
 type SymbolData = { Filename: string, SymbolName: string, Data: ArrayBufferSlice };
 type SymbolMapData = { SymbolData: SymbolData[] };
@@ -775,6 +776,8 @@ class d_s_play extends fopScn {
     public woodPacket: WoodPacket;
 
     public vrboxLoaded: boolean = false;
+    public placenameIndex: Placename;
+    public placenameState: PlacenameState;
 
     public override load(globals: dGlobals, userData: any): cPhs__Status {
         super.load(globals, userData);
@@ -793,6 +796,9 @@ class d_s_play extends fopScn {
 
     public override execute(globals: dGlobals, deltaTimeFrames: number): void {
         this.demo.update();
+
+        // From d_menu_window::dMs_placenameMove()
+        updatePlaceName(globals);
 
         // From executeEvtManager() -> SpecialProcPackage()
         if (this.demo.getMode() === EDemoMode.Ended) {
@@ -884,6 +890,7 @@ class SceneDesc {
         dKy__RegisterConstructors(framework);
         dKyw__RegisterConstructors(framework);
         d_a__RegisterConstructors(framework);
+        d_pn__RegisterConstructors(framework);
         LegacyActor__RegisterFallbackConstructor(framework);
 
         const symbolMap = new SymbolMap(modelCache.getFileData(`extra.crg1_arc`));

--- a/src/ZeldaWindWaker/d_demo.ts
+++ b/src/ZeldaWindWaker/d_demo.ts
@@ -424,6 +424,7 @@ export class dDemo_manager_c {
     private frameNoMsg: number;
     private mode = EDemoMode.None;
     private curFile: ArrayBufferSlice | null;
+    private name: string | null = null;
 
     private parser: TParse;
     private system = new dDemo_system_c(this.globals);
@@ -433,12 +434,14 @@ export class dDemo_manager_c {
         private globals: dGlobals
     ) { }
 
+    public getName() { return this.name; }
     public getFrame() { return this.frame; }
     public getFrameNoMsg() { return this.frameNoMsg; }
     public getMode() { return this.mode; }
     public getSystem() { return this.system; }
 
-    public create(data: ArrayBufferSlice, originPos?: vec3, rotY?: number, startFrame?: number): boolean {
+    public create(name: string, data: ArrayBufferSlice, originPos?: vec3, rotY?: number, startFrame?: number): boolean {
+        this.name = name;
         this.parser = new TParse(this.control);
 
         if (!this.parser.parse(data, 0)) {
@@ -463,6 +466,7 @@ export class dDemo_manager_c {
         this.control.destroyObject_all();
         this.system.remove();
         this.curFile = null;
+        this.name = null;
         this.mode = 0;
     }
 

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -26,18 +26,18 @@ export const enum PlacenameState {
 
 export function updatePlaceName(globals: dGlobals) {
     // From d_menu_window::dMs_placenameMove()
-    if(globals.scnPlay.demo.getMode() == EDemoMode.Playing) {
+    if(globals.scnPlay.demo.getMode() === EDemoMode.Playing) {
         const frameNo = globals.scnPlay.demo.getFrameNoMsg();
         const demoName = globals.scnPlay.demo.getName();
 
-        if(demoName == 'awake') { 
+        if(demoName === 'awake') { 
             if (frameNo >= 200 && frameNo < 350) {
                 globals.scnPlay.placenameIndex = Placename.OutsetIsland;
                 globals.scnPlay.placenameState = PlacenameState.Visible;
             } else if(frameNo >= 0x15e) {
                 globals.scnPlay.placenameState = PlacenameState.Hidden;
             }
-        } else if (demoName == 'majyuu_shinnyuu') {
+        } else if (demoName === 'majyuu_shinnyuu') {
             if (frameNo >= 0xb54 && frameNo < 0xbea) {
                 globals.scnPlay.placenameIndex = Placename.ForsakenFortress;
                 globals.scnPlay.placenameState = PlacenameState.Visible;
@@ -49,12 +49,12 @@ export function updatePlaceName(globals: dGlobals) {
 
     // From d_meter::dMeter_placeNameMove 
     if(currentPlaceName === null) {
-        if (globals.scnPlay.placenameState == PlacenameState.Visible) {
+        if (globals.scnPlay.placenameState === PlacenameState.Visible) {
             fpcSCtRq_Request(globals.frameworkGlobals, null, dProcName_e.d_place_name, null);
             currentPlaceName = globals.scnPlay.placenameIndex;
         }
     } else {
-        if (globals.scnPlay.placenameState == PlacenameState.Hidden) {
+        if (globals.scnPlay.placenameState === PlacenameState.Hidden) {
             currentPlaceName = null;
         }
     }
@@ -69,7 +69,7 @@ export class d_place_name extends msg_class {
 
     public override load(globals: dGlobals): cPhs__Status {
         let status = dComIfG_resLoad(globals, 'PName');
-        if (status != cPhs__Status.Complete)
+        if (status !== cPhs__Status.Complete)
             return status;
 
         const screen = globals.resCtrl.getObjectRes(ResType.Blo, `PName`, 0x04)
@@ -114,9 +114,9 @@ export class d_place_name extends msg_class {
     }
 
     public override execute(globals: dGlobals, deltaTimeFrames: number): void {
-        if (globals.scnPlay.placenameState == PlacenameState.Visible) {
+        if (globals.scnPlay.placenameState === PlacenameState.Visible) {
             this.openAnime(deltaTimeFrames);
-        } else if (globals.scnPlay.placenameState == PlacenameState.Hidden) {
+        } else if (globals.scnPlay.placenameState === PlacenameState.Hidden) {
             if (this.closeAnime(deltaTimeFrames))
                 fopMsgM_Delete(globals.frameworkGlobals, this);
         }

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -25,6 +25,8 @@ export const enum PlacenameState {
 }
 
 export function updatePlaceName(globals: dGlobals) {
+    // TODO: Initiate other place names manually
+
     // From d_menu_window::dMs_placenameMove()
     if (globals.scnPlay.demo.getMode() === EDemoMode.Playing) {
         const frameNo = globals.scnPlay.demo.getFrameNoMsg();
@@ -98,18 +100,6 @@ export class d_place_name extends msg_class {
     }
 
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
-        const pane = this.pane.children[2];
-
-        let x = (pane.data.x / 640);
-        let y = 1.0 - (pane.data.y / 480);
-
-        let h = (pane.data.h / 480);
-        let w = h * (pane.data.w / pane.data.h) / globals.camera.aspect;
-
-        // @TODO: Remove. Do this in J2D
-        MtxTrans([x, y, -1], false, pane.drawMtx);
-        mat4.scale(pane.drawMtx, pane.drawMtx, [w, h, 1]);
-
         renderInstManager.setCurrentList(globals.dlst.ui[0]);
         this.pane.draw(renderInstManager, viewerInput, this.ctx2D);
     }

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -1,4 +1,4 @@
-import { J2DGrafContext, J2DPicture, J2DScreen } from "../Common/JSYSTEM/J2D.js";
+import { J2DGrafContext, J2DPicture, J2DScreen } from "../Common/JSYSTEM/J2Dv1.js";
 import { BTI, BTIData } from "../Common/JSYSTEM/JUTTexture.js";
 import { GfxRenderInstManager } from "../gfx/render/GfxRenderInstManager.js";
 import { ViewerRenderInput } from "../viewer.js";

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -16,6 +16,22 @@ export const enum Placename {
     OutsetIsland,
     ForsakenFortress,
     DragonRoost,
+    ForestHaven,
+    GreatfishIsland,
+    WindfallIsland,
+    TowerOfTheGods,
+    KingdomOfHyrule,
+    GaleIsle,
+    HeadstoneIsle,
+    FireMountain,
+    IceRingIsle,
+    FairyAtoll,
+    DragonRoostCavern,
+    ForbiddenWoods,
+    TowerOfTheGods2,
+    EarthTemple,
+    WindTemple,
+    GanonsTower,
 }
 
 export const enum PlacenameState {
@@ -82,7 +98,8 @@ export class d_place_name extends msg_class {
         if (globals.scnPlay.placenameIndex === Placename.OutsetIsland) {
             img = globals.resCtrl.getObjectRes(ResType.Bti, `PName`, 0x07)
         } else {
-            const filename = `placename/pn_0${globals.scnPlay.placenameIndex + 1}.bti`; // @TODO: Need to support 2 digit numbers
+            const placenameId = (globals.scnPlay.placenameIndex + 1);
+            const filename = `placename/pn_${placenameId.toString().padStart(2, "0")}.bti`; 
             status = globals.modelCache.requestFileData(filename);
             if (status !== cPhs__Status.Complete)
                 return status;

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -38,7 +38,7 @@ export const enum PlacenameState {
     Visible,
 }
 
-export function updatePlaceName(globals: dGlobals) {
+export function dPn__update(globals: dGlobals) {
     // TODO: Initiate other place names manually
 
     // From d_menu_window::dMs_placenameMove()

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -31,7 +31,7 @@ export function updatePlaceName(globals: dGlobals) {
         const demoName = globals.scnPlay.demo.getName();
 
         if(demoName == 'awake') { 
-            if (frameNo >= 200 && frameNo < 0x15e) {
+            if (frameNo >= 200 && frameNo < 350) {
                 globals.scnPlay.placenameIndex = Placename.OutsetIsland;
                 globals.scnPlay.placenameState = PlacenameState.Visible;
             } else if(frameNo >= 0x15e) {
@@ -65,6 +65,7 @@ export class d_place_name extends msg_class {
     public static PROCESS_NAME = dProcName_e.d_place_name;
     private pane: J2DPane;
     private ctx2D: J2DGrafContext;
+    private animFrame: number = 0;
 
     public override load(globals: dGlobals): cPhs__Status {
         let status = dComIfG_resLoad(globals, 'PName');
@@ -113,9 +114,36 @@ export class d_place_name extends msg_class {
     }
 
     public override execute(globals: dGlobals, deltaTimeFrames: number): void {
+        if (globals.scnPlay.placenameState == PlacenameState.Visible) {
+            this.openAnime(deltaTimeFrames);
+        } else if (globals.scnPlay.placenameState == PlacenameState.Hidden) {
+            if (this.closeAnime(deltaTimeFrames))
+                fopMsgM_Delete(globals.frameworkGlobals, this);
+        }
+    }
 
-        // this.positionM(this.test.modelMatrix, 0.5, 0.5, -1.0, .5, .1);
-        // this.test.modelMatrix
+    private openAnime(deltaTimeFrames: number) {
+        if(this.animFrame < 10) {
+            this.animFrame += deltaTimeFrames;
+
+            const pct = (this.animFrame / 10)
+            const alpha = pct * pct;
+
+            this.pane.data.alpha = alpha * 0xFF;
+        }
+    }
+
+    private closeAnime(deltaTimeFrames: number) {
+        if(this.animFrame > 0) {
+            this.animFrame -= deltaTimeFrames;
+
+            const pct = (this.animFrame / 10)
+            const alpha = pct * pct;
+
+            this.pane.data.alpha = alpha * 0xFF;
+        }
+
+        return this.animFrame <= 0;
     }
 }
 
@@ -130,3 +158,4 @@ export function d_pn__RegisterConstructors(globals: fGlobals): void {
 
     R(d_place_name);
 }
+

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -6,7 +6,7 @@ import { ViewerRenderInput } from "../viewer.js";
 import { EDemoMode } from "./d_demo.js";
 import { dProcName_e } from "./d_procname.js";
 import { dComIfG_resLoad, ResType } from "./d_resorce.js";
-import { cPhs__Status, fGlobals, fpc_bs__Constructor, fpcPf__Register, fpcSCtRq_Request, leafdraw_class } from "./framework.js";
+import { cPhs__Status, fGlobals, fopMsgM_Delete, fpc_bs__Constructor, fpcPf__Register, fpcSCtRq_Request, leafdraw_class, msg_class } from "./framework.js";
 import { dGlobals } from "./Main.js";
 import { MtxTrans } from "./m_do_mtx.js";
 
@@ -61,7 +61,7 @@ export function updatePlaceName(globals: dGlobals) {
 }
 
 
-export class d_place_name extends leafdraw_class {
+export class d_place_name extends msg_class {
     public static PROCESS_NAME = dProcName_e.d_place_name;
     private pane: J2DPane;
     private ctx2D: J2DGrafContext;

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -1,5 +1,5 @@
 import { mat4, vec3 } from "gl-matrix";
-import { J2DGrafContext, J2DPane, J2DPicture, SCRN } from "../Common/JSYSTEM/J2D.js";
+import { J2DGrafContext, J2DPane, J2DPicture, J2DScreen, SCRN } from "../Common/JSYSTEM/J2D.js";
 import { BTI, BTIData } from "../Common/JSYSTEM/JUTTexture.js";
 import { GfxRenderInstManager } from "../gfx/render/GfxRenderInstManager.js";
 import { ViewerRenderInput } from "../viewer.js";
@@ -65,7 +65,7 @@ export function updatePlaceName(globals: dGlobals) {
 
 export class d_place_name extends msg_class {
     public static PROCESS_NAME = dProcName_e.d_place_name;
-    private pane: J2DPane;
+    private screen: J2DScreen;
     private ctx2D: J2DGrafContext;
     private animFrame: number = 0;
 
@@ -90,10 +90,10 @@ export class d_place_name extends msg_class {
             img = new BTIData(globals.context.device, globals.renderer.renderCache, BTI.parse(imgData, filename).texture);
         }
 
-        this.pane = new J2DPane(screen.panes[0], globals.renderer.renderCache);
-        this.pane.children[0].data.visible = false;
-        this.pane.children[1].data.visible = false;
-        const pic = this.pane.children[2] as J2DPicture;
+        this.screen = new J2DScreen(screen, globals.renderer.renderCache);
+        this.screen.children[0].data.visible = false;
+        this.screen.children[1].data.visible = false;
+        const pic = this.screen.children[2] as J2DPicture;
         pic.setTexture(img);
 
         return cPhs__Status.Complete;
@@ -101,7 +101,7 @@ export class d_place_name extends msg_class {
 
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
         renderInstManager.setCurrentList(globals.dlst.ui[0]);
-        this.pane.draw(renderInstManager, viewerInput, this.ctx2D);
+        this.screen.draw(renderInstManager, viewerInput, this.ctx2D);
     }
 
     public override execute(globals: dGlobals, deltaTimeFrames: number): void {
@@ -120,7 +120,7 @@ export class d_place_name extends msg_class {
             const pct = Math.min(this.animFrame / 10, 1.0)
             const alpha = pct * pct;
 
-            this.pane.data.alpha = alpha * 0xFF;
+            this.screen.data.alpha = alpha * 0xFF;
         }
     }
 
@@ -131,7 +131,7 @@ export class d_place_name extends msg_class {
             const pct = Math.min(this.animFrame / 10, 1.0)
             const alpha = pct * pct;
 
-            this.pane.data.alpha = alpha * 0xFF;
+            this.screen.data.alpha = alpha * 0xFF;
         }
 
         return this.animFrame <= 0;

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -110,7 +110,7 @@ export class d_place_name extends msg_class {
         MtxTrans([x, y, -1], false, pane.drawMtx);
         mat4.scale(pane.drawMtx, pane.drawMtx, [w, h, 1]);
 
-        this.pane.draw(this.ctx2D, renderInstManager);
+        this.pane.draw(renderInstManager, viewerInput, this.ctx2D );
     }
 
     public override execute(globals: dGlobals, deltaTimeFrames: number): void {

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -92,7 +92,7 @@ export class d_place_name extends msg_class {
         this.pane.children[0].data.visible = false;
         this.pane.children[1].data.visible = false;
         const pic = this.pane.children[2] as J2DPicture;
-        pic.tex = img;
+        pic.setTexture(img);
     
         return cPhs__Status.Complete;
     }

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -1,14 +1,18 @@
+import { BTI, BTIData } from "../Common/JSYSTEM/JUTTexture.js";
 import { GfxRenderInstManager } from "../gfx/render/GfxRenderInstManager.js";
 import { ViewerRenderInput } from "../viewer.js";
 import { EDemoMode } from "./d_demo.js";
 import { dProcName_e } from "./d_procname.js";
-import { fopMsgM_create } from "./f_op_msg_mng.js";
+import { dComIfG_resLoad, ResType } from "./d_resorce.js";
 import { cPhs__Status, fGlobals, fpc_bs__Constructor, fpcPf__Register, fpcSCtRq_Request, leafdraw_class } from "./framework.js";
 import { dGlobals } from "./Main.js";
+
+let currentPlaceName: number | null = null;
 
 export const enum Placename {
     OutsetIsland,
     ForsakenFortress,
+    DragonRoost,
 } 
 
 export const enum PlacenameState {
@@ -41,8 +45,15 @@ export function updatePlaceName(globals: dGlobals) {
     }
 
     // From d_meter::dMeter_placeNameMove 
-    if (globals.scnPlay.placenameState == PlacenameState.Visible) {
-        fpcSCtRq_Request(globals.frameworkGlobals, null, dProcName_e.d_place_name, null);
+    if(!currentPlaceName) {
+        if (globals.scnPlay.placenameState == PlacenameState.Visible) {
+            fpcSCtRq_Request(globals.frameworkGlobals, null, dProcName_e.d_place_name, null);
+            currentPlaceName = globals.scnPlay.placenameIndex;
+        }
+    } else {
+        if (globals.scnPlay.placenameState == PlacenameState.Hidden) {
+            currentPlaceName = null;
+        }
     }
 }
 
@@ -51,7 +62,23 @@ export class d_place_name extends leafdraw_class {
     public static PROCESS_NAME = dProcName_e.d_place_name;
 
     public override load(globals: dGlobals): cPhs__Status {
-        debugger;
+        let status = dComIfG_resLoad(globals, 'PName');
+        if (status != cPhs__Status.Complete)
+            return status;
+
+        // The Outset Island image lives inside the arc. All others are loose files in 'res/placename/'
+        let img: BTIData;
+        if( globals.scnPlay.placenameIndex === Placename.OutsetIsland ) {
+            img = globals.resCtrl.getObjectRes(ResType.Bti, `PName`, 0x07)
+        } else {
+            const filename = `placename/pn_0${globals.scnPlay.placenameIndex + 1}.bti`; // @TODO: Need to support 2 digit numbers
+            status = globals.modelCache.requestFileData(filename);
+            if (status !== cPhs__Status.Complete)
+                return status;
+            const imgData = globals.modelCache.getFileData(filename);
+            img = new BTIData(globals.context.device, globals.renderer.renderCache, BTI.parse(imgData, filename).texture);
+        }
+    
         return cPhs__Status.Complete;
     }
 

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -1,14 +1,12 @@
-import { mat4, vec3 } from "gl-matrix";
-import { J2DGrafContext, J2DPane, J2DPicture, J2DScreen, SCRN } from "../Common/JSYSTEM/J2D.js";
+import { J2DGrafContext, J2DPicture, J2DScreen } from "../Common/JSYSTEM/J2D.js";
 import { BTI, BTIData } from "../Common/JSYSTEM/JUTTexture.js";
 import { GfxRenderInstManager } from "../gfx/render/GfxRenderInstManager.js";
 import { ViewerRenderInput } from "../viewer.js";
 import { EDemoMode } from "./d_demo.js";
 import { dProcName_e } from "./d_procname.js";
 import { dComIfG_resLoad, ResType } from "./d_resorce.js";
-import { cPhs__Status, fGlobals, fopMsgM_Delete, fpc_bs__Constructor, fpcPf__Register, fpcSCtRq_Request, leafdraw_class, msg_class } from "./framework.js";
+import { cPhs__Status, fGlobals, fopMsgM_Delete, fpc_bs__Constructor, fpcPf__Register, fpcSCtRq_Request, msg_class } from "./framework.js";
 import { dGlobals } from "./Main.js";
-import { MtxTrans } from "./m_do_mtx.js";
 
 let currentPlaceName: number | null = null;
 

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -127,7 +127,7 @@ export class d_place_name extends msg_class {
         if (this.animFrame < 10) {
             this.animFrame += deltaTimeFrames;
 
-            const pct = (this.animFrame / 10)
+            const pct = Math.min(this.animFrame / 10, 1.0)
             const alpha = pct * pct;
 
             this.pane.data.alpha = alpha * 0xFF;
@@ -138,7 +138,7 @@ export class d_place_name extends msg_class {
         if (this.animFrame > 0) {
             this.animFrame -= deltaTimeFrames;
 
-            const pct = (this.animFrame / 10)
+            const pct = Math.min(this.animFrame / 10, 1.0)
             const alpha = pct * pct;
 
             this.pane.data.alpha = alpha * 0xFF;

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -110,6 +110,7 @@ export class d_place_name extends msg_class {
         MtxTrans([x, y, -1], false, pane.drawMtx);
         mat4.scale(pane.drawMtx, pane.drawMtx, [w, h, 1]);
 
+        renderInstManager.setCurrentList(globals.dlst.ui[0]);
         this.pane.draw(renderInstManager, viewerInput, this.ctx2D);
     }
 

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -1,0 +1,77 @@
+import { GfxRenderInstManager } from "../gfx/render/GfxRenderInstManager.js";
+import { ViewerRenderInput } from "../viewer.js";
+import { EDemoMode } from "./d_demo.js";
+import { dProcName_e } from "./d_procname.js";
+import { fopMsgM_create } from "./f_op_msg_mng.js";
+import { cPhs__Status, fGlobals, fpc_bs__Constructor, fpcPf__Register, fpcSCtRq_Request, leafdraw_class } from "./framework.js";
+import { dGlobals } from "./Main.js";
+
+export const enum Placename {
+    OutsetIsland,
+    ForsakenFortress,
+} 
+
+export const enum PlacenameState {
+    Init,
+    Hidden,
+    Visible,
+} 
+
+export function updatePlaceName(globals: dGlobals) {
+    // From d_menu_window::dMs_placenameMove()
+    if(globals.scnPlay.demo.getMode() == EDemoMode.Playing) {
+        const frameNo = globals.scnPlay.demo.getFrameNoMsg();
+        const demoName = globals.scnPlay.demo.getName();
+
+        if(demoName == 'awake') { 
+            if (frameNo >= 200 && frameNo < 0x15e) {
+                globals.scnPlay.placenameIndex = Placename.OutsetIsland;
+                globals.scnPlay.placenameState = PlacenameState.Visible;
+            } else if(frameNo >= 0x15e) {
+                globals.scnPlay.placenameState = PlacenameState.Hidden;
+            }
+        } else if (demoName == 'majyuu_shinnyuu') {
+            if (frameNo >= 0xb54 && frameNo < 0xbea) {
+                globals.scnPlay.placenameIndex = Placename.ForsakenFortress;
+                globals.scnPlay.placenameState = PlacenameState.Visible;
+            } else if(frameNo >= 0xbea) {
+                globals.scnPlay.placenameState = PlacenameState.Hidden;
+            }
+        }
+    }
+
+    // From d_meter::dMeter_placeNameMove 
+    if (globals.scnPlay.placenameState == PlacenameState.Visible) {
+        fpcSCtRq_Request(globals.frameworkGlobals, null, dProcName_e.d_place_name, null);
+    }
+}
+
+
+export class d_place_name extends leafdraw_class {
+    public static PROCESS_NAME = dProcName_e.d_place_name;
+
+    public override load(globals: dGlobals): cPhs__Status {
+        debugger;
+        return cPhs__Status.Complete;
+    }
+
+    public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
+        debugger;
+    }
+
+    public override execute(globals: dGlobals, deltaTimeFrames: number): void {
+        debugger;
+    }
+}
+
+interface constructor extends fpc_bs__Constructor {
+    PROCESS_NAME: dProcName_e;
+}
+
+export function d_pn__RegisterConstructors(globals: fGlobals): void {
+    function R(constructor: constructor): void {
+        fpcPf__Register(globals, constructor.PROCESS_NAME, constructor);
+    }
+
+    R(d_place_name);
+}

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -48,7 +48,7 @@ export function updatePlaceName(globals: dGlobals) {
     }
 
     // From d_meter::dMeter_placeNameMove 
-    if(!currentPlaceName) {
+    if(currentPlaceName === null) {
         if (globals.scnPlay.placenameState == PlacenameState.Visible) {
             fpcSCtRq_Request(globals.frameworkGlobals, null, dProcName_e.d_place_name, null);
             currentPlaceName = globals.scnPlay.placenameIndex;

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -80,7 +80,6 @@ export function dPn__update(globals: dGlobals) {
 export class d_place_name extends msg_class {
     public static PROCESS_NAME = dProcName_e.d_place_name;
     private screen: J2DScreen;
-    private ctx2D: J2DGrafContext;
     private animFrame: number = 0;
 
     public override load(globals: dGlobals): cPhs__Status {
@@ -88,8 +87,7 @@ export class d_place_name extends msg_class {
         if (status !== cPhs__Status.Complete)
             return status;
 
-        const screen = globals.resCtrl.getObjectRes(ResType.Blo, `PName`, 0x04)
-        this.ctx2D = new J2DGrafContext(globals.renderer.device);
+        const screen = globals.resCtrl.getObjectRes(ResType.Blo, `PName`, 0x04);
 
         // The Outset Island image lives inside the arc. All others are loose files in 'res/placename/'
         let img: BTIData;
@@ -116,7 +114,7 @@ export class d_place_name extends msg_class {
 
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
         renderInstManager.setCurrentList(globals.dlst.ui[0]);
-        this.screen.draw(renderInstManager, viewerInput, this.ctx2D);
+        this.screen.draw(renderInstManager, viewerInput, null);
     }
 
     public override execute(globals: dGlobals, deltaTimeFrames: number): void {

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -16,39 +16,39 @@ export const enum Placename {
     OutsetIsland,
     ForsakenFortress,
     DragonRoost,
-} 
+}
 
 export const enum PlacenameState {
     Init,
     Hidden,
     Visible,
-} 
+}
 
 export function updatePlaceName(globals: dGlobals) {
     // From d_menu_window::dMs_placenameMove()
-    if(globals.scnPlay.demo.getMode() === EDemoMode.Playing) {
+    if (globals.scnPlay.demo.getMode() === EDemoMode.Playing) {
         const frameNo = globals.scnPlay.demo.getFrameNoMsg();
         const demoName = globals.scnPlay.demo.getName();
 
-        if(demoName === 'awake') { 
+        if (demoName === 'awake') {
             if (frameNo >= 200 && frameNo < 350) {
                 globals.scnPlay.placenameIndex = Placename.OutsetIsland;
                 globals.scnPlay.placenameState = PlacenameState.Visible;
-            } else if(frameNo >= 0x15e) {
+            } else if (frameNo >= 0x15e) {
                 globals.scnPlay.placenameState = PlacenameState.Hidden;
             }
         } else if (demoName === 'majyuu_shinnyuu') {
             if (frameNo >= 0xb54 && frameNo < 0xbea) {
                 globals.scnPlay.placenameIndex = Placename.ForsakenFortress;
                 globals.scnPlay.placenameState = PlacenameState.Visible;
-            } else if(frameNo >= 0xbea) {
+            } else if (frameNo >= 0xbea) {
                 globals.scnPlay.placenameState = PlacenameState.Hidden;
             }
         }
     }
 
     // From d_meter::dMeter_placeNameMove 
-    if(currentPlaceName === null) {
+    if (currentPlaceName === null) {
         if (globals.scnPlay.placenameState === PlacenameState.Visible) {
             fpcSCtRq_Request(globals.frameworkGlobals, null, dProcName_e.d_place_name, null);
             currentPlaceName = globals.scnPlay.placenameIndex;
@@ -77,7 +77,7 @@ export class d_place_name extends msg_class {
 
         // The Outset Island image lives inside the arc. All others are loose files in 'res/placename/'
         let img: BTIData;
-        if( globals.scnPlay.placenameIndex === Placename.OutsetIsland ) {
+        if (globals.scnPlay.placenameIndex === Placename.OutsetIsland) {
             img = globals.resCtrl.getObjectRes(ResType.Bti, `PName`, 0x07)
         } else {
             const filename = `placename/pn_0${globals.scnPlay.placenameIndex + 1}.bti`; // @TODO: Need to support 2 digit numbers
@@ -93,13 +93,13 @@ export class d_place_name extends msg_class {
         this.pane.children[1].data.visible = false;
         const pic = this.pane.children[2] as J2DPicture;
         pic.setTexture(img);
-    
+
         return cPhs__Status.Complete;
     }
 
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
         const pane = this.pane.children[2];
-        
+
         let x = (pane.data.x / 640);
         let y = 1.0 - (pane.data.y / 480);
 
@@ -110,7 +110,7 @@ export class d_place_name extends msg_class {
         MtxTrans([x, y, -1], false, pane.drawMtx);
         mat4.scale(pane.drawMtx, pane.drawMtx, [w, h, 1]);
 
-        this.pane.draw(renderInstManager, viewerInput, this.ctx2D );
+        this.pane.draw(renderInstManager, viewerInput, this.ctx2D);
     }
 
     public override execute(globals: dGlobals, deltaTimeFrames: number): void {
@@ -123,7 +123,7 @@ export class d_place_name extends msg_class {
     }
 
     private openAnime(deltaTimeFrames: number) {
-        if(this.animFrame < 10) {
+        if (this.animFrame < 10) {
             this.animFrame += deltaTimeFrames;
 
             const pct = (this.animFrame / 10)
@@ -134,7 +134,7 @@ export class d_place_name extends msg_class {
     }
 
     private closeAnime(deltaTimeFrames: number) {
-        if(this.animFrame > 0) {
+        if (this.animFrame > 0) {
             this.animFrame -= deltaTimeFrames;
 
             const pct = (this.animFrame / 10)

--- a/src/ZeldaWindWaker/d_procname.ts
+++ b/src/ZeldaWindWaker/d_procname.ts
@@ -32,4 +32,5 @@ export const enum dProcName_e {
     d_a_swhit0          = 0x01C9,
     d_kyeff             = 0x01E4,
     d_kyeff2            = 0x01E5,
+    d_place_name        = 0x01EE,
 };

--- a/src/ZeldaWindWaker/d_resorce.ts
+++ b/src/ZeldaWindWaker/d_resorce.ts
@@ -13,7 +13,7 @@ import { dGlobals } from "./Main.js";
 import { cPhs__Status } from "./framework.js";
 import { cBgD_t } from "./d_bg.js";
 import { NamedArrayBufferSlice } from "../DataFetcher.js";
-import { BLO, SCRN } from "../Common/JSYSTEM/J2D.js";
+import { BLO, SCRN } from "../Common/JSYSTEM/J2Dv1.js";
 
 export interface DZSChunkHeader {
     type: string;

--- a/src/ZeldaWindWaker/d_resorce.ts
+++ b/src/ZeldaWindWaker/d_resorce.ts
@@ -13,6 +13,7 @@ import { dGlobals } from "./Main.js";
 import { cPhs__Status } from "./framework.js";
 import { cBgD_t } from "./d_bg.js";
 import { NamedArrayBufferSlice } from "../DataFetcher.js";
+import { BLO, SCRN } from "../Common/JSYSTEM/J2D.js";
 
 export interface DZSChunkHeader {
     type: string;
@@ -43,7 +44,7 @@ function parseDZSHeaders(buffer: ArrayBufferSlice): DZS {
 }
 
 export const enum ResType {
-    Model, Bmt, Bck, Bpk, Brk, Btp, Btk, Bti, Dzb, Dzs, Bva, Stb, Raw,
+    Model, Bmt, Bck, Bpk, Brk, Btp, Btk, Bti, Dzb, Dzs, Bva, Blo, Stb, Raw,
 }
 
 export type ResAssetType<T extends ResType> =
@@ -58,6 +59,7 @@ export type ResAssetType<T extends ResType> =
     T extends ResType.Dzb ? cBgD_t :
     T extends ResType.Dzs ? DZS :
     T extends ResType.Bva ? VAF1 :
+    T extends ResType.Blo ? SCRN :
     T extends ResType.Stb ? NamedArrayBufferSlice :
     T extends ResType.Raw ? NamedArrayBufferSlice :
     unknown;
@@ -162,6 +164,8 @@ export class dRes_info_c {
                 resEntry.res = BTK.parse(file.buffer) as ResAssetType<T>;
             } else if (resType === ResType.Bva) {
                 resEntry.res = BVA.parse(file.buffer) as ResAssetType<T>;
+            } else if (resType === ResType.Blo) {
+                resEntry.res = BLO.parse(file.buffer) as ResAssetType<T>;
             } else if (resType === ResType.Dzs) {
                 resEntry.res = parseDZSHeaders(file.buffer) as ResAssetType<T>;
             } else if (resType === ResType.Raw || resType === ResType.Stb) {

--- a/src/ZeldaWindWaker/framework.ts
+++ b/src/ZeldaWindWaker/framework.ts
@@ -1,9 +1,10 @@
 
-import { vec3 } from "gl-matrix";
+import { ReadonlyVec3, vec3 } from "gl-matrix";
 import ArrayBufferSlice from "../ArrayBufferSlice.js";
 import { GfxRenderInstManager } from "../gfx/render/GfxRenderInstManager.js";
 import { arrayRemove, assert, assertExists, nArray } from "../util.js";
 import { ViewerRenderInput } from "../viewer.js";
+import { fopAc_ac_c } from "./f_op_actor.js";
 
 export type fpc_pc__ProfileList = { Profiles: ArrayBufferSlice[] };
 
@@ -490,6 +491,46 @@ export function fopKyM_create(globals: fGlobals, pcName: number, parameters: num
 
 export function fopKyM_Delete(globals: fGlobals, ky: kankyo_class): void {
     fpcDt_Delete(globals, ky);
+}
+//#endregion
+
+//#region fopMsgM
+export class msg_class extends leafdraw_class {
+    public actor: fopAc_ac_c | null;
+    public pos = vec3.create();
+    public msgNo: number;
+    
+    private loadInit: boolean = false;
+
+    public override load(globals: GlobalUserData, prm: fopMsg_prm_class | null): cPhs__Status {
+        if (!this.loadInit) {
+            this.loadInit = true;
+
+            if (prm !== null) {
+                if (prm.pos !== null)
+                    vec3.copy(this.pos, prm.pos);
+                this.actor = prm.actor;
+                this.msgNo = prm.msgNo;
+            }
+        }
+        return cPhs__Status.Next;
+    }
+};
+
+export interface fopMsg_prm_class {
+    actor: fopAc_ac_c | null;
+    pos: ReadonlyVec3 | null;
+    msgNo: number;
+}
+
+export function fopMsgM_Delete(globals: fGlobals, msg: leafdraw_class) {
+    fpcDt_Delete(globals, msg);
+}
+
+export function fopMsgM_create(globals: fGlobals, pcName: number): number | null {
+    // Create on current layer.
+    const prm: fopMsg_prm_class = { actor: null, pos: null, msgNo: 0 };
+    return fpcSCtRq_Request(globals, null, pcName, prm);
 }
 //#endregion
 //#endregion


### PR DESCRIPTION
<img width="1123" alt="Screenshot 2024-12-12 at 4 28 38 PM" src="https://github.com/user-attachments/assets/c344302b-f8e7-4639-93f6-e453b5b6e9d1" />

- Added `src/Common/JSYSTEM/J2D.ts`
- Added new automatic file type handling, `BLO` (Binary Layout). 
- Added `fopMsgM` functionality to `framework.ts`
- Implemented place names handing in `src/ZeldaWindWaker/d_place_name.ts`

BLO files contain layout data for 2D elements. It is made up of a hierarchy of J2DPanes (essentially just a bounding box) and J2Pictures. Child elements inherit the transform from their parents. The entire hierarchy contained in a single root J2DScreen object. I followed the pattern of J3D and split up the loading functions from the runtime objects. 

J2D and BLO files can also be used to render message boxes during demos. I'm hoping that others will find uses for them as well. 

As for place names: currently, the only ones that will display are Outset Island and The Forsaken Fortress during their intro cutscenes. 