### PR TITLE
Wind Waker: Add black bars to top and bottom during demos

### DIFF
--- a/src/Common/JSYSTEM/J2Dv1.ts
+++ b/src/Common/JSYSTEM/J2Dv1.ts
@@ -268,7 +268,7 @@ export class J2DPane {
             // To support dynamic aspect ratios, we keep the original screenspace height and the original aspect ratio. 
             // So changing the window width will not cause 2D elements to scale, but changing the window height will. 
             vec2.set(this.drawPos, this.data.x, this.data.y);
-            vec2.set(this.drawDimensions, this.data.w * (ctx2D.aspectRatio / viewerRenderInput.camera.aspect), this.data.h);
+            vec2.set(this.drawDimensions, this.data.w * (ctx2D.aspectRatio / viewerRenderInput.camera.aspect), this.data.h); // TODO: Don't use camera.aspect, use backbuffer aspect
             this.drawAlpha = this.data.alpha / 0xFF;
 
             if (this.parent) {

--- a/src/Common/JSYSTEM/J2Dv1.ts
+++ b/src/Common/JSYSTEM/J2Dv1.ts
@@ -451,20 +451,15 @@ export class J2DPicture extends J2DPane {
 //#region J2DScreen
 export class J2DScreen extends J2DPane {
     public color: Color
-    private defaultCtx: J2DGrafContext;
 
     constructor(data: SCRN, cache: GfxRenderCache) {
         super(data.panes[0], cache, null);
-        this.defaultCtx = new J2DGrafContext(cache.device, 0.0, 0.0, 640.0, 480.0, -1.0, 0.0);
         this.color = data.inf1.color;
     }
 
-    override draw(renderInstManager: GfxRenderInstManager, viewerRenderInput: ViewerRenderInput, ctx2D: J2DGrafContext | null, offsetX?: number, offsetY?: number): void {
-        if (ctx2D !== null) {
-            super.draw(renderInstManager, viewerRenderInput, ctx2D, offsetX, offsetY);
-        } else {
-            super.draw(renderInstManager, viewerRenderInput, this.defaultCtx, offsetX, offsetY);
-        }
+    override draw(renderInstManager: GfxRenderInstManager, viewerRenderInput: ViewerRenderInput, ctx2D: J2DGrafContext, offsetX?: number, offsetY?: number): void {
+        assert(!!ctx2D);
+        super.draw(renderInstManager, viewerRenderInput, ctx2D, offsetX, offsetY);
     }
 }
 

--- a/src/Common/JSYSTEM/J3D/J3DGraphSimple.ts
+++ b/src/Common/JSYSTEM/J3D/J3DGraphSimple.ts
@@ -280,22 +280,22 @@ export class J3DModelInstanceSimple extends J3DModelInstance {
     }
 
     // The classic public interface, for compatibility.
-    public prepareToRender(device: GfxDevice, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
+    public prepareToRender(device: GfxDevice, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput, camera: Camera = viewerInput.camera): void {
         if (!this.visible)
             return;
 
         this.animationController.setTimeInMilliseconds(viewerInput.time);
-        this.calcSkybox(viewerInput.camera);
+        this.calcSkybox(camera);
         this.calcAnim();
-        this.calcView(viewerInput.camera, viewerInput.camera.viewMatrix);
+        this.calcView(camera, camera.viewMatrix);
 
         // If entire model is culled away, then we don't need to render anything.
         if (!this.isAnyShapeVisible())
             return;
 
-        const depth = this.computeDepth(viewerInput.camera);
+        const depth = this.computeDepth(camera);
         for (let i = 0; i < this.materialInstances.length; i++)
-            this.materialInstances[i].prepareToRenderShapes(device, renderInstManager, depth, viewerInput.camera, this.modelData, this.materialInstanceState, this.shapeInstanceState);
+            this.materialInstances[i].prepareToRenderShapes(device, renderInstManager, depth, camera, this.modelData, this.materialInstanceState, this.shapeInstanceState);
     }
 
     public override destroy(device: GfxDevice): void {

--- a/src/ZeldaTwilightPrincess/d_kankyo_wether.ts
+++ b/src/ZeldaTwilightPrincess/d_kankyo_wether.ts
@@ -1384,7 +1384,7 @@ export class dKankyo_star_Packet {
         vec3.transformMat4(scratchVec3d, scratchVec3d, scratchMatrix);
 
         // Projected moon position.
-        mDoLib_projectFB(scratchVec3e, envLight.moonPos, viewerInput);
+        mDoLib_projectFB(scratchVec3e, envLight.moonPos, viewerInput.camera, viewerInput);
 
         let radius = 0.0, angle: number = -Math.PI, angleIncr = 0.0;
         for (let i = 0; i < envLight.starCount; i++) {
@@ -1415,7 +1415,7 @@ export class dKankyo_star_Packet {
 
             vec3.add(scratchVec3a, scratchVec3a, globals.cameraPosition);
 
-            mDoLib_projectFB(scratchVec3, scratchVec3a, viewerInput);
+            mDoLib_projectFB(scratchVec3, scratchVec3a, viewerInput.camera, viewerInput);
             const distToMoon = vec3.dist(scratchVec3, scratchVec3e);
             if (distToMoon < 80.0)
                 continue;

--- a/src/ZeldaWindWaker/Grass.ts
+++ b/src/ZeldaWindWaker/Grass.ts
@@ -975,7 +975,7 @@ export class GrassPacket {
 
             vec3.copy(scratchVec3a, data.pos);
             scratchVec3a[1] += 260.0;
-            data.flags = setBitFlagEnabled(data.flags, GrassFlags.IsFrustumCulled, !globals.camera.frustum.containsSphere(scratchVec3a, 260.0));
+            data.flags = setBitFlagEnabled(data.flags, GrassFlags.IsFrustumCulled, !globals.camera.viewerCamera.frustum.containsSphere(scratchVec3a, 260.0));
 
             if (!(data.flags & GrassFlags.IsFrustumCulled)) {
                 // Update model matrix for all non-culled objects

--- a/src/ZeldaWindWaker/Grass.ts
+++ b/src/ZeldaWindWaker/Grass.ts
@@ -368,7 +368,7 @@ export class FlowerPacket {
     private drawFlowers(globals: dGlobals, roomIdx: number, type: FlowerType, model: DynamicModel, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
         const camera = globals.camera;
 
-        getMatrixTranslation(scratchVec3a, camera.viewerCamera.worldMatrix);
+        getMatrixTranslation(scratchVec3a, camera.worldMatrix);
 
         const template = renderInstManager.pushTemplate();
         template.setSamplerBindingsFromTextureMappings(model.textureMapping);
@@ -388,7 +388,7 @@ export class FlowerPacket {
 
             const renderInst = renderInstManager.newRenderInst();
             model.shapes[0].setOnRenderInst(renderInst);
-            mat4.mul(drawParams.u_PosMtx[0], camera.viewerCamera.viewMatrix, data.modelMatrix);
+            mat4.mul(drawParams.u_PosMtx[0], camera.viewMatrix, data.modelMatrix);
             model.materialHelper.allocateDrawParamsDataOnInst(renderInst, drawParams);
             renderInstManager.submitRenderInst(renderInst);
         }
@@ -726,8 +726,8 @@ export class TreePacket {
         if (room.length === 0)
             return;
 
-        const worldToView = globals.camera.viewerCamera.viewMatrix;
-        const worldCamPos = mat4.getTranslation(scratchVec3b, globals.camera.viewerCamera.worldMatrix);
+        const worldToView = globals.camera.viewMatrix;
+        const worldCamPos = mat4.getTranslation(scratchVec3b, globals.camera.worldMatrix);
 
         // Draw shadows
         {
@@ -975,7 +975,7 @@ export class GrassPacket {
 
             vec3.copy(scratchVec3a, data.pos);
             scratchVec3a[1] += 260.0;
-            data.flags = setBitFlagEnabled(data.flags, GrassFlags.IsFrustumCulled, !globals.camera.viewerCamera.frustum.containsSphere(scratchVec3a, 260.0));
+            data.flags = setBitFlagEnabled(data.flags, GrassFlags.IsFrustumCulled, !globals.camera.frustum.containsSphere(scratchVec3a, 260.0));
 
             if (!(data.flags & GrassFlags.IsFrustumCulled)) {
                 // Update model matrix for all non-culled objects
@@ -1024,8 +1024,8 @@ export class GrassPacket {
         if (room.length === 0)
             return;
 
-        const worldToView = globals.camera.viewerCamera.viewMatrix;
-        const worldCamPos = mat4.getTranslation(scratchVec3b, globals.camera.viewerCamera.worldMatrix);
+        const worldToView = globals.camera.viewMatrix;
+        const worldCamPos = mat4.getTranslation(scratchVec3b, globals.camera.worldMatrix);
 
         const template = renderInstManager.pushTemplate();
         template.setSamplerBindingsFromTextureMappings(this.grassModel.textureMapping);

--- a/src/ZeldaWindWaker/Grass.ts
+++ b/src/ZeldaWindWaker/Grass.ts
@@ -366,14 +366,14 @@ export class FlowerPacket {
     }
 
     private drawFlowers(globals: dGlobals, roomIdx: number, type: FlowerType, model: DynamicModel, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
-        const camera = viewerInput.camera;
+        const camera = globals.camera;
 
-        getMatrixTranslation(scratchVec3a, camera.worldMatrix);
+        getMatrixTranslation(scratchVec3a, camera.viewerCamera.worldMatrix);
 
         const template = renderInstManager.pushTemplate();
         template.setSamplerBindingsFromTextureMappings(model.textureMapping);
         setColorFromRoomNo(globals, materialParams, roomIdx);
-        dKy_GxFog_set(globals.g_env_light, materialParams.u_FogBlock, viewerInput.camera);
+        dKy_GxFog_set(globals.g_env_light, materialParams.u_FogBlock, camera);
         model.materialHelper.allocateMaterialParamsDataOnInst(template, materialParams);
         model.materialHelper.setOnRenderInst(renderInstManager.gfxRenderCache, template);
 
@@ -388,7 +388,7 @@ export class FlowerPacket {
 
             const renderInst = renderInstManager.newRenderInst();
             model.shapes[0].setOnRenderInst(renderInst);
-            mat4.mul(drawParams.u_PosMtx[0], camera.viewMatrix, data.modelMatrix);
+            mat4.mul(drawParams.u_PosMtx[0], camera.viewerCamera.viewMatrix, data.modelMatrix);
             model.materialHelper.allocateDrawParamsDataOnInst(renderInst, drawParams);
             renderInstManager.submitRenderInst(renderInst);
         }
@@ -726,8 +726,8 @@ export class TreePacket {
         if (room.length === 0)
             return;
 
-        const worldToView = viewerInput.camera.viewMatrix;
-        const worldCamPos = mat4.getTranslation(scratchVec3b, viewerInput.camera.worldMatrix);
+        const worldToView = globals.camera.viewerCamera.viewMatrix;
+        const worldCamPos = mat4.getTranslation(scratchVec3b, globals.camera.viewerCamera.worldMatrix);
 
         // Draw shadows
         {
@@ -735,7 +735,7 @@ export class TreePacket {
             const template = renderInstManager.pushTemplate();
             template.sortKey = makeSortKey(GfxRendererLayer.TRANSLUCENT);
             setColorFromRoomNo(globals, materialParams, roomIdx);
-            dKy_GxFog_set(globals.g_env_light, materialParams.u_FogBlock, viewerInput.camera);
+            dKy_GxFog_set(globals.g_env_light, materialParams.u_FogBlock, globals.camera);
             // Set the shadow color. Pulled from d_tree::l_shadowColor$4656
             colorFromRGBA(materialParams.u_Color[ColorKind.C0], 0, 0, 0, 0x64/0xFF);
             this.treeModel.shadow.materialHelper.allocateMaterialParamsDataOnInst(template, materialParams);
@@ -760,7 +760,7 @@ export class TreePacket {
         {
             const template = renderInstManager.pushTemplate();
             setColorFromRoomNo(globals, materialParams, roomIdx);
-            dKy_GxFog_set(globals.g_env_light, materialParams.u_FogBlock, viewerInput.camera);
+            dKy_GxFog_set(globals.g_env_light, materialParams.u_FogBlock, globals.camera);
             // Set the tree alpha. This fades after the tree is cut. This is multiplied with the texture alpha at the end of TEV stage 1.
             colorFromRGBA(materialParams.u_Color[ColorKind.C2], 0, 0, 0, 1);
             this.treeModel.main.materialHelper.allocateMaterialParamsDataOnInst(template, materialParams);
@@ -1024,13 +1024,13 @@ export class GrassPacket {
         if (room.length === 0)
             return;
 
-        const worldToView = viewerInput.camera.viewMatrix;
-        const worldCamPos = mat4.getTranslation(scratchVec3b, viewerInput.camera.worldMatrix);
+        const worldToView = globals.camera.viewerCamera.viewMatrix;
+        const worldCamPos = mat4.getTranslation(scratchVec3b, globals.camera.viewerCamera.worldMatrix);
 
         const template = renderInstManager.pushTemplate();
         template.setSamplerBindingsFromTextureMappings(this.grassModel.textureMapping);
         setColorFromRoomNo(globals, materialParams, roomIdx);
-        dKy_GxFog_set(globals.g_env_light, materialParams.u_FogBlock, viewerInput.camera);
+        dKy_GxFog_set(globals.g_env_light, materialParams.u_FogBlock, globals.camera);
         this.grassModel.materialHelper.allocateMaterialParamsDataOnInst(template, materialParams);
         this.grassModel.materialHelper.setOnRenderInst(renderInstManager.gfxRenderCache, template);
 

--- a/src/ZeldaWindWaker/LegacyActor.ts
+++ b/src/ZeldaWindWaker/LegacyActor.ts
@@ -1849,7 +1849,7 @@ export class BMDObjectRenderer {
 
             // Don't compute screen area culling on child meshes (don't want heads to disappear before bodies.)
             bboxScratch.transform(this.modelInstance.modelData.bbox, this.modelInstance.modelMatrix);
-            computeScreenSpaceProjectionFromWorldSpaceAABB(screenProjection, globals.camera.viewerCamera, bboxScratch);
+            computeScreenSpaceProjectionFromWorldSpaceAABB(screenProjection, globals.camera, bboxScratch);
 
             if (screenProjection.getScreenArea() <= 0.0002)
                 return;
@@ -1864,7 +1864,7 @@ export class BMDObjectRenderer {
             morf.entryDL(globals, renderInstManager, viewerInput);
         } else {
             this.setExtraTextures(globals.renderer.extraTextures);
-            this.modelInstance.prepareToRender(device, renderInstManager, viewerInput);
+            this.modelInstance.prepareToRender(device, renderInstManager, viewerInput, globals.camera);
         }
         
         for (let i = 0; i < this.childObjects.length; i++)

--- a/src/ZeldaWindWaker/LegacyActor.ts
+++ b/src/ZeldaWindWaker/LegacyActor.ts
@@ -1849,7 +1849,7 @@ export class BMDObjectRenderer {
 
             // Don't compute screen area culling on child meshes (don't want heads to disappear before bodies.)
             bboxScratch.transform(this.modelInstance.modelData.bbox, this.modelInstance.modelMatrix);
-            computeScreenSpaceProjectionFromWorldSpaceAABB(screenProjection, viewerInput.camera, bboxScratch);
+            computeScreenSpaceProjectionFromWorldSpaceAABB(screenProjection, globals.camera.viewerCamera, bboxScratch);
 
             if (screenProjection.getScreenArea() <= 0.0002)
                 return;
@@ -1857,7 +1857,7 @@ export class BMDObjectRenderer {
 
         mat4.getTranslation(scratchVec3a, this.modelMatrix);
         settingTevStruct(globals, this.lightTevColorType, scratchVec3a, this.tevstr);
-        setLightTevColorType(globals, this.modelInstance, this.tevstr, viewerInput.camera);
+        setLightTevColorType(globals, this.modelInstance, this.tevstr, globals.camera);
 
         if( morf ) {
             morf.calc();

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -267,7 +267,7 @@ class dCamera_c {
         
         // From dCamera_c::CalcTrimSize()
         // Animate up to the trim size for the current mode.
-        if(this.cameraMode == CameraMode.Cinematic) {
+        if(this.cameraMode === CameraMode.Cinematic) {
             this.trimHeight += (dCamera_c.trimHeightCinematic - this.trimHeight) * 0.25;
         } else {
             this.trimHeight += -this.trimHeight * 0.25;

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -275,6 +275,9 @@ export class dCamera_c extends Camera {
             mat4.targetTo(this.worldMatrix, this.cameraPos, targetPos, this.cameraUp);
             mat4.rotateZ(this.worldMatrix, this.worldMatrix, this.roll);
 
+            // Keep the noclip camera in sync with the demo cam so it isn't jarring when we pause
+            mat4.copy(viewerInput.camera.worldMatrix, this.worldMatrix);
+
             this.cameraMode = CameraMode.Cinematic;
             globals.context.inputManager.isMouseEnabled = false;
         } else {

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -234,7 +234,6 @@ class dCamera_c {
         // noclip modification: if we're paused, allow noclip camera control during demos
         const isPaused = viewerInput.deltaTime === 0;
 
-        // TODO: Determine the correct place for this
         // dCamera_c::Store() sets the camera params if the demo camera is active
         const demoCam = globals.scnPlay.demo.getSystem().getCamera();
         if (demoCam && !isPaused) {
@@ -242,6 +241,8 @@ class dCamera_c {
             let targetPos = vec3.add(scratchVec3a, globals.cameraPosition, globals.cameraFwd);
             let upVec = vec3.set(scratchVec3b, 0, 1, 0);
             let roll = 0.0;
+
+            // TODO: Blend between these camera params when switching camera modes, instead of the sudden snap.
 
             if (demoCam.flags & EDemoCamFlags.HasTargetPos) { targetPos = demoCam.targetPosition; }
             if (demoCam.flags & EDemoCamFlags.HasEyePos) { viewPos = demoCam.viewPosition; }
@@ -1055,7 +1056,7 @@ class DemoDesc extends SceneDesc implements Viewer.SceneDesc {
                 console.debug(`Loading stage demo file: ${globals.roomCtrl.demoArcName}`);
 
                 globals.modelCache.fetchObjectData(globals.roomCtrl.demoArcName).catch(e => {
-                    // @TODO: Better error handling. This does not prevent a debugger break.
+                    // TODO: Better error handling. This does not prevent a debugger break.
                     console.log(`Failed to load stage demo file: ${globals.roomCtrl.demoArcName}`, e);
                 })
             }
@@ -1074,7 +1075,7 @@ class DemoDesc extends SceneDesc implements Viewer.SceneDesc {
             setTimeout(waitForActors, 30);
         })(); });
 
-        // @TODO: Set noclip layer visiblity based on this.layer
+        // TODO: Set noclip layer visiblity based on this.layer
 
         // From dEvDtStaff_c::specialProcPackage()
         let demoData;

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -282,10 +282,10 @@ export class dCamera_c extends Camera {
         }
 
         this.finishSetup();
-        
+
         // From dCamera_c::CalcTrimSize()
         // Animate up to the trim size for the current mode.
-        if(this.cameraMode === CameraMode.Cinematic) {
+        if (this.cameraMode === CameraMode.Cinematic) {
             this.trimHeight += (dCamera_c.trimHeightCinematic - this.trimHeight) * 0.25;
         } else {
             this.trimHeight += -this.trimHeight * 0.25;

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -18,7 +18,7 @@ import { J3DModelInstance } from '../Common/JSYSTEM/J3D/J3DGraphBase.js';
 import * as JPA from '../Common/JSYSTEM/JPA.js';
 import { BTIData } from '../Common/JSYSTEM/JUTTexture.js';
 import { dfRange } from '../DebugFloaters.js';
-import { MathConstants, getMatrixAxisZ, getMatrixTranslation, range } from '../MathHelpers.js';
+import { MathConstants, clamp, getMatrixAxisZ, getMatrixTranslation, range } from '../MathHelpers.js';
 import { SceneContext } from '../SceneBase.js';
 import { TextureMapping } from '../TextureHolder.js';
 import { setBackbufferDescSimple, standardFullClearRenderPassDescriptor } from '../gfx/helpers/RenderGraphHelpers.js';
@@ -285,11 +285,12 @@ export class dCamera_c extends Camera {
         this.finishSetup();
 
         // From dCamera_c::CalcTrimSize()
-        // Animate up to the trim size for the current mode.
+        // Animate up to the trim size for the current mode (even when paused)
+        const deltaTimeFrames = clamp(viewerInput.deltaTime / 1000 * 30, 0.5, 1);
         if (this.cameraMode === CameraMode.Cinematic) {
-            this.trimHeight += (dCamera_c.trimHeightCinematic - this.trimHeight) * 0.25;
+            this.trimHeight += (dCamera_c.trimHeightCinematic - this.trimHeight) * 0.25 * deltaTimeFrames;
         } else {
-            this.trimHeight += -this.trimHeight * 0.25;
+            this.trimHeight += -this.trimHeight * 0.25 * deltaTimeFrames;
         }
 
         const trimPx = (this.trimHeight / 480) * viewerInput.backbufferHeight;

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -223,11 +223,10 @@ export class dCamera_c extends Camera {
     private static trimHeightCinematic = 65.0;
 
     public finishSetup(): void {
-        mat4.invert(this.worldMatrix, this.viewMatrix);
-        mat4.mul(this.clipFromWorldMatrix, this.projectionMatrix, this.viewMatrix);
+        mat4.invert(this.viewMatrix, this.worldMatrix);
+        this.setClipPlanes(this.near, this.far);
         getMatrixTranslation(this.cameraPos, this.worldMatrix);
         getMatrixAxisZ(this.cameraFwd, this.viewMatrix);
-        this.frustum.updateClipFrustum(this.clipFromWorldMatrix, this.clipSpaceNearZ);
     }
 
     public setupFromCamera(camera: Camera): void {
@@ -235,7 +234,7 @@ export class dCamera_c extends Camera {
         this.aspect = camera.aspect;
         this.fovY = camera.fovY;
 
-        mat4.copy(this.viewMatrix, camera.viewMatrix);
+        mat4.copy(this.worldMatrix, camera.worldMatrix);
         mat4.copy(this.projectionMatrix, camera.projectionMatrix);
     }
 
@@ -272,7 +271,6 @@ export class dCamera_c extends Camera {
             if (demoCam.flags & EDemoCamFlags.HasNearZ) { this.near = demoCam.projNear; }
             if (demoCam.flags & EDemoCamFlags.HasFarZ) { this.far = demoCam.projFar; }
 
-            // TODO: Clean this up
             mat4.targetTo(this.worldMatrix, this.cameraPos, targetPos, this.cameraUp);
             mat4.rotateZ(this.worldMatrix, this.worldMatrix, this.roll);
 
@@ -283,9 +281,6 @@ export class dCamera_c extends Camera {
             globals.context.inputManager.isMouseEnabled = true;
         }
 
-        // TODO: Clean this up
-        this.worldMatrixUpdated();
-        this.setClipPlanes(this.near, this.far);
         this.finishSetup();
         
         // From dCamera_c::CalcTrimSize()

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -215,6 +215,7 @@ export class dCamera_c extends Camera {
 
     // For people to play around with.
     public cameraFrozen = false;
+    public trimmingEnabled = false;
 
     private trimHeight = 0;
     private cameraMode: CameraMode = CameraMode.Default;
@@ -302,7 +303,9 @@ export class dCamera_c extends Camera {
     }
 
     public applyScissor(pass: GfxRenderPass) {
-        pass.setScissor(this.scissor[0], this.scissor[1], this.scissor[2], this.scissor[3]);
+        if (this.trimmingEnabled) {
+            pass.setScissor(this.scissor[0], this.scissor[1], this.scissor[2], this.scissor[3]);
+        }
     }
 }
 

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -207,7 +207,7 @@ const enum CameraMode {
     Cinematic
 }
 
-class dCamera_c {
+export class dCamera_c {
     // TODO: Remove
     public viewerCamera: Camera;
 
@@ -561,17 +561,17 @@ export class WindWakerRenderer implements Viewer.SceneGfx {
 
         renderInstManager.setCurrentList(dlst.bg[0]);
         {
-            this.globals.particleCtrl.calc(viewerInput);
+            this.globals.particleCtrl.calc(this.globals, viewerInput);
 
             for (let group = EffectDrawGroup.Main; group <= EffectDrawGroup.Indirect; group++) {
                 let texPrjMtx: mat4 | null = null;
 
                 if (group === EffectDrawGroup.Indirect) {
                     texPrjMtx = scratchMatrix;
-                    texProjCameraSceneTex(texPrjMtx, viewerInput.camera, 1);
+                    texProjCameraSceneTex(texPrjMtx, this.globals.camera.viewerCamera, 1);
                 }
 
-                this.globals.particleCtrl.setDrawInfo(viewerInput.camera.viewMatrix, viewerInput.camera.projectionMatrix, texPrjMtx, viewerInput.camera.frustum);
+                this.globals.particleCtrl.setDrawInfo(this.globals.camera.viewerCamera.viewMatrix, this.globals.camera.viewerCamera.projectionMatrix, texPrjMtx, this.globals.camera.viewerCamera.frustum);
                 renderInstManager.setCurrentList(dlst.effect[group]);
                 this.globals.particleCtrl.draw(device, this.renderHelper.renderInstManager, group);
             }

--- a/src/ZeldaWindWaker/d_a.ts
+++ b/src/ZeldaWindWaker/d_a.ts
@@ -621,8 +621,8 @@ class d_a_vrbox extends fopAc_ac_c {
         if (fili !== null)
             skyboxOffsY = fili.skyboxY;
 
-        MtxTrans(globals.cameraPosition, false);
-        calc_mtx[13] -= 0.09 * (globals.cameraPosition[1] - skyboxOffsY);
+        MtxTrans(globals.camera.cameraPos, false);
+        calc_mtx[13] -= 0.09 * (globals.camera.cameraPos[1] - skyboxOffsY);
         mat4.copy(this.model.modelMatrix, calc_mtx);
 
         dKy_setLight__OnModelInstance(envLight, this.model, globals.camera);
@@ -676,7 +676,7 @@ class d_a_vrbox2 extends fopAc_ac_c {
         }
 
         // Camera forward in XZ plane
-        vec3.copy(scratchVec3a, globals.cameraFwd);
+        vec3.copy(scratchVec3a, globals.camera.cameraFwd);
         scratchVec3a[1] = 0;
         vec3.normalize(scratchVec3a, scratchVec3a);
 
@@ -738,8 +738,8 @@ class d_a_vrbox2 extends fopAc_ac_c {
         if (fili !== null)
             skyboxOffsY = fili.skyboxY;
 
-        MtxTrans(globals.cameraPosition, false);
-        calc_mtx[13] -= 0.09 * (globals.cameraPosition[1] - skyboxOffsY);
+        MtxTrans(globals.camera.cameraPos, false);
+        calc_mtx[13] -= 0.09 * (globals.camera.cameraPos[1] - skyboxOffsY);
 
         if (this.usoUmi !== null) {
             mat4.copy(this.usoUmi.modelMatrix, calc_mtx);
@@ -818,10 +818,10 @@ class d_a_kytag00 extends fopAc_ac_c {
 
     private get_check_pos(globals: dGlobals): vec3 {
         // Return the closer of the two.
-        if (this.alwaysCheckPlayerPos || vec3.distance(this.pos, globals.playerPosition) < vec3.distance(this.pos, globals.cameraPosition))
+        if (this.alwaysCheckPlayerPos || vec3.distance(this.pos, globals.playerPosition) < vec3.distance(this.pos, globals.camera.cameraPos))
             return globals.playerPosition;
         else
-            return globals.cameraPosition;
+            return globals.camera.cameraPos;
     }
 
     private wether_tag_efect_move(globals: dGlobals): void {
@@ -1199,7 +1199,7 @@ function dDlst_texSpecmapST(dst: mat4, globals: dGlobals, pos: ReadonlyVec3, tev
     mat4.mul(dst, dst, scratchMat4a);
 
     // Half-vector lookAt transform.
-    vec3.sub(scratchVec3a, pos, globals.cameraPosition);
+    vec3.sub(scratchVec3a, pos, globals.camera.cameraPos);
     dKyr_get_vectle_calc(tevStr.lightObj.Position, pos, scratchVec3b);
     vecHalfAngle(scratchVec3a, scratchVec3a, scratchVec3b);
     mat4.lookAt(scratchMat4a, Vec3Zero, scratchVec3a, Vec3UnitY);
@@ -1524,7 +1524,7 @@ class dDlst_2DObject_c extends dDlst_2DBase_c {
         this.materialHelper.allocateMaterialParamsDataOnInst(renderInst, materialParams);
         renderInst.setSamplerBindingsFromTextureMappings(materialParams.m_TextureMapping);
 
-        mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix, this.modelMatrix);
+        mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewMatrix, this.modelMatrix);
         this.materialHelper.allocateDrawParamsDataOnInst(renderInst, drawParams);
 
         renderInstManager.submitRenderInst(renderInst);
@@ -1574,7 +1574,7 @@ class dDlst_2DNumber_c extends dDlst_2DBase_c {
 
             vec3.set(scratchVec3a, x, 0, 0);
             mat4.translate(scratchMat4a, this.modelMatrix, scratchVec3a);
-            mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix, scratchMat4a);
+            mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewMatrix, scratchMat4a);
             x -= this.spacing * 2;
 
             this.materialHelper.allocateDrawParamsDataOnInst(renderInst, drawParams);
@@ -2288,7 +2288,7 @@ class dCloth_packet_c {
             for (let fly = 0; fly < this.flyGridSize; fly++) {
                 transformVec3Mat4w1(scratchVec3a, this.mtx, this.posArr[this.curArr][this.getIndex(fly, hoist)]);
                 transformVec3Mat4w0(scratchVec3b, this.mtx, this.nrmArr[this.getIndex(fly, hoist)]);
-                drawWorldSpaceVector(ctx, globals.camera.viewerCamera.clipFromWorldMatrix, scratchVec3a, scratchVec3b, 50);
+                drawWorldSpaceVector(ctx, globals.camera.clipFromWorldMatrix, scratchVec3a, scratchVec3b, 50);
             }
         }
         */
@@ -2303,7 +2303,7 @@ class dCloth_packet_c {
         colorCopy(materialParams.u_Color[ColorKind.C0], this.tevStr.colorC0);
         colorCopy(materialParams.u_Color[ColorKind.C1], this.tevStr.colorK0);
         colorCopy(materialParams.u_Color[ColorKind.C2], this.tevStr.colorK1);
-        mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix, this.mtx);
+        mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewMatrix, this.mtx);
         this.materialHelper.allocateDrawParamsDataOnInst(template, drawParams);
 
         const ddraw = this.ddraw;
@@ -2769,8 +2769,8 @@ class d_a_majuu_flag extends fopAc_ac_c {
         /*
         for (let i = 0; i < this.pointCount; i++) {
             transformVec3Mat4w1(scratchVec3a, this.mtx, this.posArr[0][i]);
-            drawWorldSpacePoint(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, scratchVec3a);
-            drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, scratchVec3a, '' + i);
+            drawWorldSpacePoint(getDebugOverlayCanvas2D(), globals.camera.clipFromWorldMatrix, scratchVec3a);
+            drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.clipFromWorldMatrix, scratchVec3a, '' + i);
         }
         */
 
@@ -2791,7 +2791,7 @@ class d_a_majuu_flag extends fopAc_ac_c {
         colorCopy(materialParams.u_Color[ColorKind.C0], this.tevStr.colorC0);
         colorCopy(materialParams.u_Color[ColorKind.C1], this.tevStr.colorK0);
         colorCopy(materialParams.u_Color[ColorKind.C2], this.tevStr.colorK1);
-        mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix, this.mtx);
+        mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewMatrix, this.mtx);
         this.materialHelper.allocateDrawParamsDataOnInst(template, drawParams);
 
         const ddraw = this.ddraw;
@@ -3190,9 +3190,9 @@ class d_a_kamome extends fopAc_ac_c {
         setLightTevColorType(globals, this.morf.model, this.tevStr, globals.camera);
         this.morf.entryDL(globals, renderInstManager, viewerInput);
 
-        // drawWorldSpaceLine(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.pos, this.targetPos, Green, 2);
-        // drawWorldSpacePoint(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.pos, Magenta, 8);
-        // drawWorldSpacePoint(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.targetPos, Yellow, 6);
+        // drawWorldSpaceLine(getDebugOverlayCanvas2D(), globals.camera.clipFromWorldMatrix, this.pos, this.targetPos, Green, 2);
+        // drawWorldSpacePoint(getDebugOverlayCanvas2D(), globals.camera.clipFromWorldMatrix, this.pos, Magenta, 8);
+        // drawWorldSpacePoint(getDebugOverlayCanvas2D(), globals.camera.clipFromWorldMatrix, this.targetPos, Yellow, 6);
 
         // shadow
     }
@@ -3755,7 +3755,7 @@ class d_a_oship extends fopAc_ac_c implements ModeFuncExec<d_a_oship_mode> {
     ];
 
     private changeModeByRange(globals: dGlobals): void {
-        const dist = cLib_distanceXZ(this.pos, globals.cameraPosition);
+        const dist = cLib_distanceXZ(this.pos, globals.camera.cameraPos);
         let mode = this.curMode;
         if (dist < 2500.0)
             mode = d_a_oship_mode.rangeA;
@@ -3829,7 +3829,7 @@ class d_a_oship extends fopAc_ac_c implements ModeFuncExec<d_a_oship_mode> {
     private modeAttackInit(globals: dGlobals): void {
         this.attackTimer = -1;
 
-        vec3.copy(this.targetPos, globals.cameraPosition);
+        vec3.copy(this.targetPos, globals.camera.cameraPos);
 
         // Aim at our target.
 
@@ -3907,7 +3907,7 @@ class d_a_oship extends fopAc_ac_c implements ModeFuncExec<d_a_oship_mode> {
     }
 
     private rangeTargetCommon(globals: dGlobals, deltaTimeFrames: number): void {
-        vec3.copy(this.targetPos, globals.cameraPosition);
+        vec3.copy(this.targetPos, globals.camera.cameraPos);
         this.calcY(globals);
 
         if (this.checkTgHit(globals))
@@ -3978,19 +3978,19 @@ class d_a_oship extends fopAc_ac_c implements ModeFuncExec<d_a_oship_mode> {
         mDoExt_modelEntryDL(globals, this.model, renderInstManager, viewerInput);
 
         /*
-        drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.pos, `PId: ${this.processId}`, 0, White, { outline: 2 });
-        drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.pos, `Mode: ${d_a_oship_mode[this.curMode]}`, 14, White, { outline: 2 });
-        drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.pos, `Aim  : ${hexzero0x(this.aimRotX, 4)} ${hexzero0x(this.aimRotY, 4)}`, 14*2, White, { outline: 2 });
-        drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.pos, `Aim T: ${hexzero0x(this.aimRotXTarget, 4)} ${hexzero0x(this.aimRotYTarget, 4)}`, 14*3, White, { outline: 2 });
-        drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.pos, `Tgt  : ${this.targetPos[0].toFixed(2)} ${this.targetPos[1].toFixed(2)} ${this.targetPos[2].toFixed(2)}`, 14*4, White, { outline: 2 });
-        drawWorldSpacePoint(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.targetPos, Green, 10);
+        drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.clipFromWorldMatrix, this.pos, `PId: ${this.processId}`, 0, White, { outline: 2 });
+        drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.clipFromWorldMatrix, this.pos, `Mode: ${d_a_oship_mode[this.curMode]}`, 14, White, { outline: 2 });
+        drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.clipFromWorldMatrix, this.pos, `Aim  : ${hexzero0x(this.aimRotX, 4)} ${hexzero0x(this.aimRotY, 4)}`, 14*2, White, { outline: 2 });
+        drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.clipFromWorldMatrix, this.pos, `Aim T: ${hexzero0x(this.aimRotXTarget, 4)} ${hexzero0x(this.aimRotYTarget, 4)}`, 14*3, White, { outline: 2 });
+        drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.clipFromWorldMatrix, this.pos, `Tgt  : ${this.targetPos[0].toFixed(2)} ${this.targetPos[1].toFixed(2)} ${this.targetPos[2].toFixed(2)}`, 14*4, White, { outline: 2 });
+        drawWorldSpacePoint(getDebugOverlayCanvas2D(), globals.camera.clipFromWorldMatrix, this.targetPos, Green, 10);
         */
     }
 
     private setMtx(globals: dGlobals, deltaTimeFrames: number): void {
         dLib_waveRot(globals, this.wave, this.pos, this.attackSwayAmount, deltaTimeFrames);
 
-        const angleY = this.rot[1] + cLib_targetAngleY(this.pos, globals.cameraPosition);
+        const angleY = this.rot[1] + cLib_targetAngleY(this.pos, globals.camera.cameraPos);
         const swayAmount = Math.sin(cM_s2rad(this.attackSwayTimer)) * (this.attackSwayAmount * 10);
 
         if (this.curMode !== d_a_oship_mode.delete) {
@@ -4575,8 +4575,8 @@ export class d_a_ff extends fopAc_ac_c {
         const peekZ = globals.dlst.peekZ;
         const dst = this.peekZResult;
 
-        mDoLib_project(scratchVec3a, this.pos, globals.camera.viewerCamera);
-        if (globals.camera.viewerCamera.clipSpaceNearZ === GfxClipSpaceNearZ.NegativeOne)
+        mDoLib_project(scratchVec3a, this.pos, globals.camera);
+        if (globals.camera.clipSpaceNearZ === GfxClipSpaceNearZ.NegativeOne)
             scratchVec3a[2] = scratchVec3a[2] * 0.5 + 0.5;
 
         if (!peekZ.newData(dst, scratchVec3a[0], scratchVec3a[1], scratchVec3a[2]))

--- a/src/ZeldaWindWaker/d_a.ts
+++ b/src/ZeldaWindWaker/d_a.ts
@@ -3539,7 +3539,7 @@ class d_a_obj_ikada extends fopAc_ac_c implements ModeFuncExec<d_a_obj_ikada_mod
         this.model.calcAnim();
 
         if (this.isShip()) {
-            if (this.velocityFwd > 2.0 && this.cullingCheck(globals.camera)) {
+            if (this.velocityFwd > 2.0 && this.cullingCheck(globals.camera.viewerCamera)) {
                 this.setWave(globals, deltaTimeFrames);
             } else {
                 this.waveL!.remove();
@@ -4105,7 +4105,7 @@ class d_a_oship extends fopAc_ac_c implements ModeFuncExec<d_a_oship_mode> {
         this.setMtx(globals, deltaTimeFrames);
 
         this.visible
-        if (this.velocityFwd > 2.0 && this.cullingCheck(globals.camera)) {
+        if (this.velocityFwd > 2.0 && this.cullingCheck(globals.camera.viewerCamera)) {
             this.setWave(globals, deltaTimeFrames);
         } else {
             this.waveL.remove();
@@ -4575,8 +4575,8 @@ export class d_a_ff extends fopAc_ac_c {
         const peekZ = globals.dlst.peekZ;
         const dst = this.peekZResult;
 
-        mDoLib_project(scratchVec3a, this.pos, globals.camera);
-        if (globals.camera.clipSpaceNearZ === GfxClipSpaceNearZ.NegativeOne)
+        mDoLib_project(scratchVec3a, this.pos, globals.camera.viewerCamera);
+        if (globals.camera.viewerCamera.clipSpaceNearZ === GfxClipSpaceNearZ.NegativeOne)
             scratchVec3a[2] = scratchVec3a[2] * 0.5 + 0.5;
 
         if (!peekZ.newData(dst, scratchVec3a[0], scratchVec3a[1], scratchVec3a[2]))

--- a/src/ZeldaWindWaker/d_a.ts
+++ b/src/ZeldaWindWaker/d_a.ts
@@ -267,7 +267,7 @@ class d_a_ep extends fopAc_ac_c {
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
         if (this.type === 0 || this.type === 3) {
             settingTevStruct(globals, LightType.BG0, this.pos, this.tevStr);
-            setLightTevColorType(globals, this.model, this.tevStr, viewerInput.camera);
+            setLightTevColorType(globals, this.model, this.tevStr, globals.camera);
             mDoExt_modelUpdateDL(globals, this.model, renderInstManager, viewerInput);
 
             // TODO(jstpierre): ga
@@ -500,7 +500,7 @@ class d_a_bg extends fopAc_ac_c {
 
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
         // TODO(jstpierre): Proper culling check
-        // if (!this.cullingCheck(viewerInput.camera))
+        // if (!this.cullingCheck(globals.camera))
         //     return;
 
         // force far plane to 100000.0 ?
@@ -510,7 +510,7 @@ class d_a_bg extends fopAc_ac_c {
                 continue;
 
             settingTevStruct(globals, LightType.BG0 + i, null, this.bgTevStr[i]!);
-            setLightTevColorType(globals, this.bgModel[i]!, this.bgTevStr[i]!, viewerInput.camera);
+            setLightTevColorType(globals, this.bgModel[i]!, this.bgTevStr[i]!, globals.camera);
             // this is actually mDoExt_modelEntryDL
             mDoExt_modelUpdateDL(globals, this.bgModel[i]!, renderInstManager, viewerInput);
         }
@@ -625,7 +625,7 @@ class d_a_vrbox extends fopAc_ac_c {
         calc_mtx[13] -= 0.09 * (globals.cameraPosition[1] - skyboxOffsY);
         mat4.copy(this.model.modelMatrix, calc_mtx);
 
-        dKy_setLight__OnModelInstance(envLight, this.model, viewerInput.camera);
+        dKy_setLight__OnModelInstance(envLight, this.model, globals.camera);
         mDoExt_modelUpdateDL(globals, this.model, renderInstManager, viewerInput, globals.dlst.sky);
     }
 }
@@ -1078,11 +1078,11 @@ class d_a_obj_Ygush00 extends fopAc_ac_c {
     }
 
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
-        if (!this.cullingCheck(viewerInput.camera))
+        if (!this.cullingCheck(globals.camera))
             return;
 
         settingTevStruct(globals, LightType.BG1, this.pos, this.tevStr);
-        setLightTevColorType(globals, this.model, this.tevStr, viewerInput.camera);
+        setLightTevColorType(globals, this.model, this.tevStr, globals.camera);
 
         this.btkAnm.entry(this.model);
         this.bckAnm.entry(this.model);
@@ -1169,11 +1169,11 @@ class d_a_obj_lpalm extends fopAc_ac_c {
     }
 
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
-        if (!this.cullingCheck(viewerInput.camera))
+        if (!this.cullingCheck(globals.camera))
             return;
 
         settingTevStruct(globals, LightType.BG0, this.pos, this.tevStr);
-        setLightTevColorType(globals, this.model, this.tevStr, viewerInput.camera);
+        setLightTevColorType(globals, this.model, this.tevStr, globals.camera);
         mDoExt_modelUpdateDL(globals, this.model, renderInstManager, viewerInput);
     }
 }
@@ -1253,11 +1253,11 @@ class d_a_obj_zouK extends fopAc_ac_c {
     }
 
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
-        if (!this.cullingCheck(viewerInput.camera))
+        if (!this.cullingCheck(globals.camera))
             return;
 
         settingTevStruct(globals, LightType.Actor, this.pos, this.tevStr);
-        setLightTevColorType(globals, this.model, this.tevStr, viewerInput.camera);
+        setLightTevColorType(globals, this.model, this.tevStr, globals.camera);
         this.setEffectMtx(globals, this.pos, 0.5);
         this.bckAnm.entry(this.model);
         mDoExt_modelUpdateDL(globals, this.model, renderInstManager, viewerInput);
@@ -1304,11 +1304,11 @@ class d_a_swhit0 extends fopAc_ac_c {
     }
 
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
-        if (!this.cullingCheck(viewerInput.camera))
+        if (!this.cullingCheck(globals.camera))
             return;
 
         settingTevStruct(globals, LightType.BG0, this.pos, this.tevStr);
-        setLightTevColorType(globals, this.model, this.tevStr, viewerInput.camera);
+        setLightTevColorType(globals, this.model, this.tevStr, globals.camera);
 
         this.model.setColorOverride(ColorKind.C1, d_a_swhit0.color1Normal);
         this.model.setColorOverride(ColorKind.C2, d_a_swhit0.color2Normal);
@@ -1524,7 +1524,7 @@ class dDlst_2DObject_c extends dDlst_2DBase_c {
         this.materialHelper.allocateMaterialParamsDataOnInst(renderInst, materialParams);
         renderInst.setSamplerBindingsFromTextureMappings(materialParams.m_TextureMapping);
 
-        mat4.mul(drawParams.u_PosMtx[0], viewerInput.camera.viewMatrix, this.modelMatrix);
+        mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix, this.modelMatrix);
         this.materialHelper.allocateDrawParamsDataOnInst(renderInst, drawParams);
 
         renderInstManager.submitRenderInst(renderInst);
@@ -1574,7 +1574,7 @@ class dDlst_2DNumber_c extends dDlst_2DBase_c {
 
             vec3.set(scratchVec3a, x, 0, 0);
             mat4.translate(scratchMat4a, this.modelMatrix, scratchVec3a);
-            mat4.mul(drawParams.u_PosMtx[0], viewerInput.camera.viewMatrix, scratchMat4a);
+            mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix, scratchMat4a);
             x -= this.spacing * 2;
 
             this.materialHelper.allocateDrawParamsDataOnInst(renderInst, drawParams);
@@ -1962,28 +1962,28 @@ class d_a_mgameboard extends fopAc_ac_c {
     }
 
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
-        if (!this.cullingCheck(viewerInput.camera))
+        if (!this.cullingCheck(globals.camera))
             return;
 
         settingTevStruct(globals, LightType.Actor, this.pos, this.tevStr);
-        setLightTevColorType(globals, this.boardModel, this.tevStr, viewerInput.camera);
+        setLightTevColorType(globals, this.boardModel, this.tevStr, globals.camera);
         mDoExt_modelUpdateDL(globals, this.boardModel, renderInstManager, viewerInput);
 
         if (!this.minigameActive)
             return;
 
-        setLightTevColorType(globals, this.cursorModel, this.tevStr, viewerInput.camera);
+        setLightTevColorType(globals, this.cursorModel, this.tevStr, globals.camera);
         mDoExt_modelUpdateDL(globals, this.cursorModel, renderInstManager, viewerInput, globals.dlst.ui);
 
         for (let i = 0; i < this.hitModelCount; i++) {
             const model = this.hitModels[i];
-            setLightTevColorType(globals, model, this.tevStr, viewerInput.camera);
+            setLightTevColorType(globals, model, this.tevStr, globals.camera);
             mDoExt_modelUpdateDL(globals, model, renderInstManager, viewerInput, globals.dlst.ui);
         }
 
         for (let i = 0; i < this.missModelCount; i++) {
             const model = this.missModels[i];
-            setLightTevColorType(globals, model, this.tevStr, viewerInput.camera);
+            setLightTevColorType(globals, model, this.tevStr, globals.camera);
             mDoExt_modelUpdateDL(globals, model, renderInstManager, viewerInput, globals.dlst.ui);
         }
 
@@ -1991,7 +1991,7 @@ class d_a_mgameboard extends fopAc_ac_c {
         if (this.minigame.bulletNum === 0) {
             for (let i = 0; i < this.minigame.ships.length; i++) {
                 const model = this.shipModels[i];
-                setLightTevColorType(globals, model, this.tevStr, viewerInput.camera);
+                setLightTevColorType(globals, model, this.tevStr, globals.camera);
                 mDoExt_modelUpdateDL(globals, model, renderInstManager, viewerInput, globals.dlst.ui);
             }
         }
@@ -2288,14 +2288,14 @@ class dCloth_packet_c {
             for (let fly = 0; fly < this.flyGridSize; fly++) {
                 transformVec3Mat4w1(scratchVec3a, this.mtx, this.posArr[this.curArr][this.getIndex(fly, hoist)]);
                 transformVec3Mat4w0(scratchVec3b, this.mtx, this.nrmArr[this.getIndex(fly, hoist)]);
-                drawWorldSpaceVector(ctx, viewerInput.camera.clipFromWorldMatrix, scratchVec3a, scratchVec3b, 50);
+                drawWorldSpaceVector(ctx, globals.camera.viewerCamera.clipFromWorldMatrix, scratchVec3a, scratchVec3b, 50);
             }
         }
         */
 
         const template = renderInstManager.pushTemplate();
 
-        dKy_setLight__OnMaterialParams(globals.g_env_light, materialParams, viewerInput.camera);
+        dKy_setLight__OnMaterialParams(globals.g_env_light, materialParams, globals.camera);
         this.flagTex.fillTextureMapping(materialParams.m_TextureMapping[0]);
         this.toonTex.fillTextureMapping(materialParams.m_TextureMapping[1]);
         template.setSamplerBindingsFromTextureMappings(materialParams.m_TextureMapping);
@@ -2303,7 +2303,7 @@ class dCloth_packet_c {
         colorCopy(materialParams.u_Color[ColorKind.C0], this.tevStr.colorC0);
         colorCopy(materialParams.u_Color[ColorKind.C1], this.tevStr.colorK0);
         colorCopy(materialParams.u_Color[ColorKind.C2], this.tevStr.colorK1);
-        mat4.mul(drawParams.u_PosMtx[0], viewerInput.camera.viewMatrix, this.mtx);
+        mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix, this.mtx);
         this.materialHelper.allocateDrawParamsDataOnInst(template, drawParams);
 
         const ddraw = this.ddraw;
@@ -2376,12 +2376,12 @@ class d_a_sie_flag extends fopAc_ac_c {
     }
 
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
-        if (!this.cullingCheck(viewerInput.camera))
+        if (!this.cullingCheck(globals.camera))
             return;
 
         settingTevStruct(globals, LightType.BG0, this.pos, this.tevStr);
         settingTevStruct(globals, LightType.Actor, this.pos, this.clothTevStr);
-        setLightTevColorType(globals, this.model, this.tevStr, viewerInput.camera);
+        setLightTevColorType(globals, this.model, this.tevStr, globals.camera);
         mDoExt_modelUpdateDL(globals, this.model, renderInstManager, viewerInput);
         this.cloth.cloth_draw(globals, renderInstManager, viewerInput);
     }
@@ -2462,12 +2462,12 @@ class d_a_tori_flag extends fopAc_ac_c {
     }
 
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
-        if (!this.cullingCheck(viewerInput.camera))
+        if (!this.cullingCheck(globals.camera))
             return;
 
         settingTevStruct(globals, LightType.BG0, this.pos, this.tevStr);
         settingTevStruct(globals, LightType.Actor, this.pos, this.clothTevStr);
-        setLightTevColorType(globals, this.model, this.tevStr, viewerInput.camera);
+        setLightTevColorType(globals, this.model, this.tevStr, globals.camera);
         mDoExt_modelUpdateDL(globals, this.model, renderInstManager, viewerInput);
         this.cloth.cloth_draw(globals, renderInstManager, viewerInput);
     }
@@ -2762,15 +2762,15 @@ class d_a_majuu_flag extends fopAc_ac_c {
     }
 
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
-        if (!this.cullingCheck(viewerInput.camera))
+        if (!this.cullingCheck(globals.camera))
             return;
 
         // For reference.
         /*
         for (let i = 0; i < this.pointCount; i++) {
             transformVec3Mat4w1(scratchVec3a, this.mtx, this.posArr[0][i]);
-            drawWorldSpacePoint(getDebugOverlayCanvas2D(), viewerInput.camera.clipFromWorldMatrix, scratchVec3a);
-            drawWorldSpaceText(getDebugOverlayCanvas2D(), viewerInput.camera.clipFromWorldMatrix, scratchVec3a, '' + i);
+            drawWorldSpacePoint(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, scratchVec3a);
+            drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, scratchVec3a, '' + i);
         }
         */
 
@@ -2783,7 +2783,7 @@ class d_a_majuu_flag extends fopAc_ac_c {
 
         const template = renderInstManager.pushTemplate();
 
-        dKy_setLight__OnMaterialParams(globals.g_env_light, materialParams, viewerInput.camera);
+        dKy_setLight__OnMaterialParams(globals.g_env_light, materialParams, globals.camera);
         this.flagTex.fillTextureMapping(materialParams.m_TextureMapping[0]);
         this.toonTex.fillTextureMapping(materialParams.m_TextureMapping[1]);
         template.setSamplerBindingsFromTextureMappings(materialParams.m_TextureMapping);
@@ -2791,7 +2791,7 @@ class d_a_majuu_flag extends fopAc_ac_c {
         colorCopy(materialParams.u_Color[ColorKind.C0], this.tevStr.colorC0);
         colorCopy(materialParams.u_Color[ColorKind.C1], this.tevStr.colorK0);
         colorCopy(materialParams.u_Color[ColorKind.C2], this.tevStr.colorK1);
-        mat4.mul(drawParams.u_PosMtx[0], viewerInput.camera.viewMatrix, this.mtx);
+        mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix, this.mtx);
         this.materialHelper.allocateDrawParamsDataOnInst(template, drawParams);
 
         const ddraw = this.ddraw;
@@ -3183,16 +3183,16 @@ class d_a_kamome extends fopAc_ac_c {
         if (this.noDraw || this.switch_id !== 0)
             return;
 
-        if (!this.cullingCheck(viewerInput.camera))
+        if (!this.cullingCheck(globals.camera))
             return;
 
         settingTevStruct(globals, LightType.Actor, this.pos, this.tevStr);
-        setLightTevColorType(globals, this.morf.model, this.tevStr, viewerInput.camera);
+        setLightTevColorType(globals, this.morf.model, this.tevStr, globals.camera);
         this.morf.entryDL(globals, renderInstManager, viewerInput);
 
-        // drawWorldSpaceLine(getDebugOverlayCanvas2D(), viewerInput.camera.clipFromWorldMatrix, this.pos, this.targetPos, Green, 2);
-        // drawWorldSpacePoint(getDebugOverlayCanvas2D(), viewerInput.camera.clipFromWorldMatrix, this.pos, Magenta, 8);
-        // drawWorldSpacePoint(getDebugOverlayCanvas2D(), viewerInput.camera.clipFromWorldMatrix, this.targetPos, Yellow, 6);
+        // drawWorldSpaceLine(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.pos, this.targetPos, Green, 2);
+        // drawWorldSpacePoint(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.pos, Magenta, 8);
+        // drawWorldSpacePoint(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.targetPos, Yellow, 6);
 
         // shadow
     }
@@ -3437,11 +3437,11 @@ class d_a_obj_ikada extends fopAc_ac_c implements ModeFuncExec<d_a_obj_ikada_mod
     }
 
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
-        if (!this.cullingCheck(viewerInput.camera))
+        if (!this.cullingCheck(globals.camera))
             return;
 
         settingTevStruct(globals, LightType.Actor, this.pos, this.tevStr);
-        setLightTevColorType(globals, this.model, this.tevStr, viewerInput.camera);
+        setLightTevColorType(globals, this.model, this.tevStr, globals.camera);
 
         if (this.isSv()) {
             // update bck
@@ -3539,7 +3539,7 @@ class d_a_obj_ikada extends fopAc_ac_c implements ModeFuncExec<d_a_obj_ikada_mod
         this.model.calcAnim();
 
         if (this.isShip()) {
-            if (this.velocityFwd > 2.0 && this.cullingCheck(globals.camera.viewerCamera)) {
+            if (this.velocityFwd > 2.0 && this.cullingCheck(globals.camera)) {
                 this.setWave(globals, deltaTimeFrames);
             } else {
                 this.waveL!.remove();
@@ -3968,22 +3968,22 @@ class d_a_oship extends fopAc_ac_c implements ModeFuncExec<d_a_oship_mode> {
     };
 
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
-        if (!this.cullingCheck(viewerInput.camera))
+        if (!this.cullingCheck(globals.camera))
             return;
 
         settingTevStruct(globals, LightType.Actor, this.pos, this.tevStr);
-        setLightTevColorType(globals, this.model, this.tevStr, viewerInput.camera);
+        setLightTevColorType(globals, this.model, this.tevStr, globals.camera);
         const specScale = 0.75;
         dDlst_texSpecmapST(this.effectMtx, globals, this.pos, this.tevStr, specScale);
         mDoExt_modelEntryDL(globals, this.model, renderInstManager, viewerInput);
 
         /*
-        drawWorldSpaceText(getDebugOverlayCanvas2D(), viewerInput.camera.clipFromWorldMatrix, this.pos, `PId: ${this.processId}`, 0, White, { outline: 2 });
-        drawWorldSpaceText(getDebugOverlayCanvas2D(), viewerInput.camera.clipFromWorldMatrix, this.pos, `Mode: ${d_a_oship_mode[this.curMode]}`, 14, White, { outline: 2 });
-        drawWorldSpaceText(getDebugOverlayCanvas2D(), viewerInput.camera.clipFromWorldMatrix, this.pos, `Aim  : ${hexzero0x(this.aimRotX, 4)} ${hexzero0x(this.aimRotY, 4)}`, 14*2, White, { outline: 2 });
-        drawWorldSpaceText(getDebugOverlayCanvas2D(), viewerInput.camera.clipFromWorldMatrix, this.pos, `Aim T: ${hexzero0x(this.aimRotXTarget, 4)} ${hexzero0x(this.aimRotYTarget, 4)}`, 14*3, White, { outline: 2 });
-        drawWorldSpaceText(getDebugOverlayCanvas2D(), viewerInput.camera.clipFromWorldMatrix, this.pos, `Tgt  : ${this.targetPos[0].toFixed(2)} ${this.targetPos[1].toFixed(2)} ${this.targetPos[2].toFixed(2)}`, 14*4, White, { outline: 2 });
-        drawWorldSpacePoint(getDebugOverlayCanvas2D(), viewerInput.camera.clipFromWorldMatrix, this.targetPos, Green, 10);
+        drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.pos, `PId: ${this.processId}`, 0, White, { outline: 2 });
+        drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.pos, `Mode: ${d_a_oship_mode[this.curMode]}`, 14, White, { outline: 2 });
+        drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.pos, `Aim  : ${hexzero0x(this.aimRotX, 4)} ${hexzero0x(this.aimRotY, 4)}`, 14*2, White, { outline: 2 });
+        drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.pos, `Aim T: ${hexzero0x(this.aimRotXTarget, 4)} ${hexzero0x(this.aimRotYTarget, 4)}`, 14*3, White, { outline: 2 });
+        drawWorldSpaceText(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.pos, `Tgt  : ${this.targetPos[0].toFixed(2)} ${this.targetPos[1].toFixed(2)} ${this.targetPos[2].toFixed(2)}`, 14*4, White, { outline: 2 });
+        drawWorldSpacePoint(getDebugOverlayCanvas2D(), globals.camera.viewerCamera.clipFromWorldMatrix, this.targetPos, Green, 10);
         */
     }
 
@@ -4105,7 +4105,7 @@ class d_a_oship extends fopAc_ac_c implements ModeFuncExec<d_a_oship_mode> {
         this.setMtx(globals, deltaTimeFrames);
 
         this.visible
-        if (this.velocityFwd > 2.0 && this.cullingCheck(globals.camera.viewerCamera)) {
+        if (this.velocityFwd > 2.0 && this.cullingCheck(globals.camera)) {
             this.setWave(globals, deltaTimeFrames);
         } else {
             this.waveL.remove();
@@ -4245,7 +4245,7 @@ class d_a_obj_flame extends fopAc_ac_c {
         super.draw(globals, renderInstManager, viewerInput);
 
         settingTevStruct(globals, LightType.Actor, this.pos, this.tevStr);
-        setLightTevColorType(globals, this.model, this.tevStr, viewerInput.camera);
+        setLightTevColorType(globals, this.model, this.tevStr, globals.camera);
 
         this.btkAnm.entry(this.model);
         if (this.brkAnm !== null)
@@ -4797,8 +4797,8 @@ class d_a_npc_ls1 extends fopNpc_npc_c {
         super.draw(globals, renderInstManager, viewerInput);
 
         settingTevStruct(globals, LightType.Actor, this.pos, this.tevStr);
-        setLightTevColorType(globals, this.morf.model, this.tevStr, viewerInput.camera);
-        setLightTevColorType(globals, this.handModel, this.tevStr, viewerInput.camera);
+        setLightTevColorType(globals, this.morf.model, this.tevStr, globals.camera);
+        setLightTevColorType(globals, this.handModel, this.tevStr, globals.camera);
 
         // this.btkAnim.entry(this.morf.model, this.btkFrame);
         // this.btpAnim.entry(this.morf.model, this.btpFrame);
@@ -4808,7 +4808,7 @@ class d_a_npc_ls1 extends fopNpc_npc_c {
         mDoExt_modelEntryDL(globals, this.handModel, renderInstManager, viewerInput);
 
         if (this.itemModel) {
-            setLightTevColorType(globals, this.itemModel, this.tevStr, viewerInput.camera);
+            setLightTevColorType(globals, this.itemModel, this.tevStr, globals.camera);
             mDoExt_modelEntryDL(globals, this.itemModel, renderInstManager, viewerInput);
         }
 
@@ -5031,7 +5031,7 @@ class d_a_npc_zl1 extends fopNpc_npc_c {
         super.draw(globals, renderInstManager, viewerInput);
 
         settingTevStruct(globals, LightType.Actor, this.pos, this.tevStr);
-        setLightTevColorType(globals, this.morf.model, this.tevStr, viewerInput.camera);
+        setLightTevColorType(globals, this.morf.model, this.tevStr, globals.camera);
 
         if (this.btpAnim.anm) this.btpAnim.entry(this.morf.model);
         if (this.btkAnim.anm) this.btkAnim.entry(this.morf.model);
@@ -5302,15 +5302,15 @@ class d_a_py_lk extends fopAc_ac_c implements ModeFuncExec<d_a_py_lk_mode> {
             this.model.setShapeVisible(LkModelShape.Scabbard, false);
             this.model.setShapeVisible(LkModelShape.Buckle, false);
 
-            setLightTevColorType(globals, this.modelKatsura, this.tevStr, viewerInput.camera);
+            setLightTevColorType(globals, this.modelKatsura, this.tevStr, globals.camera);
             mDoExt_modelEntryDL(globals, this.modelKatsura, renderInstManager, viewerInput);
         }
 
         if (this.equippedItem === LkEquipItem.Sword) {
-            setLightTevColorType(globals, this.equippedItemModel!, this.tevStr, viewerInput.camera);
+            setLightTevColorType(globals, this.equippedItemModel!, this.tevStr, globals.camera);
             mDoExt_modelEntryDL(globals, this.equippedItemModel!, renderInstManager, viewerInput);
 
-            setLightTevColorType(globals, this.modelSwordHilt, this.tevStr, viewerInput.camera);
+            setLightTevColorType(globals, this.modelSwordHilt, this.tevStr, globals.camera);
             mDoExt_modelEntryDL(globals, this.modelSwordHilt, renderInstManager, viewerInput);
         }
 
@@ -5325,7 +5325,7 @@ class d_a_py_lk extends fopAc_ac_c implements ModeFuncExec<d_a_py_lk_mode> {
         if (this.anmBtp.anm) this.anmBtp.entry(this.model);
         if (this.anmBtk.anm) this.anmBtk.entry(this.model);
 
-        setLightTevColorType(globals, this.model, this.tevStr, viewerInput.camera);
+        setLightTevColorType(globals, this.model, this.tevStr, globals.camera);
         mDoExt_modelEntryDL(globals, this.model, renderInstManager, viewerInput);
     }
 

--- a/src/ZeldaWindWaker/d_a_sea.ts
+++ b/src/ZeldaWindWaker/d_a_sea.ts
@@ -568,7 +568,7 @@ export class d_a_sea extends fopAc_ac_c {
         materialHelper.setOnRenderInst(renderInstManager.gfxRenderCache, renderInst);
         renderInst.setSamplerBindingsFromTextureMappings(materialParams.m_TextureMapping);
         materialHelper.allocateMaterialParamsDataOnInst(renderInst, materialParams);
-        mat4.copy(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix);
+        mat4.copy(drawParams.u_PosMtx[0], globals.camera.viewMatrix);
         materialHelper.allocateDrawParamsDataOnInst(renderInst, drawParams);
         renderInstManager.submitRenderInst(renderInst);
     }

--- a/src/ZeldaWindWaker/d_a_sea.ts
+++ b/src/ZeldaWindWaker/d_a_sea.ts
@@ -562,13 +562,13 @@ export class d_a_sea extends fopAc_ac_c {
         this.texWyurayura.fillTextureMapping(materialParams.m_TextureMapping[1]);
         this.texSeaBTI.fillTextureMapping(materialParams.m_TextureMapping[2]);
         materialParams.m_TextureMapping[2].lodBias = 1.0;
-        dKy_GxFog_sea_set(envLight, materialParams.u_FogBlock, viewerInput.camera);
+        dKy_GxFog_sea_set(envLight, materialParams.u_FogBlock, globals.camera);
 
         const renderInst = this.ddraw.endDrawAndMakeRenderInst(renderInstManager);
         materialHelper.setOnRenderInst(renderInstManager.gfxRenderCache, renderInst);
         renderInst.setSamplerBindingsFromTextureMappings(materialParams.m_TextureMapping);
         materialHelper.allocateMaterialParamsDataOnInst(renderInst, materialParams);
-        mat4.copy(drawParams.u_PosMtx[0], viewerInput.camera.viewMatrix);
+        mat4.copy(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix);
         materialHelper.allocateDrawParamsDataOnInst(renderInst, drawParams);
         renderInstManager.submitRenderInst(renderInst);
     }

--- a/src/ZeldaWindWaker/d_demo.ts
+++ b/src/ZeldaWindWaker/d_demo.ts
@@ -50,7 +50,7 @@ class dDemo_camera_c extends TCamera {
         const camera = this.globals.camera;
         if (!camera)
             return 0.0;
-        return camera.viewerCamera.near;
+        return camera.near;
     }
 
     public override JSGSetProjectionNear(v: number) {
@@ -62,7 +62,7 @@ class dDemo_camera_c extends TCamera {
         const camera = this.globals.camera;
         if (!camera)
             return 1.0;
-        return camera.viewerCamera.far;
+        return camera.far;
     }
 
 
@@ -76,7 +76,7 @@ class dDemo_camera_c extends TCamera {
         const camera = this.globals.camera;
         if (!camera)
             return 60.0;
-        return camera.viewerCamera.fovY;
+        return camera.fovY;
     }
 
 
@@ -90,7 +90,7 @@ class dDemo_camera_c extends TCamera {
         const camera = this.globals.camera;
         if (!camera)
             return 1.3333;
-        return camera.viewerCamera.aspect;
+        return camera.aspect;
     }
 
 
@@ -101,7 +101,7 @@ class dDemo_camera_c extends TCamera {
 
 
     public override JSGGetViewPosition(dst: vec3) {
-        vec3.copy(dst, this.globals.cameraPosition);
+        vec3.copy(dst, this.globals.camera.cameraPos);
     }
 
 
@@ -115,7 +115,7 @@ class dDemo_camera_c extends TCamera {
         const camera = this.globals.camera;
         if (!camera)
             vec3.set(dst, 0, 1, 0);
-        getMatrixAxisY(dst, camera.viewerCamera.viewMatrix); // @TODO: Double check that this is correct
+        vec3.copy(dst, camera.cameraUp);
     }
 
 
@@ -129,7 +129,7 @@ class dDemo_camera_c extends TCamera {
         const camera = this.globals.camera;
         if (!camera)
             vec3.zero(dst);
-        vec3.add(dst, this.globals.cameraPosition, this.globals.cameraFwd);
+        vec3.add(dst, this.globals.camera.cameraPos, this.globals.camera.cameraFwd);
     }
 
 
@@ -143,7 +143,7 @@ class dDemo_camera_c extends TCamera {
         const camera = this.globals.camera;
         if (!camera)
             return 0.0;
-        return this.roll; // HACK: Instead of actually computing roll (complicated), just assume no one else is modifying it
+        return camera.roll;
     }
 
 

--- a/src/ZeldaWindWaker/d_demo.ts
+++ b/src/ZeldaWindWaker/d_demo.ts
@@ -50,7 +50,7 @@ class dDemo_camera_c extends TCamera {
         const camera = this.globals.camera;
         if (!camera)
             return 0.0;
-        return camera.near;
+        return camera.viewerCamera.near;
     }
 
     public override JSGSetProjectionNear(v: number) {
@@ -62,7 +62,7 @@ class dDemo_camera_c extends TCamera {
         const camera = this.globals.camera;
         if (!camera)
             return 1.0;
-        return camera.far;
+        return camera.viewerCamera.far;
     }
 
 
@@ -76,7 +76,7 @@ class dDemo_camera_c extends TCamera {
         const camera = this.globals.camera;
         if (!camera)
             return 60.0;
-        return camera.fovY;
+        return camera.viewerCamera.fovY;
     }
 
 
@@ -90,7 +90,7 @@ class dDemo_camera_c extends TCamera {
         const camera = this.globals.camera;
         if (!camera)
             return 1.3333;
-        return camera.aspect;
+        return camera.viewerCamera.aspect;
     }
 
 
@@ -115,7 +115,7 @@ class dDemo_camera_c extends TCamera {
         const camera = this.globals.camera;
         if (!camera)
             vec3.set(dst, 0, 1, 0);
-        getMatrixAxisY(dst, camera.viewMatrix); // @TODO: Double check that this is correct
+        getMatrixAxisY(dst, camera.viewerCamera.viewMatrix); // @TODO: Double check that this is correct
     }
 
 

--- a/src/ZeldaWindWaker/d_drawlist.ts
+++ b/src/ZeldaWindWaker/d_drawlist.ts
@@ -132,7 +132,7 @@ class dDlst_alphaModel_c {
 
             if (data.type === dDlst_alphaModel__Type.Bonbori) {
                 this.bonboriShape.setOnRenderInst(template);
-                mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix, data.mtx);
+                mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewMatrix, data.mtx);
                 this.materialHelperBackRevZ.allocateDrawParamsDataOnInst(template, drawParams);
 
                 materialParams.u_Color[ColorKind.MAT0].a = data.alpha / 0xFF;

--- a/src/ZeldaWindWaker/d_drawlist.ts
+++ b/src/ZeldaWindWaker/d_drawlist.ts
@@ -132,7 +132,7 @@ class dDlst_alphaModel_c {
 
             if (data.type === dDlst_alphaModel__Type.Bonbori) {
                 this.bonboriShape.setOnRenderInst(template);
-                mat4.mul(drawParams.u_PosMtx[0], viewerInput.camera.viewMatrix, data.mtx);
+                mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix, data.mtx);
                 this.materialHelperBackRevZ.allocateDrawParamsDataOnInst(template, drawParams);
 
                 materialParams.u_Color[ColorKind.MAT0].a = data.alpha / 0xFF;

--- a/src/ZeldaWindWaker/d_kankyo.ts
+++ b/src/ZeldaWindWaker/d_kankyo.ts
@@ -600,10 +600,10 @@ function GxFogSet_Sub(fog: FogBlock, tevStr: { fogStartZ: number, fogEndZ: numbe
     colorCopy(fog.Color, fogColor);
 
     // Empirically decided.
-    const fogFarPlane = Number.isFinite(camera.viewerCamera.far) ? camera.viewerCamera.far : 100000;
+    const fogFarPlane = Number.isFinite(camera.far) ? camera.far : 100000;
 
-    const type = camera.viewerCamera.isOrthographic ? FogType.ORTHO_LIN : FogType.PERSP_LIN;
-    fogBlockSet(fog, type, tevStr.fogStartZ, tevStr.fogEndZ, camera.viewerCamera.near, fogFarPlane);
+    const type = camera.isOrthographic ? FogType.ORTHO_LIN : FogType.PERSP_LIN;
+    fogBlockSet(fog, type, tevStr.fogStartZ, tevStr.fogEndZ, camera.near, fogFarPlane);
 }
 
 export function dKy_GxFog_set(envLight: dScnKy_env_light_c, fog: FogBlock, camera: dCamera_c): void {
@@ -618,12 +618,12 @@ export function dKy_GxFog_sea_set(envLight: dScnKy_env_light_c, fog: FogBlock, c
 // have global state, we have to do this here.
 export function dKy_setLight__OnModelInstance(envLight: dScnKy_env_light_c, modelInstance: J3DModelInstance, camera: dCamera_c): void {
     for (let i = 0; i < 2; i++)
-        lightSetFromWorldLight(modelInstance.getGXLightReference(i), envLight.lightStatus[i], camera.viewerCamera);
+        lightSetFromWorldLight(modelInstance.getGXLightReference(i), envLight.lightStatus[i], camera);
 }
 
 export function dKy_setLight__OnMaterialParams(envLight: dScnKy_env_light_c, materialParams: MaterialParams, camera: dCamera_c): void {
     for (let i = 0; i < 2; i++)
-        lightSetFromWorldLight(materialParams.u_Lights[i], envLight.lightStatus[i], camera.viewerCamera);
+        lightSetFromWorldLight(materialParams.u_Lights[i], envLight.lightStatus[i], camera);
 }
 
 export function setLightTevColorType(globals: dGlobals, modelInstance: J3DModelInstance, tevStr: dKy_tevstr_c, camera: dCamera_c): void {
@@ -634,10 +634,10 @@ export function setLightTevColorType(globals: dGlobals, modelInstance: J3DModelI
     }
 
     const light0 = modelInstance.getGXLightReference(0);
-    lightSetFromWorldLight(light0, tevStr.lightObj, camera.viewerCamera);
+    lightSetFromWorldLight(light0, tevStr.lightObj, camera);
 
     const light1 = modelInstance.getGXLightReference(1);
-    lightSetFromWorldLight(light1, envLight.lightStatus[1], camera.viewerCamera);
+    lightSetFromWorldLight(light1, envLight.lightStatus[1], camera);
 
     // if (toon_proc_check() == 0)
 
@@ -690,7 +690,7 @@ function setSunpos(envLight: dScnKy_env_light_c, cameraPos: vec3): void {
 function drawKankyo(globals: dGlobals): void {
     const envLight = globals.g_env_light;
 
-    setSunpos(envLight, globals.cameraPosition);
+    setSunpos(envLight, globals.camera.cameraPos);
     SetBaseLight(globals);
     setLight(globals, envLight);
 }

--- a/src/ZeldaWindWaker/d_kankyo.ts
+++ b/src/ZeldaWindWaker/d_kankyo.ts
@@ -15,7 +15,7 @@ import { cLib_addCalc, cLib_addCalc2, cM_rndF } from "./SComponent.js";
 import { ThunderMode, ThunderState, dKankyo__CommonTextures, dKankyo__Windline, dKankyo_housi_Packet, dKankyo_moya_Packet, dKankyo_rain_Packet, dKankyo_star_Packet, dKankyo_sun_Packet, dKankyo_vrkumo_Packet, dKankyo_wave_Packet, dKy_wave_chan_init, dKyr__sun_arrival_check, dKyw_rain_set, dKyw_wether_draw, dKyw_wether_draw2, dKyw_wether_move, dKyw_wether_move_draw, dKyw_wether_move_draw2, dKyw_wind_set } from "./d_kankyo_wether.js";
 import { dStage_stagInfo_GetSTType, stage_envr_info_class, stage_palet_info_class, stage_palet_info_class__DifAmb, stage_pselect_info_class, stage_vrbox_info_class } from "./d_stage.js";
 import { cPhs__Status, fGlobals, fopKyM_Create, fpcPf__Register, fpc_bs__Constructor, kankyo_class } from "./framework.js";
-import { dGlobals } from "./Main.js";
+import { dCamera_c, dGlobals } from "./Main.js";
 import { dProcName_e } from "./d_procname.js";
 
 export const enum LightType {
@@ -596,37 +596,37 @@ export function dKy_tevstr_init(tevstr: dKy_tevstr_c, roomNo: number, envrOverri
     tevstr.envrOverride = envrOverride;
 }
 
-function GxFogSet_Sub(fog: FogBlock, tevStr: { fogStartZ: number, fogEndZ: number, fogCol: Color }, camera: Camera, fogColor = tevStr.fogCol) {
+function GxFogSet_Sub(fog: FogBlock, tevStr: { fogStartZ: number, fogEndZ: number, fogCol: Color }, camera: dCamera_c, fogColor = tevStr.fogCol) {
     colorCopy(fog.Color, fogColor);
 
     // Empirically decided.
-    const fogFarPlane = Number.isFinite(camera.far) ? camera.far : 100000;
+    const fogFarPlane = Number.isFinite(camera.viewerCamera.far) ? camera.viewerCamera.far : 100000;
 
-    const type = camera.isOrthographic ? FogType.ORTHO_LIN : FogType.PERSP_LIN;
-    fogBlockSet(fog, type, tevStr.fogStartZ, tevStr.fogEndZ, camera.near, fogFarPlane);
+    const type = camera.viewerCamera.isOrthographic ? FogType.ORTHO_LIN : FogType.PERSP_LIN;
+    fogBlockSet(fog, type, tevStr.fogStartZ, tevStr.fogEndZ, camera.viewerCamera.near, fogFarPlane);
 }
 
-export function dKy_GxFog_set(envLight: dScnKy_env_light_c, fog: FogBlock, camera: Camera): void {
+export function dKy_GxFog_set(envLight: dScnKy_env_light_c, fog: FogBlock, camera: dCamera_c): void {
     GxFogSet_Sub(fog, envLight, camera);
 }
 
-export function dKy_GxFog_sea_set(envLight: dScnKy_env_light_c, fog: FogBlock, camera: Camera): void {
+export function dKy_GxFog_sea_set(envLight: dScnKy_env_light_c, fog: FogBlock, camera: dCamera_c): void {
     GxFogSet_Sub(fog, envLight, camera, envLight.vrUsoUmiCol);
 }
 
 // This is effectively the global state that dKy_setLight sets up, but since we don't
 // have global state, we have to do this here.
-export function dKy_setLight__OnModelInstance(envLight: dScnKy_env_light_c, modelInstance: J3DModelInstance, camera: Camera): void {
+export function dKy_setLight__OnModelInstance(envLight: dScnKy_env_light_c, modelInstance: J3DModelInstance, camera: dCamera_c): void {
     for (let i = 0; i < 2; i++)
-        lightSetFromWorldLight(modelInstance.getGXLightReference(i), envLight.lightStatus[i], camera);
+        lightSetFromWorldLight(modelInstance.getGXLightReference(i), envLight.lightStatus[i], camera.viewerCamera);
 }
 
-export function dKy_setLight__OnMaterialParams(envLight: dScnKy_env_light_c, materialParams: MaterialParams, camera: Camera): void {
+export function dKy_setLight__OnMaterialParams(envLight: dScnKy_env_light_c, materialParams: MaterialParams, camera: dCamera_c): void {
     for (let i = 0; i < 2; i++)
-        lightSetFromWorldLight(materialParams.u_Lights[i], envLight.lightStatus[i], camera);
+        lightSetFromWorldLight(materialParams.u_Lights[i], envLight.lightStatus[i], camera.viewerCamera);
 }
 
-export function setLightTevColorType(globals: dGlobals, modelInstance: J3DModelInstance, tevStr: dKy_tevstr_c, camera: Camera): void {
+export function setLightTevColorType(globals: dGlobals, modelInstance: J3DModelInstance, tevStr: dKy_tevstr_c, camera: dCamera_c): void {
     const envLight = globals.g_env_light;
 
     if (tevStr.lightMode !== LightMode.BG) {
@@ -634,10 +634,10 @@ export function setLightTevColorType(globals: dGlobals, modelInstance: J3DModelI
     }
 
     const light0 = modelInstance.getGXLightReference(0);
-    lightSetFromWorldLight(light0, tevStr.lightObj, camera);
+    lightSetFromWorldLight(light0, tevStr.lightObj, camera.viewerCamera);
 
     const light1 = modelInstance.getGXLightReference(1);
-    lightSetFromWorldLight(light1, envLight.lightStatus[1], camera);
+    lightSetFromWorldLight(light1, envLight.lightStatus[1], camera.viewerCamera);
 
     // if (toon_proc_check() == 0)
 

--- a/src/ZeldaWindWaker/d_kankyo_wether.ts
+++ b/src/ZeldaWindWaker/d_kankyo_wether.ts
@@ -161,11 +161,11 @@ export function loadRawTexture(globals: dGlobals, data: ArrayBufferSlice, width:
 const materialParams = new MaterialParams();
 const drawParams = new DrawParams();
 
-function submitScratchRenderInst(renderInstManager: GfxRenderInstManager, materialHelper: GXMaterialHelperGfx, renderInst: GfxRenderInst, viewerInput: ViewerRenderInput, materialParams_ = materialParams, drawParams_ = drawParams): void {
+function submitScratchRenderInst(globals: dGlobals, renderInstManager: GfxRenderInstManager, materialHelper: GXMaterialHelperGfx, renderInst: GfxRenderInst, materialParams_ = materialParams, drawParams_ = drawParams): void {
     materialHelper.setOnRenderInst(renderInstManager.gfxRenderCache, renderInst);
     renderInst.setSamplerBindingsFromTextureMappings(materialParams_.m_TextureMapping);
     materialHelper.allocateMaterialParamsDataOnInst(renderInst, materialParams_);
-    mat4.copy(drawParams_.u_PosMtx[0], viewerInput.camera.viewMatrix);
+    mat4.copy(drawParams_.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix);
     materialHelper.allocateDrawParamsDataOnInst(renderInst, drawParams_);
     renderInstManager.submitRenderInst(renderInst);
 }
@@ -338,7 +338,7 @@ export class dKankyo_sun_Packet {
                 if (i === 1)
                     moonSize *= 1.7;
 
-                computeMatrixWithoutTranslation(scratchMatrix, viewerInput.camera.worldMatrix);
+                computeMatrixWithoutTranslation(scratchMatrix, globals.camera.viewerCamera.worldMatrix);
                 mat4.rotateZ(scratchMatrix, scratchMatrix, MathConstants.DEG_TO_RAD * (45 + (360.0 * ((moonPitch - camPitch) / -8.0))));
 
                 if (i === 0) {
@@ -369,7 +369,7 @@ export class dKankyo_sun_Packet {
                 }
 
                 const renderInst = ddraw.makeRenderInst(renderInstManager);
-                submitScratchRenderInst(renderInstManager, this.materialHelperSunMoon, renderInst, viewerInput);
+                submitScratchRenderInst(globals, renderInstManager, this.materialHelperSunMoon, renderInst);
             }
         }
 
@@ -377,7 +377,7 @@ export class dKankyo_sun_Packet {
             const sunPos = this.sunPos;
 
             const sunPitch = vecPitch(sunPos);
-            computeMatrixWithoutTranslation(scratchMatrix, viewerInput.camera.worldMatrix);
+            computeMatrixWithoutTranslation(scratchMatrix, globals.camera.viewerCamera.worldMatrix);
             mat4.rotateZ(scratchMatrix, scratchMatrix, MathConstants.DEG_TO_RAD * (-50 + (360.0 * ((sunPitch - camPitch) / -8.0))));
 
             let sunSizeBase = 575.0;
@@ -402,7 +402,7 @@ export class dKankyo_sun_Packet {
                 this.drawSquare(ddraw, scratchMatrix, sunPos, sunSize, 1.0, 1.0);
                 const renderInst = ddraw.makeRenderInst(renderInstManager);
 
-                submitScratchRenderInst(renderInstManager, this.materialHelperSunMoon, renderInst, viewerInput);
+                submitScratchRenderInst(globals, renderInstManager, this.materialHelperSunMoon, renderInst);
             }
         }
     }
@@ -428,7 +428,7 @@ export class dKankyo_sun_Packet {
 
        const envLight = globals.g_env_light;
 
-        computeMatrixWithoutTranslation(scratchMatrix, viewerInput.camera.worldMatrix);
+        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.viewerCamera.worldMatrix);
 
         if (this.drawLenzInSky)
             renderInstManager.setCurrentList(globals.dlst.sky[1]);
@@ -493,7 +493,7 @@ export class dKankyo_sun_Packet {
         colorCopy(materialParams.u_Color[ColorKind.C0], this.lensflareColor, lensflareAlpha);
 
         const renderInst = ddraw.makeRenderInst(renderInstManager);
-        submitScratchRenderInst(renderInstManager, this.materialHelperLenzflareSolid, renderInst, viewerInput);
+        submitScratchRenderInst(globals, renderInstManager, this.materialHelperLenzflareSolid, renderInst);
 
         mat4.rotateZ(scratchMatrix, scratchMatrix, this.lensflareAngle);
 
@@ -536,7 +536,7 @@ export class dKankyo_sun_Packet {
             materialParams.u_Color[ColorKind.C0].a *= alpha;
             colorFromRGBA8(materialParams.u_Color[ColorKind.C1], 0xFF91491E);
 
-            submitScratchRenderInst(renderInstManager, this.materialHelperLenzflare, renderInst, viewerInput);
+            submitScratchRenderInst(globals, renderInstManager, this.materialHelperLenzflare, renderInst);
         }
     }
 
@@ -739,7 +739,7 @@ export class dKankyo_vrkumo_Packet {
 
             if (ddraw.hasIndicesToDraw()) {
                 const renderInst = ddraw.makeRenderInst(renderInstManager);
-                submitScratchRenderInst(renderInstManager, this.materialHelper, renderInst, viewerInput);
+                submitScratchRenderInst(globals, renderInstManager, this.materialHelper, renderInst);
             }
         }
 
@@ -809,7 +809,7 @@ export class dKankyo_rain_Packet {
         const envLight = globals.g_env_light;
         const ddraw = this.ddraw;
 
-        computeMatrixWithoutTranslation(scratchMatrix, viewerInput.camera.worldMatrix);
+        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.viewerCamera.worldMatrix);
 
         renderInstManager.setCurrentList(globals.dlst.wetherEffect);
 
@@ -881,7 +881,7 @@ export class dKankyo_rain_Packet {
 
         if (ddraw.hasIndicesToDraw()) {
             const renderInst = ddraw.makeRenderInst(renderInstManager);
-            submitScratchRenderInst(renderInstManager, this.materialHelperRain, renderInst, viewerInput);
+            submitScratchRenderInst(globals, renderInstManager, this.materialHelperRain, renderInst);
         }
     }
 
@@ -949,7 +949,7 @@ export class dKankyo_rain_Packet {
         ddraw.end();
 
         const renderInst = ddraw.makeRenderInst(renderInstManager);
-        submitScratchRenderInst(renderInstManager, this.materialHelperSibuki, renderInst, viewerInput);
+        submitScratchRenderInst(globals, renderInstManager, this.materialHelperSibuki, renderInst);
     }
 
     public draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
@@ -1061,7 +1061,7 @@ export class dKankyo_wave_Packet {
             return;
 
         const ddraw = this.ddraw;
-        computeMatrixWithoutTranslation(scratchMatrix, viewerInput.camera.worldMatrix);
+        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.viewerCamera.worldMatrix);
 
         renderInstManager.setCurrentList(globals.dlst.wetherEffect);
 
@@ -1071,7 +1071,7 @@ export class dKankyo_wave_Packet {
         else
             this.texUsonami.fillTextureMapping(materialParams.m_TextureMapping[0]);
 
-        dKy_GxFog_sea_set(envLight, materialParams.u_FogBlock, viewerInput.camera);
+        dKy_GxFog_sea_set(envLight, materialParams.u_FogBlock, globals.camera);
 
         ddraw.beginDraw(globals.modelCache.cache);
         ddraw.begin(GX.Command.DRAW_QUADS, 4 * envLight.waveCount);
@@ -1130,7 +1130,7 @@ export class dKankyo_wave_Packet {
 
         if (ddraw.hasIndicesToDraw()) {
             const renderInst = ddraw.makeRenderInst(renderInstManager);
-            submitScratchRenderInst(renderInstManager, this.materialHelper, renderInst, viewerInput);
+            submitScratchRenderInst(globals, renderInstManager, this.materialHelper, renderInst);
         }
     }
 
@@ -1211,7 +1211,7 @@ export class dKankyo_star_Packet {
         else
             renderInstManager.setCurrentList(globals.dlst.sky[1]);
 
-        dKy_GxFog_sea_set(envLight, materialParams.u_FogBlock, viewerInput.camera);
+        dKy_GxFog_sea_set(envLight, materialParams.u_FogBlock, globals.camera);
 
         ddraw.beginDraw(globals.modelCache.cache);
         ddraw.begin(GX.Command.DRAW_TRIANGLES, 6 * envLight.starCount);
@@ -1226,7 +1226,7 @@ export class dKankyo_star_Packet {
         vec3.set(scratchVec3c, starSize, -0.5 * starSize, 0.0);
         vec3.set(scratchVec3d, -starSize, -0.5 * starSize, 0.0);
 
-        computeMatrixWithoutTranslation(scratchMatrix, viewerInput.camera.worldMatrix);
+        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.viewerCamera.worldMatrix);
         mat4.rotateZ(scratchMatrix, scratchMatrix, this.rot * MathConstants.DEG_TO_RAD);
 
         vec3.transformMat4(scratchVec3b, scratchVec3b, scratchMatrix);
@@ -1234,7 +1234,7 @@ export class dKankyo_star_Packet {
         vec3.transformMat4(scratchVec3d, scratchVec3d, scratchMatrix);
 
         // Projected moon position.
-        mDoLib_projectFB(scratchVec3e, envLight.moonPos, viewerInput);
+        mDoLib_projectFB(scratchVec3e, envLight.moonPos, globals.camera.viewerCamera, viewerInput);
 
         let radius = 0.0, angle = -Math.PI, angleIncr = 0.0;
         for (let i = 0; i < envLight.starCount; i++) {
@@ -1265,7 +1265,7 @@ export class dKankyo_star_Packet {
 
             vec3.add(scratchVec3a, scratchVec3a, globals.cameraPosition);
 
-            mDoLib_projectFB(scratchVec3, scratchVec3a, viewerInput);
+            mDoLib_projectFB(scratchVec3, scratchVec3a, globals.camera.viewerCamera, viewerInput);
             const distToMoon = vec3.dist(scratchVec3, scratchVec3e);
             if (distToMoon < 80.0)
                 continue;
@@ -1313,7 +1313,7 @@ export class dKankyo_star_Packet {
 
         if (ddraw.hasIndicesToDraw()) {
             const renderInst = ddraw.makeRenderInst(renderInstManager);
-            submitScratchRenderInst(renderInstManager, this.materialHelper, renderInst, viewerInput);
+            submitScratchRenderInst(globals, renderInstManager, this.materialHelper, renderInst);
         }
     }
 
@@ -1371,7 +1371,7 @@ export class dKankyo_housi_Packet {
             return;
 
         const ddraw = this.ddraw;
-        computeMatrixWithoutTranslation(scratchMatrix, viewerInput.camera.worldMatrix);
+        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.viewerCamera.worldMatrix);
 
         renderInstManager.setCurrentList(globals.dlst.wetherEffect);
 
@@ -1428,7 +1428,7 @@ export class dKankyo_housi_Packet {
             colorFromRGBA8(materialParams.u_Color[ColorKind.C0], 0xE5FFC8FF);
             colorFromRGBA8(materialParams.u_Color[ColorKind.C1], 0x43D2CAFF);
 
-            submitScratchRenderInst(renderInstManager, this.materialHelper, renderInst, viewerInput);
+            submitScratchRenderInst(globals, renderInstManager, this.materialHelper, renderInst);
         }
     }
 
@@ -1487,7 +1487,7 @@ export class dKankyo_moya_Packet {
             return;
 
         const ddraw = this.ddraw;
-        computeMatrixWithoutTranslation(scratchMatrix, viewerInput.camera.worldMatrix);
+        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.viewerCamera.worldMatrix);
         mat4.rotateZ(scratchMatrix, scratchMatrix, this.rot * MathConstants.DEG_TO_RAD);
 
         renderInstManager.setCurrentList(globals.dlst.wetherEffect);
@@ -1548,7 +1548,7 @@ export class dKankyo_moya_Packet {
             else
                 colorCopy(materialParams.u_Color[ColorKind.C0], envLight.bgCol[0].K0, 1.0);
 
-            submitScratchRenderInst(renderInstManager, this.materialHelper, renderInst, viewerInput);
+            submitScratchRenderInst(globals, renderInstManager, this.materialHelper, renderInst);
         }
     }
 

--- a/src/ZeldaWindWaker/d_kankyo_wether.ts
+++ b/src/ZeldaWindWaker/d_kankyo_wether.ts
@@ -165,7 +165,7 @@ function submitScratchRenderInst(globals: dGlobals, renderInstManager: GfxRender
     materialHelper.setOnRenderInst(renderInstManager.gfxRenderCache, renderInst);
     renderInst.setSamplerBindingsFromTextureMappings(materialParams_.m_TextureMapping);
     materialHelper.allocateMaterialParamsDataOnInst(renderInst, materialParams_);
-    mat4.copy(drawParams_.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix);
+    mat4.copy(drawParams_.u_PosMtx[0], globals.camera.viewMatrix);
     materialHelper.allocateDrawParamsDataOnInst(renderInst, drawParams_);
     renderInstManager.submitRenderInst(renderInst);
 }
@@ -310,7 +310,7 @@ export class dKankyo_sun_Packet {
         if (!drawSun && !drawMoon)
             return;
 
-        const camPitch = vecPitch(globals.cameraFwd);
+        const camPitch = vecPitch(globals.camera.cameraFwd);
 
         renderInstManager.setCurrentList(globals.dlst.sky[1]);
 
@@ -324,8 +324,8 @@ export class dKankyo_sun_Packet {
                 vec3.copy(moonPos, this.sunPos);
             } else {
                 // Mirror the sun position
-                vec3.sub(moonPos, this.sunPos, globals.cameraPosition);
-                vec3.scaleAndAdd(moonPos, globals.cameraPosition, moonPos, -1.0);
+                vec3.sub(moonPos, this.sunPos, globals.camera.cameraPos);
+                vec3.scaleAndAdd(moonPos, globals.camera.cameraPos, moonPos, -1.0);
             }
 
             const scaleX = dayOfWeek < 4 ? -1 : 1;
@@ -338,7 +338,7 @@ export class dKankyo_sun_Packet {
                 if (i === 1)
                     moonSize *= 1.7;
 
-                computeMatrixWithoutTranslation(scratchMatrix, globals.camera.viewerCamera.worldMatrix);
+                computeMatrixWithoutTranslation(scratchMatrix, globals.camera.worldMatrix);
                 mat4.rotateZ(scratchMatrix, scratchMatrix, MathConstants.DEG_TO_RAD * (45 + (360.0 * ((moonPitch - camPitch) / -8.0))));
 
                 if (i === 0) {
@@ -377,7 +377,7 @@ export class dKankyo_sun_Packet {
             const sunPos = this.sunPos;
 
             const sunPitch = vecPitch(sunPos);
-            computeMatrixWithoutTranslation(scratchMatrix, globals.camera.viewerCamera.worldMatrix);
+            computeMatrixWithoutTranslation(scratchMatrix, globals.camera.worldMatrix);
             mat4.rotateZ(scratchMatrix, scratchMatrix, MathConstants.DEG_TO_RAD * (-50 + (360.0 * ((sunPitch - camPitch) / -8.0))));
 
             let sunSizeBase = 575.0;
@@ -428,7 +428,7 @@ export class dKankyo_sun_Packet {
 
        const envLight = globals.g_env_light;
 
-        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.viewerCamera.worldMatrix);
+        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.worldMatrix);
 
         if (this.drawLenzInSky)
             renderInstManager.setCurrentList(globals.dlst.sky[1]);
@@ -702,7 +702,7 @@ export class dKankyo_vrkumo_Packet {
                 y = Math.sin(polarY0);
                 z = Math.cos(polarY0) * Math.cos(azimuthal + azimuthalOffsY0);
                 vec3.set(scratchVec3, x * domeRadius, y * domeRadius, z * domeRadius);
-                vec3.add(scratchVec3, scratchVec3, globals.cameraPosition);
+                vec3.add(scratchVec3, scratchVec3, globals.camera.cameraPos);
                 ddraw.position3vec3(scratchVec3);
                 ddraw.color4color(GX.Attr.CLR0, materialParams.u_Color[ColorKind.C0]);
                 ddraw.texCoord2f32(GX.Attr.TEX0, 0, 0);
@@ -711,7 +711,7 @@ export class dKankyo_vrkumo_Packet {
                 y = Math.sin(polarY0);
                 z = Math.cos(polarY0) * Math.cos(azimuthal - azimuthalOffsY0);
                 vec3.set(scratchVec3, x * domeRadius, y * domeRadius, z * domeRadius);
-                vec3.add(scratchVec3, scratchVec3, globals.cameraPosition);
+                vec3.add(scratchVec3, scratchVec3, globals.camera.cameraPos);
                 ddraw.position3vec3(scratchVec3);
                 ddraw.color4color(GX.Attr.CLR0, materialParams.u_Color[ColorKind.C0]);
                 ddraw.texCoord2f32(GX.Attr.TEX0, 1, 0);
@@ -720,7 +720,7 @@ export class dKankyo_vrkumo_Packet {
                 y = Math.sin(polarY1);
                 z = Math.cos(polarY1) * Math.cos(azimuthal - azimuthalOffsY1);
                 vec3.set(scratchVec3, x * domeRadius, y * domeRadius, z * domeRadius);
-                vec3.add(scratchVec3, scratchVec3, globals.cameraPosition);
+                vec3.add(scratchVec3, scratchVec3, globals.camera.cameraPos);
                 ddraw.position3vec3(scratchVec3);
                 ddraw.color4color(GX.Attr.CLR0, materialParams.u_Color[ColorKind.C0]);
                 ddraw.texCoord2f32(GX.Attr.TEX0, 1, 1);
@@ -729,7 +729,7 @@ export class dKankyo_vrkumo_Packet {
                 y = Math.sin(polarY1);
                 z = Math.cos(polarY1) * Math.cos(azimuthal + azimuthalOffsY1);
                 vec3.set(scratchVec3, x * domeRadius, y * domeRadius, z * domeRadius);
-                vec3.add(scratchVec3, scratchVec3, globals.cameraPosition);
+                vec3.add(scratchVec3, scratchVec3, globals.camera.cameraPos);
                 ddraw.position3vec3(scratchVec3);
                 ddraw.color4color(GX.Attr.CLR0, materialParams.u_Color[ColorKind.C0]);
                 ddraw.texCoord2f32(GX.Attr.TEX0, 0, 1);
@@ -809,7 +809,7 @@ export class dKankyo_rain_Packet {
         const envLight = globals.g_env_light;
         const ddraw = this.ddraw;
 
-        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.viewerCamera.worldMatrix);
+        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.worldMatrix);
 
         renderInstManager.setCurrentList(globals.dlst.wetherEffect);
 
@@ -838,7 +838,7 @@ export class dKankyo_rain_Packet {
 
             // basePos
             vec3.add(scratchVec3, rain.basePos, rain.pos);
-            const dist = vec3.distance(scratchVec3, globals.cameraPosition);
+            const dist = vec3.distance(scratchVec3, globals.camera.cameraPos);
             vec3.add(scratchVec3c, scratchVec3c, scratchVec3);
             vec3.add(scratchVec3d, scratchVec3d, scratchVec3);
 
@@ -897,9 +897,9 @@ export class dKankyo_rain_Packet {
         this.sibukiAlpha = cLib_addCalc(this.sibukiAlpha, alphaTarget, 0.2, 3.0, 0.001);
 
         let additionalAlphaFade: number;
-        if (globals.cameraFwd[1] > 0.0 && globals.cameraFwd[1] < 0.5)
-            additionalAlphaFade = 1.0 - (globals.cameraFwd[1] / 0.5);
-        else if (globals.cameraFwd[1] > 0.0)
+        if (globals.camera.cameraFwd[1] > 0.0 && globals.camera.cameraFwd[1] < 0.5)
+            additionalAlphaFade = 1.0 - (globals.camera.cameraFwd[1] / 0.5);
+        else if (globals.camera.cameraFwd[1] > 0.0)
             additionalAlphaFade = 0.0;
         else
             additionalAlphaFade = 1.0;
@@ -1061,7 +1061,7 @@ export class dKankyo_wave_Packet {
             return;
 
         const ddraw = this.ddraw;
-        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.viewerCamera.worldMatrix);
+        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.worldMatrix);
 
         renderInstManager.setCurrentList(globals.dlst.wetherEffect);
 
@@ -1226,7 +1226,7 @@ export class dKankyo_star_Packet {
         vec3.set(scratchVec3c, starSize, -0.5 * starSize, 0.0);
         vec3.set(scratchVec3d, -starSize, -0.5 * starSize, 0.0);
 
-        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.viewerCamera.worldMatrix);
+        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.worldMatrix);
         mat4.rotateZ(scratchMatrix, scratchMatrix, this.rot * MathConstants.DEG_TO_RAD);
 
         vec3.transformMat4(scratchVec3b, scratchVec3b, scratchMatrix);
@@ -1234,7 +1234,7 @@ export class dKankyo_star_Packet {
         vec3.transformMat4(scratchVec3d, scratchVec3d, scratchMatrix);
 
         // Projected moon position.
-        mDoLib_projectFB(scratchVec3e, envLight.moonPos, globals.camera.viewerCamera, viewerInput);
+        mDoLib_projectFB(scratchVec3e, envLight.moonPos, globals.camera, viewerInput);
 
         let radius = 0.0, angle = -Math.PI, angleIncr = 0.0;
         for (let i = 0; i < envLight.starCount; i++) {
@@ -1263,9 +1263,9 @@ export class dKankyo_star_Packet {
                     radius = (20.0 * i) / 1000.0;
             }
 
-            vec3.add(scratchVec3a, scratchVec3a, globals.cameraPosition);
+            vec3.add(scratchVec3a, scratchVec3a, globals.camera.cameraPos);
 
-            mDoLib_projectFB(scratchVec3, scratchVec3a, globals.camera.viewerCamera, viewerInput);
+            mDoLib_projectFB(scratchVec3, scratchVec3a, globals.camera, viewerInput);
             const distToMoon = vec3.dist(scratchVec3, scratchVec3e);
             if (distToMoon < 80.0)
                 continue;
@@ -1371,7 +1371,7 @@ export class dKankyo_housi_Packet {
             return;
 
         const ddraw = this.ddraw;
-        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.viewerCamera.worldMatrix);
+        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.worldMatrix);
 
         renderInstManager.setCurrentList(globals.dlst.wetherEffect);
 
@@ -1487,7 +1487,7 @@ export class dKankyo_moya_Packet {
             return;
 
         const ddraw = this.ddraw;
-        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.viewerCamera.worldMatrix);
+        computeMatrixWithoutTranslation(scratchMatrix, globals.camera.worldMatrix);
         mat4.rotateZ(scratchMatrix, scratchMatrix, this.rot * MathConstants.DEG_TO_RAD);
 
         renderInstManager.setCurrentList(globals.dlst.wetherEffect);
@@ -1589,11 +1589,11 @@ function dKyr_sun_move(globals: dGlobals): void {
 
     const roomType = dStage_stagInfo_GetSTType(globals.dStage_dt.stag);
     if (envLight.baseLight.color.r === 0.0 && roomType !== 2) {
-        dKyr_get_vectle_calc(globals.cameraPosition, envLight.baseLight.pos, scratchVec3);
+        dKyr_get_vectle_calc(globals.camera.cameraPos, envLight.baseLight.pos, scratchVec3);
     } else {
-        dKyr_get_vectle_calc(globals.cameraPosition, envLight.sunPos, scratchVec3);
+        dKyr_get_vectle_calc(globals.camera.cameraPos, envLight.sunPos, scratchVec3);
     }
-    vec3.scaleAndAdd(pkt.sunPos, globals.cameraPosition, scratchVec3, 8000.0);
+    vec3.scaleAndAdd(pkt.sunPos, globals.camera.cameraPos, scratchVec3, 8000.0);
     const horizonY = scratchVec3[1];
 
     let sunCanGlare = true;
@@ -1618,7 +1618,7 @@ function dKyr_sun_move(globals: dGlobals): void {
 
         if (sunCanGlare) {
             // Original game projects the vector into viewport space, and gets distance to 320, 240.
-            mDoLib_project(scratchVec3, pkt.sunPos, globals.camera.viewerCamera);
+            mDoLib_project(scratchVec3, pkt.sunPos, globals.camera);
 
             const peekZ = globals.dlst.peekZ;
 
@@ -1678,7 +1678,7 @@ function dKyr_sun_move(globals: dGlobals): void {
     }
 
     if (dKyr_moon_arrival_check(envLight)) {
-        const diffY = (pkt.sunPos[1] - globals.cameraPosition[1]) / -8000.0;
+        const diffY = (pkt.sunPos[1] - globals.camera.cameraPos[1]) / -8000.0;
         const target = Math.min(diffY * diffY * 6.0, 1.0);
         pkt.moonAlpha = cLib_addCalc(pkt.moonAlpha, target, 0.2, 0.01, 0.001);
     } else {
@@ -1687,19 +1687,19 @@ function dKyr_sun_move(globals: dGlobals): void {
 }
 
 function dKy_set_eyevect_calc(globals: dGlobals, dst: vec3, scaleXZ: number, scaleY: number = scaleXZ): void {
-    dst[0] = globals.cameraPosition[0] + globals.cameraFwd[0] * scaleXZ;
-    dst[1] = (globals.cameraPosition[1] + globals.cameraFwd[1] * scaleY) - 200.0;
-    dst[2] = globals.cameraPosition[2] + globals.cameraFwd[2] * scaleXZ;
+    dst[0] = globals.camera.cameraPos[0] + globals.camera.cameraFwd[0] * scaleXZ;
+    dst[1] = (globals.camera.cameraPos[1] + globals.camera.cameraFwd[1] * scaleY) - 200.0;
+    dst[2] = globals.camera.cameraPos[2] + globals.camera.cameraFwd[2] * scaleXZ;
 }
 
 function dKy_set_eyevect_calc2(globals: dGlobals, dst: vec3, scaleXZ: number, scaleY: number = scaleXZ): void {
-    vec3.copy(dst, globals.cameraFwd);
+    vec3.copy(dst, globals.camera.cameraFwd);
     if (scaleY === 0.0)
         dst[1] = 0.0;
     vec3.normalize(dst, dst);
-    dst[0] = globals.cameraPosition[0] + dst[0] * scaleXZ;
-    dst[1] = globals.cameraPosition[1] + dst[1] * scaleXZ;
-    dst[2] = globals.cameraPosition[2] + dst[2] * scaleXZ;
+    dst[0] = globals.camera.cameraPos[0] + dst[0] * scaleXZ;
+    dst[1] = globals.camera.cameraPos[1] + dst[1] * scaleXZ;
+    dst[2] = globals.camera.cameraPos[2] + dst[2] * scaleXZ;
 }
 
 function dKyr_lenzflare_move(globals: dGlobals): void {
@@ -1709,21 +1709,21 @@ function dKyr_lenzflare_move(globals: dGlobals): void {
     dKy_set_eyevect_calc(globals, scratchVec3, 7200);
     dKyr_get_vectle_calc(scratchVec3, pkt.sunPos, scratchVec3);
 
-    const dist = vec3.distance(scratchVec3, globals.cameraFwd);
+    const dist = vec3.distance(scratchVec3, globals.camera.cameraFwd);
     const intensity = 250.0 + (350.0 * dist);
     for (let i = 0; i < 6; i++) {
         const whichLenz = i + 2;
         vec3.scaleAndAdd(pkt.lensflarePos[i], pkt.sunPos, scratchVec3, -intensity * whichLenz);
     }
 
-    mDoLib_project(scratchVec3, pkt.sunPos, globals.camera.viewerCamera);
+    mDoLib_project(scratchVec3, pkt.sunPos, globals.camera);
     pkt.lensflareAngle = Math.atan2(scratchVec3[1], scratchVec3[0]) + Math.PI / 2;
 }
 
 function wether_move_thunder(globals: dGlobals): void {
     const envLight = globals.g_env_light;
     if (envLight.thunderActive) {
-        dKyr_thunder_move(globals, envLight, globals.cameraPosition);
+        dKyr_thunder_move(globals, envLight, globals.camera.cameraPos);
     } else if (envLight.thunderMode !== ThunderMode.Off) {
         dKyr_thunder_init(envLight);
         envLight.thunderActive = true;
@@ -1746,9 +1746,9 @@ function dKyr_kamome_move(globals: dGlobals, deltaTimeFrames: number): void {
                 if (eff.timer <= 0.0) {
                     eff.angleY = cM_rndFX(Math.PI);
                     eff.angleX = cM_rndFX(Math.PI);
-                    eff.pos[0] = globals.cameraPosition[0] + Math.sin(eff.angleY) * 7000.0;
+                    eff.pos[0] = globals.camera.cameraPos[0] + Math.sin(eff.angleY) * 7000.0;
                     eff.pos[1] = 4500.0;
-                    eff.pos[2] = globals.cameraPosition[2] + Math.cos(eff.angleY) * 7000.0;
+                    eff.pos[2] = globals.camera.cameraPos[2] + Math.cos(eff.angleY) * 7000.0;
                     eff.angleYSpeed = cM_rndFX(1.0);
                     eff.scale = 0.0;
                     eff.timer = 300.0 + cM_rndF(180.0);
@@ -1775,9 +1775,9 @@ function dKyr_kamome_move(globals: dGlobals, deltaTimeFrames: number): void {
                 const newTargetY = Math.abs(Math.sin(eff.angleX) * 3200.0);
                 const newTargetZ = Math.cos(eff.angleY) * 7000.0;
 
-                eff.pos[0] = globals.cameraPosition[0] + newTargetX;
+                eff.pos[0] = globals.camera.cameraPos[0] + newTargetX;
                 eff.pos[1] = newTargetY + 4800;
-                eff.pos[2] = globals.cameraPosition[2] + newTargetZ;
+                eff.pos[2] = globals.camera.cameraPos[2] + newTargetZ;
                 eff.emitter.setGlobalTranslation(eff.pos);
 
                 if (eff.timer > 0 && spawnBirds) {
@@ -1964,7 +1964,7 @@ function dKyr_windline_move(globals: dGlobals, deltaTimeFrames: number): void {
             vec3.scaleAndAdd(eff.animPos, eff.animPos, scratchVec3, swervePosMag * deltaTimeFrames);
             vec3.add(emitter.globalTranslation, eff.basePos, eff.animPos);
 
-            const dist = vec3.distance(emitter.globalTranslation, globals.cameraPosition);
+            const dist = vec3.distance(emitter.globalTranslation, globals.camera.cameraPos);
             const distFade = Math.min(dist / 200.0, 1.0);
 
             const colorAvg = (envLight.bgCol[0].K0.r + envLight.bgCol[0].K0.g + envLight.bgCol[0].K0.b) / 3;
@@ -2093,14 +2093,14 @@ function wether_move_rain(globals: dGlobals, deltaTimeFrames: number): void {
                     } else {
                         vec3.set(rain.pos, cM_rndFX(800), cM_rndFX(800), cM_rndFX(800));
                     }
-                    rain.minY = -800 + globals.cameraPosition[1];
+                    rain.minY = -800 + globals.camera.cameraPos[1];
                 }
 
                 const posY = rain.basePos[1] + rain.pos[1];
                 if (posY < 20.0 + rain.minY) {
                     vec3.copy(rain.basePos, scratchVec3);
                     vec3.set(rain.pos, cM_rndFX(800.0), 200.0, cM_rndFX(800.0));
-                    rain.minY = -800 + globals.cameraPosition[1];
+                    rain.minY = -800 + globals.camera.cameraPos[1];
                     rain.timer = 10;
                 }
             } else {
@@ -2111,7 +2111,7 @@ function wether_move_rain(globals: dGlobals, deltaTimeFrames: number): void {
             vec3.set(rain.pos, cM_rndFX(800.0), cM_rndFX(600.0), cM_rndFX(800.0));
             rain.alpha = 1.0;
             rain.timer = 0;
-            rain.minY = -800 + globals.cameraPosition[1];
+            rain.minY = -800 + globals.camera.cameraPos[1];
             rain.initialized = true;
         }
 
@@ -2335,7 +2335,7 @@ function wether_move_moya(globals: dGlobals, deltaTimeFrames: number): void {
 
         eff.sizeTimer += 120 * deltaTimeFrames;
 
-        const distanceCam = vec3.distance(globals.cameraPosition, scratchVec3c);
+        const distanceCam = vec3.distance(globals.camera.cameraPos, scratchVec3c);
         eff.size = (Math.sin(cM_s2rad(eff.sizeTimer)) * 40.0) + eff.baseSize + (eff.baseSize * 1.5 * (distanceCam - 1000.0) / 2000.0);
 
         if (i < envLight.moyaCount) {
@@ -2404,7 +2404,7 @@ function wether_move_wave(globals: dGlobals, deltaTimeFrames: number): void {
         skyboxY = fili.skyboxY;
 
     // Camera forward in XZ plane
-    vec3.copy(scratchVec3a, globals.cameraFwd);
+    vec3.copy(scratchVec3a, globals.camera.cameraFwd);
     scratchVec3a[1] = 0;
     vec3.normalize(scratchVec3a, scratchVec3a);
 
@@ -2472,7 +2472,7 @@ function wether_move_wave(globals: dGlobals, deltaTimeFrames: number): void {
 
         // Sea flat fade.
         if (envLight.waveFlatInter > 0.0) {
-            const dist = Math.hypot(globals.cameraPosition[0] - scratchVec3d[0], globals.cameraPosition[2] - scratchVec3d[2]);
+            const dist = Math.hypot(globals.camera.cameraPos[0] - scratchVec3d[0], globals.camera.cameraPos[2] - scratchVec3d[2]);
             const innerRadius = envLight.waveFlatInter * 1.5 * envLight.waveSpawnRadius;
             const outerRadius = innerRadius + 1000.0;
             const fade = invlerpDistance(dist, innerRadius, outerRadius);
@@ -2487,7 +2487,7 @@ function wether_move_wave(globals: dGlobals, deltaTimeFrames: number): void {
             wave.strengthEnv *= fade;
         }
 
-        const windSpeed = Math.max(windPow, vec3.distance(scratchVec3d, globals.cameraPosition));
+        const windSpeed = Math.max(windPow, vec3.distance(scratchVec3d, globals.camera.cameraPos));
         const alphaTarget = saturate(1.03 * (1.0 - (windSpeed / (2.0 * envLight.waveSpawnDist))) * Math.sin(wave.animCounter));
         wave.alpha = cLib_addCalc(wave.alpha, alphaTarget, 0.5, 0.5, 0.001);
         wave.basePos[1] = skyboxY;
@@ -2532,7 +2532,7 @@ function vrkumo_move(globals: dGlobals, deltaTimeFrames: number): void {
         if (globals.stageName === 'Siren' && globals.mStayNo === 17)
             skyboxY = -14101.0;
         // TODO(jstpierre): Re-enable this?
-        // skyboxOffsY -= 0.09 * (globals.cameraPosition[1] - skyboxY);
+        // skyboxOffsY -= 0.09 * (globals.camera.cameraPos[1] - skyboxY);
     }
 
     for (let i = 0; i < 100; i++) {
@@ -2630,7 +2630,7 @@ function wether_move_vrkumo(globals: dGlobals, deltaTimeFrames: number): void {
 
         if (globals.stageName === 'sea' && globals.mStayNo === 9) {
             vec3.set(scratchVec3, -180000.0, 750.0, -200000.0);
-            const sqrDist = vec3.squaredDistance(globals.cameraPosition, scratchVec3);
+            const sqrDist = vec3.squaredDistance(globals.camera.cameraPos, scratchVec3);
             if (sqrDist < 2500**2)
                 pkt.strength = 1.0;
         }
@@ -2789,7 +2789,7 @@ export class d_thunder extends kankyo_class {
         this.scale[1] = nearMul * (20.0 + cM_rndF(60.0));
         this.scale[2] = 1.0;
 
-        const fwd = globals.cameraFwd;
+        const fwd = globals.camera.cameraFwd;
         const a = Math.atan2(fwd[0], fwd[2]);
         const theta = (cM_rndFX(1.0) < 0.0) ? a - Math.PI / 2 : a + Math.PI / 2;
         const phi = vecPitch(fwd);
@@ -2797,9 +2797,9 @@ export class d_thunder extends kankyo_class {
         const cosP = Math.cos(phi);
 
         const rndRot = cM_rndFX(120000.0);
-        this.pos[0] = globals.cameraPosition[0] + 100000.0 * fwd[0] + ((cosP * sinT) * rndRot);
-        this.pos[1] = globals.cameraPosition[1] + cM_rndFX(2000.0);
-        this.pos[2] = globals.cameraPosition[2] + 100000.0 * fwd[2] + ((cosP * cosT) * rndRot);
+        this.pos[0] = globals.camera.cameraPos[0] + 100000.0 * fwd[0] + ((cosP * sinT) * rndRot);
+        this.pos[1] = globals.camera.cameraPos[1] + cM_rndFX(2000.0);
+        this.pos[2] = globals.camera.cameraPos[2] + 100000.0 * fwd[2] + ((cosP * cosT) * rndRot);
         return cPhs__Status.Next;
     }
 

--- a/src/ZeldaWindWaker/d_kankyo_wether.ts
+++ b/src/ZeldaWindWaker/d_kankyo_wether.ts
@@ -1618,7 +1618,7 @@ function dKyr_sun_move(globals: dGlobals): void {
 
         if (sunCanGlare) {
             // Original game projects the vector into viewport space, and gets distance to 320, 240.
-            mDoLib_project(scratchVec3, pkt.sunPos, globals.camera);
+            mDoLib_project(scratchVec3, pkt.sunPos, globals.camera.viewerCamera);
 
             const peekZ = globals.dlst.peekZ;
 
@@ -1716,7 +1716,7 @@ function dKyr_lenzflare_move(globals: dGlobals): void {
         vec3.scaleAndAdd(pkt.lensflarePos[i], pkt.sunPos, scratchVec3, -intensity * whichLenz);
     }
 
-    mDoLib_project(scratchVec3, pkt.sunPos, globals.camera);
+    mDoLib_project(scratchVec3, pkt.sunPos, globals.camera.viewerCamera);
     pkt.lensflareAngle = Math.atan2(scratchVec3[1], scratchVec3[0]) + Math.PI / 2;
 }
 

--- a/src/ZeldaWindWaker/d_particle.ts
+++ b/src/ZeldaWindWaker/d_particle.ts
@@ -73,7 +73,7 @@ export class dPa_control_c {
         const inc = viewerInput.deltaTime / 1000 * 30;
 
         // Some hacky distance culling for emitters.
-        getMatrixTranslation(scratchVec3a, globals.camera.viewerCamera.worldMatrix);
+        getMatrixTranslation(scratchVec3a, globals.camera.worldMatrix);
         for (let i = 0; i < this.emitterManager.aliveEmitters.length; i++) {
             const emitter = this.emitterManager.aliveEmitters[i];
             const cullDistance = (emitter as any).cullDistance ?? 5000;

--- a/src/ZeldaWindWaker/d_particle.ts
+++ b/src/ZeldaWindWaker/d_particle.ts
@@ -69,11 +69,11 @@ export class dPa_control_c {
         this.drawInfo.frustum = frustum;
     }
 
-    public calc(viewerInput: ViewerRenderInput): void {
+    public calc(globals: dGlobals, viewerInput: ViewerRenderInput): void {
         const inc = viewerInput.deltaTime / 1000 * 30;
 
         // Some hacky distance culling for emitters.
-        getMatrixTranslation(scratchVec3a, viewerInput.camera.worldMatrix);
+        getMatrixTranslation(scratchVec3a, globals.camera.viewerCamera.worldMatrix);
         for (let i = 0; i < this.emitterManager.aliveEmitters.length; i++) {
             const emitter = this.emitterManager.aliveEmitters[i];
             const cullDistance = (emitter as any).cullDistance ?? 5000;

--- a/src/ZeldaWindWaker/d_place_name.ts
+++ b/src/ZeldaWindWaker/d_place_name.ts
@@ -89,6 +89,8 @@ export class d_place_name extends msg_class {
 
         const screen = globals.resCtrl.getObjectRes(ResType.Blo, `PName`, 0x04);
 
+        // @TODO: If we're on Outset Island (0), don't load any textures. Add support for BLO loading the default textures.
+
         // The Outset Island image lives inside the arc. All others are loose files in 'res/placename/'
         let img: BTIData;
         if (globals.scnPlay.placenameIndex === Placename.OutsetIsland) {
@@ -114,7 +116,10 @@ export class d_place_name extends msg_class {
 
     public override draw(globals: dGlobals, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput): void {
         renderInstManager.setCurrentList(globals.dlst.ui[0]);
-        this.screen.draw(renderInstManager, viewerInput, null);
+
+        // @TODO: This will be needed when drawing all Wind Waker 2D elements. It should be in dComIfG_play_c. 
+        const ctx = new J2DGrafContext(globals.context.device, 0.0, 0.0, 608.0, 448.0, -1.0, 0.0);
+        this.screen.draw(renderInstManager, viewerInput, ctx);
     }
 
     public override execute(globals: dGlobals, deltaTimeFrames: number): void {

--- a/src/ZeldaWindWaker/d_wood.ts
+++ b/src/ZeldaWindWaker/d_wood.ts
@@ -702,7 +702,7 @@ export class WoodPacket implements J3DPacket {
                     const clipPos = vec3.set(scratchVec3a, unit.pos[0], unit.pos[1] + kClipCenterYOffset, unit.pos[2]);
 
                     // s32 res = mDoLib_clipper::clip(j3dSys.getViewMtx(), clipPos, kClipRadius);
-                    const culled = !globals.camera.frustum.containsSphere(clipPos, kClipRadius);
+                    const culled = !globals.camera.viewerCamera.frustum.containsSphere(clipPos, kClipRadius);
 
                     if (culled) {
                         unit.flags |= UnitState_e.IsFrustumCulled;
@@ -737,7 +737,7 @@ export class WoodPacket implements J3DPacket {
 
                     const shadowRenderInst = renderInstManager.newRenderInst();
                     this.model.shapeShadow.setOnRenderInst(shadowRenderInst);
-                    mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewMatrix, unit.shadowModelMtx);
+                    mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix, unit.shadowModelMtx);
                     this.model.shadowMaterial.allocateDrawParamsDataOnInst(shadowRenderInst, drawParams);
                     renderInstManager.submitRenderInst(shadowRenderInst);
                 }
@@ -783,7 +783,7 @@ export class WoodPacket implements J3DPacket {
 
                         const renderInst = renderInstManager.newRenderInst();
                         this.model.shapeMain.setOnRenderInst(renderInst);
-                        mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewMatrix, unit.modelMtx);
+                        mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix, unit.modelMtx);
                         this.model.bushMaterial.allocateDrawParamsDataOnInst(renderInst, drawParams);
                         renderInstManager.submitRenderInst(renderInst);
 
@@ -797,7 +797,7 @@ export class WoodPacket implements J3DPacket {
                     // Always draw the trunk
                     const renderInst = renderInstManager.newRenderInst();
                     this.model.shapeTrunk.setOnRenderInst(renderInst);
-                    mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewMatrix, unit.trunkModelMtx);
+                    mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix, unit.trunkModelMtx);
                     this.model.bushMaterial.allocateDrawParamsDataOnInst(renderInst, drawParams);
                     renderInstManager.submitRenderInst(renderInst);
                 }

--- a/src/ZeldaWindWaker/d_wood.ts
+++ b/src/ZeldaWindWaker/d_wood.ts
@@ -702,7 +702,7 @@ export class WoodPacket implements J3DPacket {
                     const clipPos = vec3.set(scratchVec3a, unit.pos[0], unit.pos[1] + kClipCenterYOffset, unit.pos[2]);
 
                     // s32 res = mDoLib_clipper::clip(j3dSys.getViewMtx(), clipPos, kClipRadius);
-                    const culled = !globals.camera.viewerCamera.frustum.containsSphere(clipPos, kClipRadius);
+                    const culled = !globals.camera.frustum.containsSphere(clipPos, kClipRadius);
 
                     if (culled) {
                         unit.flags |= UnitState_e.IsFrustumCulled;
@@ -737,7 +737,7 @@ export class WoodPacket implements J3DPacket {
 
                     const shadowRenderInst = renderInstManager.newRenderInst();
                     this.model.shapeShadow.setOnRenderInst(shadowRenderInst);
-                    mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix, unit.shadowModelMtx);
+                    mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewMatrix, unit.shadowModelMtx);
                     this.model.shadowMaterial.allocateDrawParamsDataOnInst(shadowRenderInst, drawParams);
                     renderInstManager.submitRenderInst(shadowRenderInst);
                 }
@@ -783,7 +783,7 @@ export class WoodPacket implements J3DPacket {
 
                         const renderInst = renderInstManager.newRenderInst();
                         this.model.shapeMain.setOnRenderInst(renderInst);
-                        mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix, unit.modelMtx);
+                        mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewMatrix, unit.modelMtx);
                         this.model.bushMaterial.allocateDrawParamsDataOnInst(renderInst, drawParams);
                         renderInstManager.submitRenderInst(renderInst);
 
@@ -797,7 +797,7 @@ export class WoodPacket implements J3DPacket {
                     // Always draw the trunk
                     const renderInst = renderInstManager.newRenderInst();
                     this.model.shapeTrunk.setOnRenderInst(renderInst);
-                    mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewerCamera.viewMatrix, unit.trunkModelMtx);
+                    mat4.mul(drawParams.u_PosMtx[0], globals.camera.viewMatrix, unit.trunkModelMtx);
                     this.model.bushMaterial.allocateDrawParamsDataOnInst(renderInst, drawParams);
                     renderInstManager.submitRenderInst(renderInst);
                 }

--- a/src/ZeldaWindWaker/d_wood.ts
+++ b/src/ZeldaWindWaker/d_wood.ts
@@ -763,7 +763,7 @@ export class WoodPacket implements J3DPacket {
                 // Set the room color and fog params
                 colorCopy(materialParams.u_Color[ColorKind.C0], globals.roomCtrl.status[r].tevStr.colorC0);
                 colorCopy(materialParams.u_Color[ColorKind.C1], globals.roomCtrl.status[r].tevStr.colorK0);
-                dKy_GxFog_set(globals.g_env_light, materialParams.u_FogBlock, viewerInput.camera);
+                dKy_GxFog_set(globals.g_env_light, materialParams.u_FogBlock, globals.camera);
 
                 for (let unit of this.unit[r]) {
                     if (unit.flags & UnitState_e.IsFrustumCulled)

--- a/src/ZeldaWindWaker/f_op_actor.ts
+++ b/src/ZeldaWindWaker/f_op_actor.ts
@@ -4,7 +4,7 @@ import { AABB } from "../Geometry.js";
 import { Camera, computeScreenSpaceProjectionFromWorldSpaceAABB, computeScreenSpaceProjectionFromWorldSpaceSphere, ScreenSpaceProjection } from "../Camera.js";
 import { base_process_class, cPhs__Status, fGlobals, fopDwTg_DrawQTo, fopDwTg_ToDrawQ, fpcPc__IsVisible, fpcSCtRq_Request, leafdraw_class } from "./framework.js";
 import { dKy_tevstr_c, dKy_tevstr_init } from "./d_kankyo.js";
-import { dGlobals } from "./Main.js";
+import { dCamera_c, dGlobals } from "./Main.js";
 import { assert } from "../util.js";
 import { transformVec3Mat4w1 } from "../MathHelpers.js";
 import { dProcName_e } from "./d_procname.js";
@@ -101,7 +101,7 @@ export class fopAc_ac_c extends leafdraw_class {
         vec4.set(this.cullSizeSphere, x, y, z, r);
     }
 
-    protected cullingCheck(camera: Camera): boolean {
+    protected cullingCheck(camera: dCamera_c): boolean {
         if (!fpcPc__IsVisible(this))
             return false;
 
@@ -109,7 +109,7 @@ export class fopAc_ac_c extends leafdraw_class {
         if (this.cullMtx === null)
             throw "whoops";
 
-        const frustum = camera.frustum;
+        const frustum = camera.viewerCamera.frustum;
 
         if (this.cullSizeBox !== null) {
             // If the box is empty, that means I forgot to fill it in for a certain actor.
@@ -122,7 +122,7 @@ export class fopAc_ac_c extends leafdraw_class {
             if (!frustum.contains(scratchAABB))
                 return false;
 
-            computeScreenSpaceProjectionFromWorldSpaceAABB(scratchScreenSpaceProjection, camera, scratchAABB);
+            computeScreenSpaceProjectionFromWorldSpaceAABB(scratchScreenSpaceProjection, camera.viewerCamera, scratchAABB);
             if (scratchScreenSpaceProjection.getScreenArea() <= 0.0002)
                 return false;
         } else if (this.cullSizeSphere !== null) {
@@ -133,7 +133,7 @@ export class fopAc_ac_c extends leafdraw_class {
             if (!frustum.containsSphere(scratchVec3a, radius))
                 return false;
 
-            computeScreenSpaceProjectionFromWorldSpaceSphere(scratchScreenSpaceProjection, camera, scratchVec3a, radius);
+            computeScreenSpaceProjectionFromWorldSpaceSphere(scratchScreenSpaceProjection, camera.viewerCamera, scratchVec3a, radius);
             if (scratchScreenSpaceProjection.getScreenArea() <= 0.0002)
                 return false;
         }

--- a/src/ZeldaWindWaker/f_op_actor.ts
+++ b/src/ZeldaWindWaker/f_op_actor.ts
@@ -109,7 +109,7 @@ export class fopAc_ac_c extends leafdraw_class {
         if (this.cullMtx === null)
             throw "whoops";
 
-        const frustum = camera.viewerCamera.frustum;
+        const frustum = camera.frustum;
 
         if (this.cullSizeBox !== null) {
             // If the box is empty, that means I forgot to fill it in for a certain actor.
@@ -122,7 +122,7 @@ export class fopAc_ac_c extends leafdraw_class {
             if (!frustum.contains(scratchAABB))
                 return false;
 
-            computeScreenSpaceProjectionFromWorldSpaceAABB(scratchScreenSpaceProjection, camera.viewerCamera, scratchAABB);
+            computeScreenSpaceProjectionFromWorldSpaceAABB(scratchScreenSpaceProjection, camera, scratchAABB);
             if (scratchScreenSpaceProjection.getScreenArea() <= 0.0002)
                 return false;
         } else if (this.cullSizeSphere !== null) {
@@ -133,7 +133,7 @@ export class fopAc_ac_c extends leafdraw_class {
             if (!frustum.containsSphere(scratchVec3a, radius))
                 return false;
 
-            computeScreenSpaceProjectionFromWorldSpaceSphere(scratchScreenSpaceProjection, camera.viewerCamera, scratchVec3a, radius);
+            computeScreenSpaceProjectionFromWorldSpaceSphere(scratchScreenSpaceProjection, camera, scratchVec3a, radius);
             if (scratchScreenSpaceProjection.getScreenArea() <= 0.0002)
                 return false;
         }

--- a/src/ZeldaWindWaker/m_do_ext.ts
+++ b/src/ZeldaWindWaker/m_do_ext.ts
@@ -103,12 +103,12 @@ export function mDoExt_modelEntryDL(globals: dGlobals, modelInstance: J3DModelIn
         modelInstance.setTexturesEnabled(globals.renderHacks.texturesEnabled);
     }
 
-    modelInstance.calcView(viewerInput.camera, viewerInput.camera.viewMatrix);
+    modelInstance.calcView(globals.camera.viewerCamera, globals.camera.viewerCamera.viewMatrix);
 
     renderInstManager.setCurrentList(drawListSet[0]);
-    modelInstance.drawOpa(device, renderInstManager, viewerInput.camera);
+    modelInstance.drawOpa(device, renderInstManager, globals.camera.viewerCamera);
     renderInstManager.setCurrentList(drawListSet[1]);
-    modelInstance.drawXlu(device, renderInstManager, viewerInput.camera);
+    modelInstance.drawXlu(device, renderInstManager, globals.camera.viewerCamera);
 }
 
 export function mDoExt_modelUpdateDL(globals: dGlobals, modelInstance: J3DModelInstance, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput, drawListSet: dDlst_list_Set | null = null): void {
@@ -242,8 +242,8 @@ export function mDoLib_project(dst: vec3, v: vec3, camera: Camera, v4 = scratchV
     vec3.set(dst, v4[0], v4[1], v4[2]);
 }
 
-export function mDoLib_projectFB(dst: vec3, v: vec3, viewerInput: ViewerRenderInput): void {
-    mDoLib_project(dst, v, viewerInput.camera);
+export function mDoLib_projectFB(dst: vec3, v: vec3, camera: Camera, viewerInput: ViewerRenderInput): void {
+    mDoLib_project(dst, v, camera);
     // Put in viewport framebuffer space.
     dst[0] = (dst[0] * 0.5 + 0.5) * viewerInput.backbufferWidth;
     dst[1] = (dst[1] * 0.5 + 0.5) * viewerInput.backbufferHeight;

--- a/src/ZeldaWindWaker/m_do_ext.ts
+++ b/src/ZeldaWindWaker/m_do_ext.ts
@@ -103,12 +103,12 @@ export function mDoExt_modelEntryDL(globals: dGlobals, modelInstance: J3DModelIn
         modelInstance.setTexturesEnabled(globals.renderHacks.texturesEnabled);
     }
 
-    modelInstance.calcView(globals.camera.viewerCamera, globals.camera.viewerCamera.viewMatrix);
+    modelInstance.calcView(globals.camera, globals.camera.viewMatrix);
 
     renderInstManager.setCurrentList(drawListSet[0]);
-    modelInstance.drawOpa(device, renderInstManager, globals.camera.viewerCamera);
+    modelInstance.drawOpa(device, renderInstManager, globals.camera);
     renderInstManager.setCurrentList(drawListSet[1]);
-    modelInstance.drawXlu(device, renderInstManager, globals.camera.viewerCamera);
+    modelInstance.drawXlu(device, renderInstManager, globals.camera);
 }
 
 export function mDoExt_modelUpdateDL(globals: dGlobals, modelInstance: J3DModelInstance, renderInstManager: GfxRenderInstManager, viewerInput: ViewerRenderInput, drawListSet: dDlst_list_Set | null = null): void {


### PR DESCRIPTION
![zww_stolensister_2024-12-20T15_32_47 407Z](https://github.com/user-attachments/assets/75067365-fca6-4430-8e02-9cad3c8f7597)

These bars disappear when the demo is paused or when viewing a normal scene. They animate in and out using the same logic as the game. 

More interestingly, I had to add a few camera-related member variables, which made it seem like time to create `dCamera_c`. For simplicity I left it in `Main.ts`. I also implemented the scissoring as simply as I could, which is a bit hacky. We _could_ introduce `dDlst_window_c` which would get set on each draw list. Then `dCamera_c` would just modify the window during its update. Thoughts?