### PR TITLE
Use PUBLIC_STORAGE_URL variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PUBLIC_STORAGE_URL=https://z.noclip.website

--- a/src/DataFetcher.ts
+++ b/src/DataFetcher.ts
@@ -11,8 +11,7 @@ export interface NamedArrayBufferSlice extends ArrayBufferSlice {
 function getDataStorageBaseURL(isDevelopment: boolean): string {
     if (isDevelopment)
         return `/data`;
-    else
-        return `https://z.noclip.website`;
+    return import.meta.env.PUBLIC_STORAGE_URL;
 }
 
 function getDataURLForPath(url: string, isDevelopment: boolean): string {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@rsbuild/core/types" />


### PR DESCRIPTION
Allows overriding the storage URL using a build-time env var

The `PUBLIC_` prefix is a convention that allows the code to pull it in: https://rsbuild.dev/guide/advanced/env-vars#public-variables