### PR TITLE
Unity optimization + bugfix

### DIFF
--- a/src/Common/Unity/AssetManager.ts
+++ b/src/Common/Unity/AssetManager.ts
@@ -156,8 +156,10 @@ export class AssetFile {
         this.waitForHeaderPromise = null;
     }
 
-    public waitForHeader(): Promise<void> {
-        return assertExists(this.waitForHeaderPromise);
+    public async waitForHeader() {
+        if (this.waitForHeaderPromise !== null) {
+            await this.waitForHeaderPromise;
+        }
     }
 
     private async initFullInternal(dataFetcher: DataFetcher): Promise<void> {


### PR DESCRIPTION
Instead of doing `u8::read()` in a hot loop, just pull out the entire array of bytes at once.