### PR TITLE
Wind Waker: Particle system improvements 

### DIFF
--- a/src/Common/JSYSTEM/J2Dv1.ts
+++ b/src/Common/JSYSTEM/J2Dv1.ts
@@ -81,8 +81,6 @@ const enum J2DUVBinding {
 
 export class J2DGrafContext {
     private clipSpaceNearZ: GfxClipSpaceNearZ;
-    private frustum = new Frustum();
-
     public sceneParams = new SceneParams();
     public viewport = vec4.create();
     public ortho = vec4.create();
@@ -121,17 +119,6 @@ export class J2DGrafContext {
         projectionMatrixForCuboid(this.sceneParams.u_Projection, left, right, bottom, top, this.near, this.far);
         projectionMatrixConvertClipSpaceNearZ(this.sceneParams.u_Projection, this.clipSpaceNearZ, GfxClipSpaceNearZ.NegativeOne);
 
-    }
-
-    /**
-     * noclip modification:
-     * Given a view matrix, return a Frustum which can be used for culling. 
-     * In the original game, frustums are generated from proj matrices alone. But noclip expects viewProj frustums. 
-     */
-    public getFrustumForView(viewFromWorldMatrix: mat4): Frustum {
-        const clipFromWorldMatrix = mat4.mul(scratchMat, this.sceneParams.u_Projection, viewFromWorldMatrix);
-        this.frustum.updateClipFrustum(clipFromWorldMatrix, this.clipSpaceNearZ);
-        return this.frustum;
     }
 
     public setOnRenderInst(renderInst: GfxRenderInst): void {

--- a/src/Common/JSYSTEM/JPA.ts
+++ b/src/Common/JSYSTEM/JPA.ts
@@ -1711,7 +1711,7 @@ export class JPABaseEmitter {
             throw "whoops";
     }
 
-    private createParticle(): JPABaseParticle | null {
+    public createParticle(): JPABaseParticle | null {
         if (this.emitterManager.deadParticlePool.length === 0)
             return null;
 
@@ -1736,7 +1736,6 @@ export class JPABaseEmitter {
                     this.emitCount = bem1.divNumber * bem1.divNumber * 4 + 2;
                 else
                     this.emitCount = bem1.divNumber;
-                workData.volumeEmitCount = this.emitCount;
                 workData.volumeEmitIdx = 0;
             } else {
                 // Rate
@@ -1747,6 +1746,8 @@ export class JPABaseEmitter {
                 if (!!(this.status & JPAEmitterStatus.FIRST_EMISSION) && this.rate !== 0.0 && this.emitCount < 1.0)
                     this.emitCount = 1;
             }
+
+            workData.volumeEmitCount = this.emitCount;
 
             if (!!(this.status & JPAEmitterStatus.STOP_CREATE_PARTICLE))
                 this.emitCount = 0;

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -403,7 +403,7 @@ export class WindWakerRenderer implements Viewer.SceneGfx {
         {
             globals.particleCtrl.calc(globals, viewerInput);
 
-            for (let group = ParticleGroup.Normal; group <= ParticleGroup.TwoDmenuBack; group++) {
+            for (let group = ParticleGroup.Normal; group <= ParticleGroup.Wind; group++) {
                 let texPrjMtx: mat4 | null = null;
 
                 if (group === ParticleGroup.Projection) {
@@ -413,6 +413,19 @@ export class WindWakerRenderer implements Viewer.SceneGfx {
 
                 globals.particleCtrl.setDrawInfo(globals.camera.viewFromWorldMatrix, globals.camera.clipFromViewMatrix, texPrjMtx, globals.camera.frustum);
                 renderInstManager.setCurrentList(dlst.effect[group == ParticleGroup.Projection ? EffectDrawGroup.Indirect : EffectDrawGroup.Main]);
+                globals.particleCtrl.draw(device, this.renderHelper.renderInstManager, group);
+            }
+
+            // From mDoGph_Painter(). Draw the 2D particle groups with 640x480 ortho matrices.  
+            for (let group = ParticleGroup.TwoDfore; group <= ParticleGroup.TwoDmenuBack; group++) {
+                const orthoCtx = this.globals.scnPlay.currentGrafPort;
+                const viewMtx = mat4.fromTranslation(scratchMatrix, [orthoCtx.aspectRatioCorrection * 320, 240, 0]);
+                const frustum = orthoCtx.getFrustumForView(viewMtx);
+                const template = renderInstManager.pushTemplate();
+                orthoCtx.setOnRenderInst(template);
+
+                globals.particleCtrl.setDrawInfo(viewMtx, orthoCtx.sceneParams.u_Projection, null, frustum);
+                renderInstManager.setCurrentList(dlst.effect[EffectDrawGroup.Main]);
                 globals.particleCtrl.draw(device, this.renderHelper.renderInstManager, group);
             }
         }

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -17,7 +17,7 @@ import { J3DModelInstance } from '../Common/JSYSTEM/J3D/J3DGraphBase.js';
 import * as JPA from '../Common/JSYSTEM/JPA.js';
 import { BTIData } from '../Common/JSYSTEM/JUTTexture.js';
 import { dfRange } from '../DebugFloaters.js';
-import { range } from '../MathHelpers.js';
+import { computeModelMatrixT, range } from '../MathHelpers.js';
 import { SceneContext } from '../SceneBase.js';
 import { TextureMapping } from '../TextureHolder.js';
 import { setBackbufferDescSimple, standardFullClearRenderPassDescriptor } from '../gfx/helpers/RenderGraphHelpers.js';
@@ -419,10 +419,11 @@ export class WindWakerRenderer implements Viewer.SceneGfx {
             // From mDoGph_Painter(). Draw the 2D particle groups with different view/proj matrices. 
             {
                 const orthoCtx = this.globals.scnPlay.currentGrafPort;
-                const viewMtx = mat4.fromTranslation(scratchMatrix, [orthoCtx.aspectRatioCorrection * 320, 240, 0]);
                 const template = renderInstManager.pushTemplate();
                 orthoCtx.setOnRenderInst(template);
 
+                const viewMtx = scratchMatrix;
+                computeModelMatrixT(viewMtx, orthoCtx.aspectRatioCorrection * 320, 240, 0);
                 globals.particleCtrl.setDrawInfo(viewMtx, orthoCtx.sceneParams.u_Projection, null, null);
                 
                 renderInstManager.setCurrentList(dlst.particle2DBack);

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -416,8 +416,8 @@ export class WindWakerRenderer implements Viewer.SceneGfx {
                 globals.particleCtrl.draw(device, this.renderHelper.renderInstManager, group);
             }
 
-            // From mDoGph_Painter(). Draw the 2D particle groups with 640x480 ortho matrices.  
-            for (let group = ParticleGroup.TwoDfore; group <= ParticleGroup.TwoDmenuBack; group++) {
+            // From mDoGph_Painter(). Draw the 2D particle groups with different view/proj matrices. 
+            {
                 const orthoCtx = this.globals.scnPlay.currentGrafPort;
                 const viewMtx = mat4.fromTranslation(scratchMatrix, [orthoCtx.aspectRatioCorrection * 320, 240, 0]);
                 const frustum = orthoCtx.getFrustumForView(viewMtx);
@@ -425,8 +425,14 @@ export class WindWakerRenderer implements Viewer.SceneGfx {
                 orthoCtx.setOnRenderInst(template);
 
                 globals.particleCtrl.setDrawInfo(viewMtx, orthoCtx.sceneParams.u_Projection, null, frustum);
-                renderInstManager.setCurrentList(dlst.effect[EffectDrawGroup.Main]);
-                globals.particleCtrl.draw(device, this.renderHelper.renderInstManager, group);
+                
+                renderInstManager.setCurrentList(dlst.particle2DBack);
+                globals.particleCtrl.draw(device, this.renderHelper.renderInstManager, ParticleGroup.TwoDback);
+                globals.particleCtrl.draw(device, this.renderHelper.renderInstManager, ParticleGroup.TwoDmenuBack);
+
+                renderInstManager.setCurrentList(dlst.particle2DFore);
+                globals.particleCtrl.draw(device, this.renderHelper.renderInstManager, ParticleGroup.TwoDfore);
+                globals.particleCtrl.draw(device, this.renderHelper.renderInstManager, ParticleGroup.TwoDmenuFore);
             }
         }
 
@@ -494,9 +500,11 @@ export class WindWakerRenderer implements Viewer.SceneGfx {
 
                 this.executeList(passRenderer, dlst.effect[EffectDrawGroup.Main]);
                 this.executeList(passRenderer, dlst.wetherEffect);
-                this.executeListSet(passRenderer, dlst.ui);
 
+                this.executeList(passRenderer, dlst.particle2DBack);
+                this.executeListSet(passRenderer, dlst.ui);
                 this.executeListSet(passRenderer, dlst.ui2D);
+                this.executeList(passRenderer, dlst.particle2DFore);
             });
         });
 

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -824,8 +824,8 @@ class SceneDesc {
         renderer.extraTextures = new ZWWExtraTextures(device, ZAtoon, ZBtoonEX);
 
         globals.particleCtrl = new dPa_control_c(renderer.renderCache);
-        globals.particleCtrl.createCommon(JPA.parse(modelCache.getFileData(particleArchives[0])));
-        globals.particleCtrl.createRoomScene(JPA.parse(modelCache.getFileData(particleArchives[1])));
+        globals.particleCtrl.createCommon(globals, JPA.parse(modelCache.getFileData(particleArchives[0])));
+        globals.particleCtrl.createRoomScene(globals, JPA.parse(modelCache.getFileData(particleArchives[1])));
 
         // dStage_Create
         dKankyo_create(globals);

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -823,12 +823,9 @@ class SceneDesc {
 
         renderer.extraTextures = new ZWWExtraTextures(device, ZAtoon, ZBtoonEX);
 
-        const jpac: JPA.JPAC[] = [];
-        for (let i = 0; i < particleArchives.length; i++) {
-            const jpacData = modelCache.getFileData(particleArchives[i]);
-            jpac.push(JPA.parse(jpacData));
-        }
-        globals.particleCtrl = new dPa_control_c(renderer.renderCache, jpac);
+        globals.particleCtrl = new dPa_control_c(renderer.renderCache);
+        globals.particleCtrl.createCommon(JPA.parse(modelCache.getFileData(particleArchives[0])));
+        globals.particleCtrl.createRoomScene(JPA.parse(modelCache.getFileData(particleArchives[1])));
 
         // dStage_Create
         dKankyo_create(globals);

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -35,7 +35,7 @@ import { EDemoMode, dDemo_manager_c } from './d_demo.js';
 import { dDlst_list_Set, dDlst_list_c } from './d_drawlist.js';
 import { dKankyo_create, dKy__RegisterConstructors, dKy_setLight, dScnKy_env_light_c } from './d_kankyo.js';
 import { dKyw__RegisterConstructors } from './d_kankyo_wether.js';
-import { dPa_control_c } from './d_particle.js';
+import { dPa_control_c, ParticleGroup } from './d_particle.js';
 import { Placename, PlacenameState, dPn__update, d_pn__RegisterConstructors } from './d_place_name.js';
 import { dProcName_e } from './d_procname.js';
 import { ResType, dRes_control_c } from './d_resorce.js';
@@ -403,16 +403,16 @@ export class WindWakerRenderer implements Viewer.SceneGfx {
         {
             globals.particleCtrl.calc(globals, viewerInput);
 
-            for (let group = EffectDrawGroup.Main; group <= EffectDrawGroup.Indirect; group++) {
+            for (let group = ParticleGroup.Normal; group <= ParticleGroup.TwoDmenuBack; group++) {
                 let texPrjMtx: mat4 | null = null;
 
-                if (group === EffectDrawGroup.Indirect) {
+                if (group === ParticleGroup.Projection) {
                     texPrjMtx = scratchMatrix;
                     texProjCameraSceneTex(texPrjMtx, globals.camera.clipFromViewMatrix, 1);
                 }
 
                 globals.particleCtrl.setDrawInfo(globals.camera.viewFromWorldMatrix, globals.camera.clipFromViewMatrix, texPrjMtx, globals.camera.frustum);
-                renderInstManager.setCurrentList(dlst.effect[group]);
+                renderInstManager.setCurrentList(dlst.effect[group == ParticleGroup.Projection ? EffectDrawGroup.Indirect : EffectDrawGroup.Main]);
                 globals.particleCtrl.draw(device, this.renderHelper.renderInstManager, group);
             }
         }

--- a/src/ZeldaWindWaker/Main.ts
+++ b/src/ZeldaWindWaker/Main.ts
@@ -420,11 +420,10 @@ export class WindWakerRenderer implements Viewer.SceneGfx {
             {
                 const orthoCtx = this.globals.scnPlay.currentGrafPort;
                 const viewMtx = mat4.fromTranslation(scratchMatrix, [orthoCtx.aspectRatioCorrection * 320, 240, 0]);
-                const frustum = orthoCtx.getFrustumForView(viewMtx);
                 const template = renderInstManager.pushTemplate();
                 orthoCtx.setOnRenderInst(template);
 
-                globals.particleCtrl.setDrawInfo(viewMtx, orthoCtx.sceneParams.u_Projection, null, frustum);
+                globals.particleCtrl.setDrawInfo(viewMtx, orthoCtx.sceneParams.u_Projection, null, null);
                 
                 renderInstManager.setCurrentList(dlst.particle2DBack);
                 globals.particleCtrl.draw(device, this.renderHelper.renderInstManager, ParticleGroup.TwoDback);

--- a/src/ZeldaWindWaker/d_a.ts
+++ b/src/ZeldaWindWaker/d_a.ts
@@ -249,13 +249,11 @@ class d_a_ep extends fopAc_ac_c {
         // Create particle systems.
 
         // TODO(jstpierre): Implement the real thing.
-        const pa = globals.particleCtrl.set(globals, 0, 0x0001, null)!;
-        vec3.copy(pa.globalTranslation, this.posTop);
-        pa.globalTranslation[1] += -240 + 235 + 15;
+        const pos = vec3.set(scratchVec3a, this.posTop[0], this.posTop[1] + -240 + 235 + 15, this.posTop[2]);
+        globals.particleCtrl.setSimple(0x0001, pos, 0xFF, White, White, false);
         if (this.type !== 2) {
-            const pb = globals.particleCtrl.set(globals, 0, 0x4004, null)!;
-            vec3.copy(pb.globalTranslation, pa.globalTranslation);
-            pb.globalTranslation[1] += 20;
+            pos[1] += 20;
+            globals.particleCtrl.setSimple(0x4004, pos, 0xFF, White, White, false);
         }
         const pc = globals.particleCtrl.set(globals, 0, 0x01EA, null)!;
         vec3.copy(pc.globalTranslation, this.posTop);

--- a/src/ZeldaWindWaker/d_a.ts
+++ b/src/ZeldaWindWaker/d_a.ts
@@ -4450,19 +4450,38 @@ class d_a_obj_flame extends fopAc_ac_c {
     }
 
     private em_simple_set(globals: dGlobals): void {
-        /*
         if (this.em0State === d_a_obj_em_state.TurnOn) {
             vec3.copy(scratchVec3a, this.eyePos);
             scratchVec3a[1] += this.extraScaleY * this.eyePosY * -300.0;
-            globals.particleCtrl.setSimple(globals, 0x805A, scratchVec3a, 1.0, White, White, false);
+            globals.particleCtrl.setSimple(0x805A, scratchVec3a, 0xFF, White, White, false);
         }
 
         if (this.em1State === d_a_obj_em_state.TurnOn)
-            globals.particleCtrl.setSimple(globals, 0x805B, this.eyePos, 1.0, White, White, false);
+            globals.particleCtrl.setSimple(0x805B, this.eyePos, 0xFF, White, White, false);
 
         if (this.em2State === d_a_obj_em_state.TurnOn)
-            globals.particleCtrl.setSimple(globals, this.bubblesParticleID, this.eyePos, 1.0, White, White, false);
-        */
+            globals.particleCtrl.setSimple(this.bubblesParticleID, this.pos, 0xFF, White, White, false);
+    }
+
+    private em_simple_inv(globals: dGlobals): void {
+        const forceKillEm = false;
+        if (forceKillEm) {
+            if (this.em0State === d_a_obj_em_state.On)
+                this.em0State = d_a_obj_em_state.TurnOff;
+            if (this.em2State === d_a_obj_em_state.On)
+                this.em2State = d_a_obj_em_state.TurnOff;
+        }
+
+        if (this.em0State === d_a_obj_em_state.TurnOff) {
+            this.em0 = null;
+        }
+        if (this.em1State === d_a_obj_em_state.TurnOff) {
+            this.em1 = null;
+        }
+        if (this.em2State !== d_a_obj_em_state.TurnOff) {
+            return;
+        }
+        this.em2 = null;
     }
 
     private mode_proc_call(globals: dGlobals, deltaTimeFrames: number): void {
@@ -4472,11 +4491,10 @@ class d_a_obj_flame extends fopAc_ac_c {
 
         this.mode_proc_tbl[this.mode].call(this, globals);
 
-        // TODO(jstpierre): Simple particle system
-        if (false && this.useSimpleEm) {
+        if (this.useSimpleEm) {
             this.em_position(globals);
             this.em_simple_set(globals);
-            // this.em_simple_inv(globals);
+            this.em_simple_inv(globals);
         } else {
             this.em_manual_set(globals);
             this.em_manual_inv(globals);

--- a/src/ZeldaWindWaker/d_a.ts
+++ b/src/ZeldaWindWaker/d_a.ts
@@ -30,7 +30,7 @@ import { PeekZResult } from "./d_dlst_peekZ.js";
 import { dDlst_alphaModel__Type } from "./d_drawlist.js";
 import { LIGHT_INFLUENCE, LightType, WAVE_INFO, dKy_change_colpat, dKy_checkEventNightStop, dKy_plight_cut, dKy_plight_set, dKy_setLight__OnMaterialParams, dKy_setLight__OnModelInstance, dKy_tevstr_c, dKy_tevstr_init, setLightTevColorType, settingTevStruct } from "./d_kankyo.js";
 import { ThunderMode, dKyr_get_vectle_calc, dKyw_get_AllWind_vecpow, dKyw_get_wind_pow, dKyw_get_wind_vec, dKyw_rain_set, loadRawTexture } from "./d_kankyo_wether.js";
-import { dPa_splashEcallBack, dPa_trackEcallBack, dPa_waveEcallBack } from "./d_particle.js";
+import { dPa_splashEcallBack, dPa_trackEcallBack, dPa_waveEcallBack, ParticleGroup } from "./d_particle.js";
 import { dProcName_e } from "./d_procname.js";
 import { ResType, dComIfG_resLoad } from "./d_resorce.js";
 import { dPath, dPath_GetRoomPath, dPath__Point, dStage_Multi_c, dStage_stagInfo_GetSTType } from "./d_stage.js";
@@ -5797,7 +5797,7 @@ const enum TitlePane {
     JapanSubtitle,
     PressStart,
     Nintendo,
-    Effect1,
+    ShipParticles,
     Effect2,
 }
 
@@ -5813,7 +5813,8 @@ class d_a_title extends fopAc_ac_c {
     private btkSubtitle = new mDoExt_btkAnm();
     private btkShimmer = new mDoExt_btkAnm();
     private screen: J2DScreen;
-    private panes: J2DPane[] = [];
+    private panes: J2DPane[] = []; 
+    private emitter: JPABaseEmitter | null = null;
 
     private anmFrameCounter = 0
     private delayFrameCounter = 120;
@@ -5842,7 +5843,7 @@ class d_a_title extends fopAc_ac_c {
                 // TODO: mDoAud_seStart(JA_SE_TITLE_WIND);
             }
         } else {
-            this.calc_2d_alpha(deltaTimeFrames);
+            this.calc_2d_alpha(globals, deltaTimeFrames);
         }
 
         if (this.enterMode == 2) {
@@ -5970,7 +5971,7 @@ class d_a_title extends fopAc_ac_c {
         mDoMtx_ZXYrotM(this.modelSubtitleShimmer.modelMatrix, [0, -0x8000, 0]);
     }
 
-    private calc_2d_alpha(deltaTimeFrames: number) {
+    private calc_2d_alpha(globals: dGlobals, deltaTimeFrames: number) {
         this.anmFrameCounter += deltaTimeFrames;
         if (this.anmFrameCounter >= 200 && this.enterMode == 0) {
             this.enterMode = 1;
@@ -5981,7 +5982,17 @@ class d_a_title extends fopAc_ac_c {
                 this.shipFrameCounter += deltaTimeFrames;
             }
 
-            // TODO: Emitters
+            const emitterPos = vec3.set(scratchVec3a, 
+                ((this.panes[TitlePane.ShipParticles].data.x - 320.0) - this.shipOffsetX) + 85.0,
+                (this.panes[TitlePane.ShipParticles].data.y - 240.0) + 5.0,
+                0.0
+            );
+
+            if (this.emitter == null) {
+                this.emitter = globals.particleCtrl.set(globals, ParticleGroup.TwoDback, 0x83F9, emitterPos);
+            } else {    
+                this.emitter.setGlobalTranslation(emitterPos);
+            }
 
             if (this.anmFrameCounter <= 30) {
                 this.panes[TitlePane.MainTitle].setAlpha(0.0);

--- a/src/ZeldaWindWaker/d_a.ts
+++ b/src/ZeldaWindWaker/d_a.ts
@@ -350,11 +350,11 @@ class d_a_ep extends fopAc_ac_c {
             this.lightPowerTarget = this.scale[0];
         } else if (this.state === 3 || this.state === 4) {
             this.lightPower = cLib_addCalc2(this.lightPower, this.lightPowerTarget, 0.5 * deltaTimeFrames, 0.2);
-            if (this.type !== 2) {
+            
+            // TODO: Type 2 flames should be handled by d_a_lamp, but for now lets just handle them here 
+            if (true || this.type !== 2) {
                 if (this.burstTimer < 7) globals.particleCtrl.setSimple(0x0001, flamePos, 0xFF, White, White, false);
                 // Check for collision. If hit, set the burst timer to emit a quick burst of flame 
-
-                // Emit a heat particle and reset the timer
                 flamePos[1] += 20;
                 globals.particleCtrl.setSimple(0x4004, flamePos, 0xFF, White, White, false);
             }

--- a/src/ZeldaWindWaker/d_a.ts
+++ b/src/ZeldaWindWaker/d_a.ts
@@ -246,18 +246,6 @@ class d_a_ep extends fopAc_ac_c {
 
         dKy_plight_set(globals.g_env_light, this.light);
 
-        // Create particle systems.
-
-        // TODO(jstpierre): Implement the real thing.
-        const pos = vec3.set(scratchVec3a, this.posTop[0], this.posTop[1] + -240 + 235 + 15, this.posTop[2]);
-        globals.particleCtrl.setSimple(0x0001, pos, 0xFF, White, White, false);
-        if (this.type !== 2) {
-            pos[1] += 20;
-            globals.particleCtrl.setSimple(0x4004, pos, 0xFF, White, White, false);
-        }
-        const pc = globals.particleCtrl.set(globals, 0, 0x01EA, null)!;
-        vec3.copy(pc.globalTranslation, this.posTop);
-        pc.globalTranslation[1] += -240 + 235 + 8;
         // TODO(jstpierre): ga
 
         return cPhs__Status.Next;
@@ -318,7 +306,7 @@ class d_a_ep extends fopAc_ac_c {
         this.alphaModelRotY += 0xD0 * deltaTimeFrames;
         this.alphaModelRotX += 0x100 * deltaTimeFrames;
 
-        this.ep_move();
+        this.ep_move(globals);
     }
 
     public override delete(globals: dGlobals): void {
@@ -347,7 +335,7 @@ class d_a_ep extends fopAc_ac_c {
         // TODO(jstpierre): ga
     }
 
-    private ep_move(): void {
+    private ep_move(globals: dGlobals): void {
         // tons of fun timers and such
         if (this.state === 0) {
             // check switches
@@ -356,8 +344,12 @@ class d_a_ep extends fopAc_ac_c {
         } else if (this.state === 3 || this.state === 4) {
             this.lightPower = cLib_addCalc2(this.lightPower, this.lightPowerTarget, 0.5, 0.2);
             if (this.type !== 2) {
+                const pos = vec3.set(scratchVec3a, this.posTop[0], this.posTop[1] + -240 + 235 + 15, this.posTop[2]);
+                globals.particleCtrl.setSimple(0x0001, pos, 0xFF, White, White, false);
+                pos[1] += 20;
+                globals.particleCtrl.setSimple(0x4004, pos, 0xFF, White, White, false);
+
                 // check a bunch of stuff, collision, etc.
-                // setSimple 0x4004
             }
         }
 

--- a/src/ZeldaWindWaker/d_drawlist.ts
+++ b/src/ZeldaWindWaker/d_drawlist.ts
@@ -205,6 +205,9 @@ export class dDlst_list_c {
         new GfxRenderInstList(gfxRenderInstCompareNone, GfxRenderInstExecutionOrder.Forwards)
     ];
 
+    public particle2DBack = new GfxRenderInstList(gfxRenderInstCompareNone, GfxRenderInstExecutionOrder.Forwards);
+    public particle2DFore = new GfxRenderInstList(gfxRenderInstCompareNone, GfxRenderInstExecutionOrder.Forwards);
+
     public alphaModel = new GfxRenderInstList(gfxRenderInstCompareNone, GfxRenderInstExecutionOrder.Forwards);
     public peekZ = new PeekZManager(128);
     public alphaModel0: dDlst_alphaModel_c;

--- a/src/ZeldaWindWaker/d_particle.ts
+++ b/src/ZeldaWindWaker/d_particle.ts
@@ -82,9 +82,9 @@ export class dPa_control_c {
             setTextureMappingIndirect(m, this.flipY);
         this.jpacData.push(jpacData);
 
-        for(let id of j_o_id) {
+        for (let id of j_o_id) {
             const resData = this.getResData(globals, id);
-            if(resData) {
+            if (resData) {
                 this.newSimple(resData, id, id & 0x4000 ? ParticleGroup.Projection : ParticleGroup.Normal)
             }
         }
@@ -97,9 +97,9 @@ export class dPa_control_c {
             setTextureMappingIndirect(m, this.flipY);
         this.jpacData.push(jpacData);
 
-        for(let id of s_o_id) {
+        for (let id of s_o_id) {
             const resData = this.getResData(globals, id);
-            if(resData) {
+            if (resData) {
                 let groupID;
                 if (id & 0x4000) groupID = ParticleGroup.Projection;
                 else if (id & 0x2000) groupID = ParticleGroup.Toon;
@@ -267,7 +267,7 @@ class dPa_simpleEcallBack extends JPAEmitterCallBack {
         this.userID = userID;
         this.groupID = groupID;
         this.baseEmitter = emitterManager.createEmitter(resData);
-        if(this.baseEmitter) {
+        if (this.baseEmitter) {
             this.baseEmitter.drawGroupId = groupID;
             this.baseEmitter.emitterCallBack = this;
             this.baseEmitter.maxFrame = 0;
@@ -290,7 +290,7 @@ class dPa_simpleEcallBack extends JPAEmitterCallBack {
     }
 
     public set(pos: vec3, alpha: number, prmColor: Color, envColor: Color, isAffectedByWind: boolean) {
-        this.datas.push({ pos: vec3.clone(pos), prmColor: colorNewCopy(prmColor, alpha), envColor: colorNewCopy(envColor), isAffectedByWind});
+        this.datas.push({ pos: vec3.clone(pos), prmColor: colorNewCopy(prmColor, alpha), envColor: colorNewCopy(envColor), isAffectedByWind });
     }
 
     public override executeAfter(emitter: JPABaseEmitter): void {
@@ -307,16 +307,16 @@ class dPa_simpleEcallBack extends JPAEmitterCallBack {
         this.emitCount -= emitThisFrame;
 
         emitter.playCreateParticle();
-        for(let simple of this.datas) {
+        for (let simple of this.datas) {
             // TODO: Frustum culling
             emitter.setGlobalTranslation(workData.emitterTranslation);
             colorCopy(emitter.globalColorPrm, simple.prmColor);
             colorCopy(emitter.globalColorEnv, simple.envColor);
             for (let i = 0; i < emitThisFrame; i++) {
                 const particle = emitter.createParticle();
-                if(!particle) 
+                if (!particle)
                     break;
-                
+
                 vec3.copy(particle.offsetPosition, simple.pos);
                 if (simple.isAffectedByWind) {
                     // TODO: Wind callback

--- a/src/ZeldaWindWaker/d_particle.ts
+++ b/src/ZeldaWindWaker/d_particle.ts
@@ -270,6 +270,8 @@ class dPa_simpleEcallBack extends JPAEmitterCallBack {
         if(this.baseEmitter) {
             this.baseEmitter.drawGroupId = groupID;
             this.baseEmitter.emitterCallBack = this;
+            this.baseEmitter.maxFrame = 0;
+            this.baseEmitter.stopCreateParticle();
 
             // From dPa_simpleEcallBack::draw(). Fixup TEV settings for particles that access the framebuffer.  
             if (groupID == ParticleGroup.Projection) {
@@ -307,7 +309,7 @@ class dPa_simpleEcallBack extends JPAEmitterCallBack {
         emitter.playCreateParticle();
         for(let simple of this.datas) {
             // TODO: Frustum culling
-            vec3.copy(workData.emitterTranslation, simple.pos);
+            emitter.setGlobalTranslation(workData.emitterTranslation);
             colorCopy(emitter.globalColorPrm, simple.prmColor);
             colorCopy(emitter.globalColorEnv, simple.envColor);
             for (let i = 0; i < emitThisFrame; i++) {

--- a/src/ZeldaWindWaker/d_particle.ts
+++ b/src/ZeldaWindWaker/d_particle.ts
@@ -158,6 +158,7 @@ export class dPa_control_c {
         return null;
     }
 
+    // TODO: Remove
     private patchResData(globals: dGlobals, resData: JPAResourceData): void {
         if (resData.resourceId & 0x4000) {
             const m = resData.materialHelper.material;
@@ -316,7 +317,9 @@ class dPa_simpleEcallBack extends JPAEmitterCallBack {
                 const particle = emitter.createParticle();
                 if (!particle)
                     break;
-
+                
+                // NOTE: Overwriting this removes the influence of the local emitter translation (bem.emitterTrs)
+                //       I.e. all simple emitters ignore their local offsets and are fixed to the local origin.
                 vec3.copy(particle.offsetPosition, simple.pos);
                 if (simple.isAffectedByWind) {
                     // TODO: Wind callback

--- a/src/ZeldaWindWaker/d_particle.ts
+++ b/src/ZeldaWindWaker/d_particle.ts
@@ -287,20 +287,21 @@ class dPa_simpleEcallBack extends JPAEmitterCallBack {
 
         emitter.playCreateParticle();
         for (let simple of this.datas) {
-            // TODO: Frustum culling
-            emitter.setGlobalTranslation(workData.emitterTranslation);
-            colorCopy(emitter.globalColorPrm, simple.prmColor);
-            colorCopy(emitter.globalColorEnv, simple.envColor);
-            for (let i = 0; i < emitThisFrame; i++) {
-                const particle = emitter.createParticle();
-                if (!particle)
-                    break;
-                
-                // NOTE: Overwriting this removes the influence of the local emitter translation (bem.emitterTrs)
-                //       I.e. all simple emitters ignore their local offsets and are fixed to the local origin.
-                vec3.copy(particle.offsetPosition, simple.pos);
-                if (simple.isAffectedByWind) {
-                    // TODO: Wind callback
+            if (!workData.frustum || workData.frustum.containsSphere(simple.pos, 200)) {
+                emitter.setGlobalTranslation(simple.pos);
+                colorCopy(emitter.globalColorPrm, simple.prmColor);
+                colorCopy(emitter.globalColorEnv, simple.envColor);
+                for (let i = 0; i < emitThisFrame; i++) {
+                    const particle = emitter.createParticle();
+                    if (!particle)
+                        break;
+                    
+                    // NOTE: Overwriting this removes the influence of the local emitter translation (bem.emitterTrs)
+                    //       I.e. all simple emitters ignore their local offsets and are fixed to the local origin.
+                    vec3.copy(particle.offsetPosition, simple.pos);
+                    if (simple.isAffectedByWind) {
+                        // TODO: Wind callback
+                    }
                 }
             }
         }

--- a/src/ZeldaWindWaker/d_particle.ts
+++ b/src/ZeldaWindWaker/d_particle.ts
@@ -127,6 +127,11 @@ export class dPa_control_c {
         // Some hacky distance culling for emitters.
         for (let i = 0; i < this.emitterManager.aliveEmitters.length; i++) {
             const emitter = this.emitterManager.aliveEmitters[i];
+            
+            // Don't distance cull 2D/UI emitters
+            if(emitter.drawGroupId >= ParticleGroup.TwoDfore)
+                continue;
+
             const cullDistance = (emitter as any).cullDistance ?? 5000;
             if (vec3.distance(emitter.globalTranslation, globals.camera.cameraPos) > cullDistance) {
                 emitter.stopCalcEmitter();

--- a/src/ZeldaWindWaker/d_particle.ts
+++ b/src/ZeldaWindWaker/d_particle.ts
@@ -2,7 +2,7 @@
 // particle
 
 import { mat4, ReadonlyMat4, ReadonlyVec3, vec2, vec3 } from "gl-matrix";
-import { Color, colorCopy } from "../Color.js";
+import { Color, colorCopy, colorNewCopy } from "../Color.js";
 import { JPABaseEmitter, JPAEmitterManager, JPAResourceData, JPAEmitterCallBack, JPADrawInfo, JPACData, JPAC, JPAResourceRaw } from "../Common/JSYSTEM/JPA.js";
 import { Frustum } from "../Geometry.js";
 import { GfxDevice } from "../gfx/platform/GfxPlatform.js";
@@ -11,7 +11,7 @@ import { EFB_HEIGHT, EFB_WIDTH } from "../gx/gx_material.js";
 import { computeModelMatrixR, getMatrixTranslation, saturate, transformVec3Mat4w0 } from "../MathHelpers.js";
 import { TDDraw } from "../SuperMarioGalaxy/DDraw.js";
 import { TextureMapping } from "../TextureHolder.js";
-import { nArray } from "../util.js";
+import { assert, nArray } from "../util.js";
 import { ViewerRenderInput } from "../viewer.js";
 import { dKy_get_seacolor } from "./d_kankyo.js";
 import { cLib_addCalc2, cM_s2rad } from "./SComponent.js";
@@ -20,6 +20,16 @@ import * as GX from '../gx/gx_enum.js';
 import { ColorKind } from "../gx/gx_render.js";
 import { gfxDeviceNeedsFlipY } from "../gfx/helpers/GfxDeviceHelpers.js";
 import { GfxRenderCache } from "../gfx/render/GfxRenderCache.js";
+
+// Simple common particles
+const j_o_id: number[] = [ 0x0000, 0x0001, 0x0002, 0x0003, 0x03DA, 0x03DB, 0x03DC, 0x4004 ];
+
+// Simple scene particles
+const s_o_id: number[] = [
+    0x8058, 0x8059, 0x805A, 0x805B, 0x805C, 0x8221, 0x8222, 0x8060, 0x8061, 0x8062, 0x8063, 0x8064, 0x8065, 0x8066, 
+    0x8067, 0x8068, 0x8069, 0x81D5, 0x8240, 0x8241, 0x8306, 0x8407, 0x8408, 0x8409, 0x8443, 0x840A, 0x840B, 0x840C,
+    0x840D, 0x840E, 0x840F, 0xA410, 0xA06A, 0xC06B,
+];
 
 export abstract class dPa_levelEcallBack extends JPAEmitterCallBack {
     constructor(protected globals: dGlobals) {
@@ -57,6 +67,7 @@ export class dPa_control_c {
     private jpacData: JPACData[] = [];
     private resourceDatas = new Map<number, JPAResourceData>();
     private flipY: boolean;
+    private simpleCallbacks: dPa_simpleEcallBack[] = [];
 
     constructor(cache: GfxRenderCache) {
         const device = cache.device;
@@ -64,21 +75,44 @@ export class dPa_control_c {
         this.emitterManager = new JPAEmitterManager(cache, 6000, 300);
     }
 
-    public createCommon(commonJpac: JPAC) {
+    public createCommon(globals: dGlobals, commonJpac: JPAC) {
         const jpacData = new JPACData(commonJpac);
         const m = jpacData.getTextureMappingReference('AK_kagerouSwap00');
         if (m !== null)
             setTextureMappingIndirect(m, this.flipY);
         this.jpacData.push(jpacData);
+
+        for(let id of j_o_id) {
+            const resData = this.getResData(globals, id);
+            if(resData) {
+                this.newSimple(resData, id, id & 0x4000 ? ParticleGroup.Projection : ParticleGroup.Normal)
+            }
+        }
     }
 
-    public createRoomScene(sceneJpac: JPAC) {
+    public createRoomScene(globals: dGlobals, sceneJpac: JPAC) {
         const jpacData = new JPACData(sceneJpac);
         const m = jpacData.getTextureMappingReference('AK_kagerouSwap00');
         if (m !== null)
             setTextureMappingIndirect(m, this.flipY);
-
         this.jpacData.push(jpacData);
+
+        for(let id of s_o_id) {
+            const resData = this.getResData(globals, id);
+            if(resData) {
+                let groupID;
+                if (id & 0x4000) groupID = ParticleGroup.Projection;
+                else if (id & 0x2000) groupID = ParticleGroup.Toon;
+                else groupID = ParticleGroup.Normal;
+                this.newSimple(resData, id, groupID)
+            }
+        }
+    }
+
+    private newSimple(resData: JPAResourceData, userID: number, groupID: number) {
+        const simple = new dPa_simpleEcallBack();
+        simple.create(this.emitterManager, resData, userID, groupID);
+        this.simpleCallbacks.push(simple);
     }
 
     public setDrawInfo(posCamMtx: ReadonlyMat4, prjMtx: ReadonlyMat4, texPrjMtx: ReadonlyMat4 | null, frustum: Frustum): void {
@@ -201,23 +235,81 @@ export class dPa_control_c {
         return baseEmitter;
     }
 
-    // TODO(jstpierre): Full simple particle system
-/*
-    public setSimple(globals: dGlobals, userID: number, pos: ReadonlyVec3, alpha: number = 1.0, colorPrm: Color | null = null, colorEnv: Color | null = null, affectedByWind: boolean = false): boolean {
-        let groupID = EffectDrawGroup.Main;
-
-        if (!!(userID & 0x4000))
-            groupID = EffectDrawGroup.Indirect;
-
-        this.set(globals, groupID, userID, pos, null, null, alpha, null, 0, colorPrm, colorEnv);
-        return true;
+    public setSimple(userID: number, pos: vec3, alpha: number, prmColor: Color, envColor: Color, isAffectedByWind: boolean) {
+        const simple = this.simpleCallbacks.find(s => s.userID == userID);
+        if (!simple)
+            return false;
+        return simple.set(pos, alpha / 0xFF, prmColor, envColor, isAffectedByWind);
     }
-*/
 
     public destroy(device: GfxDevice): void {
         for (let i = 0; i < this.jpacData.length; i++)
             this.jpacData[i].destroy(device);
         this.emitterManager.destroy(device);
+    }
+}
+
+interface dPa_simpleData_c {
+    pos: vec3;
+    prmColor: Color;
+    envColor: Color;
+    isAffectedByWind: boolean;
+};
+
+class dPa_simpleEcallBack extends JPAEmitterCallBack {
+    public userID: number;
+    public groupID: number;
+    private baseEmitter: JPABaseEmitter | null;
+    private datas: dPa_simpleData_c[] = [];
+    private emitCount: number = 0;
+
+    public create(emitterManager: JPAEmitterManager, resData: JPAResourceData, userID: number, groupID: number) {
+        this.userID = userID;
+        this.groupID = groupID;
+        this.baseEmitter = emitterManager.createEmitter(resData);
+        if(this.baseEmitter) {
+            this.baseEmitter.emitterCallBack = this;
+            if(userID == 0xa06a || userID == 0xa410) {
+                // TODO: Smoke callback
+            }
+        }
+    }
+
+    public set(pos: vec3, alpha: number, prmColor: Color, envColor: Color, isAffectedByWind: boolean) {
+        this.datas.push({ pos: vec3.clone(pos), prmColor: colorNewCopy(prmColor, alpha), envColor: colorNewCopy(envColor), isAffectedByWind});
+    }
+
+    public override executeAfter(emitter: JPABaseEmitter): void {
+        const workData = emitter.emitterManager.workData;
+        if (workData.volumeEmitCount <= 0) {
+            this.datas = [];
+            return;
+        }
+
+        // The emit count is often 1 per game-frame, meaning our emit count will be ~0.5 
+        // So we track the emit count across frames and only actually emit when it is >1
+        this.emitCount += workData.volumeEmitCount * workData.deltaTime;
+        const emitThisFrame = Math.floor(this.emitCount);
+        this.emitCount -= emitThisFrame;
+
+        emitter.playCreateParticle();
+        for(let simple of this.datas) {
+            // TODO: Frustum culling
+            vec3.copy(workData.emitterTranslation, simple.pos);
+            colorCopy(emitter.globalColorPrm, simple.prmColor);
+            colorCopy(emitter.globalColorEnv, simple.envColor);
+            for (let i = 0; i < emitThisFrame; i++) {
+                const particle = emitter.createParticle();
+                if(!particle) 
+                    break;
+                
+                vec3.copy(particle.offsetPosition, simple.pos);
+                if (simple.isAffectedByWind) {
+                    // TODO: Wind callback
+                }
+            }
+        }
+        emitter.stopCreateParticle();
     }
 }
 

--- a/src/ZeldaWindWaker/d_particle.ts
+++ b/src/ZeldaWindWaker/d_particle.ts
@@ -30,9 +30,18 @@ export abstract class dPa_levelEcallBack extends JPAEmitterCallBack {
     }
 }
 
-const enum EffectDrawGroup {
-    Main = 0,
-    Indirect = 1,
+export const enum ParticleGroup {
+    Normal,
+    NormalP1,
+    Toon,
+    ToonP1,
+    Projection,
+    ShipTail,
+    Wind,
+    TwoDfore,
+    TwoDback,
+    TwoDmenuFore,
+    TwoDmenuBack,
 }
 
 function setTextureMappingIndirect(m: TextureMapping, flipY: boolean): void {
@@ -159,9 +168,9 @@ export class dPa_control_c {
         // This seems to mark it as an indirect particle (???) for simple particles.
         // ref. d_paControl_c::readCommon / readRoomScene
         if (!!(userID & 0x4000)) {
-            baseEmitter.drawGroupId = EffectDrawGroup.Indirect;
+            baseEmitter.drawGroupId = ParticleGroup.Projection;
         } else {
-            baseEmitter.drawGroupId = EffectDrawGroup.Main;
+            baseEmitter.drawGroupId = ParticleGroup.Normal;
         }
 
         if (pos !== null)

--- a/src/ZeldaWindWaker/d_particle.ts
+++ b/src/ZeldaWindWaker/d_particle.ts
@@ -317,6 +317,7 @@ class dPa_simpleEcallBack extends JPAEmitterCallBack {
                 }
             }
         }
+        this.datas = [];
         emitter.stopCreateParticle();
     }
 }

--- a/src/ZeldaWindWaker/d_particle.ts
+++ b/src/ZeldaWindWaker/d_particle.ts
@@ -47,20 +47,29 @@ export class dPa_control_c {
     private drawInfo = new JPADrawInfo();
     private jpacData: JPACData[] = [];
     private resourceDatas = new Map<number, JPAResourceData>();
+    private flipY: boolean;
 
-    constructor(cache: GfxRenderCache, private jpac: JPAC[]) {
+    constructor(cache: GfxRenderCache) {
         const device = cache.device;
-        const flipY = gfxDeviceNeedsFlipY(device);
+        this.flipY = gfxDeviceNeedsFlipY(device);
         this.emitterManager = new JPAEmitterManager(cache, 6000, 300);
-        for (let i = 0; i < this.jpac.length; i++) {
-            const jpacData = new JPACData(this.jpac[i]);
+    }
 
-            const m = jpacData.getTextureMappingReference('AK_kagerouSwap00');
-            if (m !== null)
-                setTextureMappingIndirect(m, flipY);
+    public createCommon(commonJpac: JPAC) {
+        const jpacData = new JPACData(commonJpac);
+        const m = jpacData.getTextureMappingReference('AK_kagerouSwap00');
+        if (m !== null)
+            setTextureMappingIndirect(m, this.flipY);
+        this.jpacData.push(jpacData);
+    }
 
-            this.jpacData.push(jpacData);
-        }
+    public createRoomScene(sceneJpac: JPAC) {
+        const jpacData = new JPACData(sceneJpac);
+        const m = jpacData.getTextureMappingReference('AK_kagerouSwap00');
+        if (m !== null)
+            setTextureMappingIndirect(m, this.flipY);
+
+        this.jpacData.push(jpacData);
     }
 
     public setDrawInfo(posCamMtx: ReadonlyMat4, prjMtx: ReadonlyMat4, texPrjMtx: ReadonlyMat4 | null, frustum: Frustum): void {
@@ -127,6 +136,8 @@ export class dPa_control_c {
                 const resData = new JPAResourceData(device, cache, jpacData, jpaResRaw);
                 this.patchResData(globals, resData);
                 this.resourceDatas.set(userIndex, resData);
+            } else {
+                return null;
             }
         }
 

--- a/src/ZeldaWindWaker/d_particle.ts
+++ b/src/ZeldaWindWaker/d_particle.ts
@@ -199,15 +199,6 @@ export class dPa_control_c {
 
         baseEmitter.drawGroupId = groupID;
 
-        // HACK for now
-        // This seems to mark it as an indirect particle (???) for simple particles.
-        // ref. d_paControl_c::readCommon / readRoomScene
-        if (!!(userID & 0x4000)) {
-            baseEmitter.drawGroupId = ParticleGroup.Projection;
-        } else {
-            baseEmitter.drawGroupId = ParticleGroup.Normal;
-        }
-
         if (pos !== null)
             vec3.copy(baseEmitter.globalTranslation, pos);
         if (rot !== null)

--- a/src/ZeldaWindWaker/d_particle.ts
+++ b/src/ZeldaWindWaker/d_particle.ts
@@ -158,19 +158,6 @@ export class dPa_control_c {
         return null;
     }
 
-    // TODO: Remove
-    private patchResData(globals: dGlobals, resData: JPAResourceData): void {
-        if (resData.resourceId & 0x4000) {
-            const m = resData.materialHelper.material;
-            m.tevStages[0].alphaInA = GX.CA.ZERO;
-            m.tevStages[0].alphaInB = GX.CA.ZERO;
-            m.tevStages[0].alphaInC = GX.CA.ZERO;
-            m.tevStages[0].alphaInD = GX.CA.A0;
-
-            resData.materialHelper.materialInvalidated();
-        }
-    }
-
     private getResData(globals: dGlobals, userIndex: number): JPAResourceData | null {
         if (!this.resourceDatas.has(userIndex)) {
             const data = this.findResData(userIndex);
@@ -178,7 +165,6 @@ export class dPa_control_c {
                 const [jpacData, jpaResRaw] = data;
                 const device = globals.modelCache.device, cache = globals.modelCache.cache;
                 const resData = new JPAResourceData(device, cache, jpacData, jpaResRaw);
-                this.patchResData(globals, resData);
                 this.resourceDatas.set(userIndex, resData);
             } else {
                 return null;

--- a/src/ZeldaWindWaker/d_particle.ts
+++ b/src/ZeldaWindWaker/d_particle.ts
@@ -75,7 +75,7 @@ export class dPa_control_c {
         this.emitterManager = new JPAEmitterManager(cache, 6000, 300);
     }
 
-    public createCommon(globals: dGlobals, commonJpac: JPAC) {
+    public createCommon(globals: dGlobals, commonJpac: JPAC): void {
         const jpacData = new JPACData(commonJpac);
         const m = jpacData.getTextureMappingReference('AK_kagerouSwap00');
         if (m !== null)
@@ -90,7 +90,7 @@ export class dPa_control_c {
         }
     }
 
-    public createRoomScene(globals: dGlobals, sceneJpac: JPAC) {
+    public createRoomScene(globals: dGlobals, sceneJpac: JPAC): void {
         const jpacData = new JPACData(sceneJpac);
         const m = jpacData.getTextureMappingReference('AK_kagerouSwap00');
         if (m !== null)
@@ -109,7 +109,7 @@ export class dPa_control_c {
         }
     }
 
-    private newSimple(resData: JPAResourceData, userID: number, groupID: number) {
+    private newSimple(resData: JPAResourceData, userID: number, groupID: number): void {
         const simple = new dPa_simpleEcallBack();
         simple.create(this.emitterManager, resData, userID, groupID);
         this.simpleCallbacks.push(simple);
@@ -227,7 +227,7 @@ export class dPa_control_c {
         return baseEmitter;
     }
 
-    public setSimple(userID: number, pos: vec3, alpha: number, prmColor: Color, envColor: Color, isAffectedByWind: boolean) {
+    public setSimple(userID: number, pos: vec3, alpha: number, prmColor: Color, envColor: Color, isAffectedByWind: boolean): boolean {
         const simple = this.simpleCallbacks.find(s => s.userID == userID);
         if (!simple)
             return false;
@@ -281,8 +281,9 @@ class dPa_simpleEcallBack extends JPAEmitterCallBack {
         }
     }
 
-    public set(pos: vec3, alpha: number, prmColor: Color, envColor: Color, isAffectedByWind: boolean) {
+    public set(pos: vec3, alpha: number, prmColor: Color, envColor: Color, isAffectedByWind: boolean): boolean {
         this.datas.push({ pos: vec3.clone(pos), prmColor: colorNewCopy(prmColor, alpha), envColor: colorNewCopy(envColor), isAffectedByWind });
+        return true;
     }
 
     public override executeAfter(emitter: JPABaseEmitter): void {

--- a/src/ZeldaWindWaker/d_particle.ts
+++ b/src/ZeldaWindWaker/d_particle.ts
@@ -268,8 +268,20 @@ class dPa_simpleEcallBack extends JPAEmitterCallBack {
         this.groupID = groupID;
         this.baseEmitter = emitterManager.createEmitter(resData);
         if(this.baseEmitter) {
+            this.baseEmitter.drawGroupId = groupID;
             this.baseEmitter.emitterCallBack = this;
-            if(userID == 0xa06a || userID == 0xa410) {
+
+            // From dPa_simpleEcallBack::draw(). Fixup TEV settings for particles that access the framebuffer.  
+            if (groupID == ParticleGroup.Projection) {
+                const m = resData.materialHelper.material;
+                m.tevStages[0].alphaInA = GX.CA.ZERO;
+                m.tevStages[0].alphaInB = GX.CA.ZERO;
+                m.tevStages[0].alphaInC = GX.CA.ZERO;
+                m.tevStages[0].alphaInD = GX.CA.A0;
+                resData.materialHelper.materialInvalidated();
+            }
+
+            if (userID == 0xa06a || userID == 0xa410) {
                 // TODO: Smoke callback
             }
         }

--- a/src/ZeldaWindWaker/d_particle.ts
+++ b/src/ZeldaWindWaker/d_particle.ts
@@ -115,7 +115,7 @@ export class dPa_control_c {
         this.simpleCallbacks.push(simple);
     }
 
-    public setDrawInfo(posCamMtx: ReadonlyMat4, prjMtx: ReadonlyMat4, texPrjMtx: ReadonlyMat4 | null, frustum: Frustum): void {
+    public setDrawInfo(posCamMtx: ReadonlyMat4, prjMtx: ReadonlyMat4, texPrjMtx: ReadonlyMat4 | null, frustum: Frustum | null): void {
         this.drawInfo.posCamMtx = posCamMtx;
         this.drawInfo.texPrjMtx = texPrjMtx;
         this.drawInfo.frustum = frustum;


### PR DESCRIPTION
- Added Simple particle system (shares emitters for common particle types, eg. flame) 
  - Removed a few TODOs and HACKs related to this (more to come)
  - Allow particles for which `(userID & 0x4000)` is true to be drawn in a particle group other than `Projection`/`Indirect`
- Introduced ParticleGroup enum. Partially determines partical draw order, and in the future some other state such as the current view matrix
- Add support for 2D/UI particle groups
  - These emitters expect different view/proj matrices (ortho, 640x480), and to be drawn later than the 3D emitters
- Fixes incorrect Y position of flame emitters (d_a_ep). Simple particles ignore the emitter translation from their definition, resulting in flame emitters being 20 units lower which matches up with the original game (see flame positioning against torches)

![zww_title_2025-01-03T19_05_20 592Z](https://github.com/user-attachments/assets/77974b36-1ec9-4839-8862-f77d6c8e065d)

 
![zww_Cave01_2025-01-03T17_23_11 201Z](https://github.com/user-attachments/assets/aafee607-565e-4e51-8714-e3a94282b8ab)


Impetus here is that the emitters used in d_a_title need to draw into a new ParticleGroup that supports ortho view/proj matrices. Since those emitters have their 0x4000 ID bit set, fixing up the `simple` system seemed appropriate.

"Bomb Island" and "Beedle's Shop" are good scene's to analyze `d_a_ep` (flames) which are the first actor to use the new simple system. "Dragon Roost Cavern" features `d_a_obj_flame` actors that have `useSimpleEm` set. The "Title Screen" demo can be used to test 2D emitters.
  