### PR TITLE
Fix zuldrak

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,8 +13,10 @@ crate-type = ["cdylib", "rlib"]
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ['-O', '--enable-bulk-memory']
 
-[package.metadata.wasm-pack.profile.profiling]
+[package.metadata.wasm-pack.profile.dev]
 wasm-opt = ['-Os', '--enable-bulk-memory', '--debuginfo']
+
+[package.metadata.wasm-pack.profile.dev.wasm-bindgen]
 demangle-name-section = true
 dwarf-debug-info = true
 

--- a/rust/src/wow/common.rs
+++ b/rust/src/wow/common.rs
@@ -100,6 +100,7 @@ impl<'a> Iterator for ChunkedData<'a> {
         let (_, chunk) = Chunk::from_bytes((&self.data[self.idx..], 0)).unwrap();
         let chunk_start = self.idx + 8;
         let mut chunk_end = chunk_start + chunk.size as usize;
+        // hack: ADTs in Zul'Drak seem to be missing 1 chunk for some reason
         if chunk_end > self.data.len() {
             chunk_end = self.data.len() - 1;
         }

--- a/rust/src/wow/common.rs
+++ b/rust/src/wow/common.rs
@@ -99,7 +99,10 @@ impl<'a> Iterator for ChunkedData<'a> {
         }
         let (_, chunk) = Chunk::from_bytes((&self.data[self.idx..], 0)).unwrap();
         let chunk_start = self.idx + 8;
-        let chunk_end = chunk_start + chunk.size as usize;
+        let mut chunk_end = chunk_start + chunk.size as usize;
+        if chunk_end > self.data.len() {
+            chunk_end = self.data.len() - 1;
+        }
         let chunk_data = &self.data[chunk_start..chunk_end];
         self.idx = chunk_end;
         assert!(self.idx <= self.data.len());

--- a/src/WorldOfWarcraft/data.ts
+++ b/src/WorldOfWarcraft/data.ts
@@ -631,10 +631,9 @@ export class ModelData {
         this.boneScalings = new Float32Array(this.numBones * 3);
         this.numColors = this.animationManager.get_num_colors();
         this.numLights = this.animationManager.get_num_lights();
-        assert(
-            this.numLights <= 4,
-            `model ${this.fileId} has ${this.numLights} lights`,
-        );
+        if (this.numLights > 4) {
+            console.warn(`model ${this.fileId} has ${this.numLights} lights`);
+        }
         this.vertexColors = new Float32Array(this.numColors * 4);
         this.ambientLightColors = new Float32Array(this.numLights * 4);
         this.diffuseLightColors = new Float32Array(this.numLights * 4);
@@ -1348,10 +1347,14 @@ export class WmoDefinition {
                 doodad.worldAABB.centerPoint(p);
                 vec3.transformMat4(p, p, this.invModelMatrix);
 
+                const groupIds = this.doodadIndexToGroupIds.get(ref)!;
+                if (groupIds.length === 0) {
+                    console.warn(`doodad has 0 group ids: ${doodad.modelId}/${doodad.uniqueId}`)
+                    continue;
+                }
                 // for some reason, the same doodad can exist in multiple groups. if
                 // that's the case, select the closest group (by AABB centerpoint) for
                 // lighting purposes
-                const groupIds = this.doodadIndexToGroupIds.get(ref)!;
                 let group: WowWmoGroupDescriptor;
                 if (groupIds.length > 1) {
                     let closestGroupId;


### PR DESCRIPTION
One of the last very broken elements of WOTLK was that none of Zul'Drak loaded -- this adds a few hacky edge cases which fix it.