### PR TITLE
Workaround for SMB/Source filedrop conflict

### DIFF
--- a/src/Scenes_FileDrops.ts
+++ b/src/Scenes_FileDrops.ts
@@ -104,13 +104,14 @@ export async function createSceneFromFiles(context: SceneContext, buffers: Named
     if (buffer.name.endsWith('.bch'))
         CTR_H3D.parse(buffer);
 
-    if (buffer.name.endsWith('.bsp') || buffer.name.endsWith('.gma'))
-        return SourceFileDrops.createFileDropsScene(context, buffer); 
-
+    // Source renderer also use .gma extension, so try SMB first to see if it parses or not
     const superMonkeyBallRenderer = SuperMonkeyBall.createSceneFromNamedBuffers(context, buffers);
     if (superMonkeyBallRenderer !== null) {
         return superMonkeyBallRenderer;
     }
+
+    if (buffer.name.endsWith('.bsp') || buffer.name.endsWith('.gma'))
+        return SourceFileDrops.createFileDropsScene(context, buffer); 
 
     throw "whoops";
 }


### PR DESCRIPTION
Since Super Monkey Ball and Source Engine both seem to use a `.gma` file extension, first try loading dropped files with the SMB renderer, and if parsing fails, try Source.

It'd probably be better to explicitly check the file format to avoid masking bugs in SMB, but don't know how to do that right now.