### PR TITLE
Halo: convert to deku

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -68,6 +68,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +558,7 @@ dependencies = [
 name = "noclip-support"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "byteorder",
  "console_error_panic_hook",
  "deku 0.19.1",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -234,9 +234,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9711031e209dc1306d66985363b4397d4c7b911597580340b93c9729b55f6eb"
 dependencies = [
  "bitvec",
- "deku_derive",
+ "deku_derive 0.18.1",
+ "no_std_io2 0.8.1",
+ "rustversion",
+]
+
+[[package]]
+name = "deku"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476a022dcfbb013d1365734a42e05b6aca967ebe0d3bb38170086abd9ea3324"
+dependencies = [
+ "bitvec",
+ "deku_derive 0.19.1",
  "log",
- "no_std_io2",
+ "no_std_io2 0.9.0",
  "rustversion",
 ]
 
@@ -245,6 +257,19 @@ name = "deku_derive"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58cb0719583cbe4e81fb40434ace2f0d22ccc3e39a74bb3796c22b451b4f139d"
+dependencies = [
+ "darling",
+ "proc-macro-crate 3.2.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "deku_derive"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb216d425bdf810c165a8ae1649523033e88b5f795480ccec63926295541b084"
 dependencies = [
  "darling",
  "proc-macro-crate 3.2.0",
@@ -506,6 +531,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c2b9acd47481ab557a89a5665891be79e43cce8a29ad77aa9419d7be5a7c06a"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "noclip-macros"
 version = "0.1.0"
 dependencies = [
@@ -520,7 +554,7 @@ version = "0.0.0"
 dependencies = [
  "byteorder",
  "console_error_panic_hook",
- "deku",
+ "deku 0.19.1",
  "env_logger 0.10.2",
  "getrandom",
  "inflate",
@@ -625,7 +659,7 @@ name = "polymorph"
 version = "0.1.0"
 source = "git+https://github.com/wgreenberg/polymorph#01adf7df7a22ae2978731404ea1ab434ceb50524"
 dependencies = [
- "deku",
+ "deku 0.18.1",
  "env_logger 0.11.6",
  "hashers",
  "log",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -230,7 +230,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -265,10 +265,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58cb0719583cbe4e81fb40434ace2f0d22ccc3e39a74bb3796c22b451b4f139d"
 dependencies = [
  "darling",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -278,10 +278,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb216d425bdf810c165a8ae1649523033e88b5f795480ccec63926295541b084"
 dependencies = [
  "darling",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -551,7 +551,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -572,7 +572,6 @@ dependencies = [
  "naga",
  "nalgebra-glm",
  "noclip-macros",
- "num_enum",
  "polymorph",
  "rand",
  "texture2ddecoder",
@@ -629,27 +628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,21 +671,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.22.22",
+ "toml_edit",
 ]
 
 [[package]]
@@ -841,17 +809,6 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
@@ -901,7 +858,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -912,24 +869,13 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow 0.6.24",
+ "winnow",
 ]
 
 [[package]]
@@ -990,7 +936,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1012,7 +958,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1139,15 +1085,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
@@ -1182,5 +1119,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ opt-level = "s"
 [dependencies]
 byteorder = "1.4.3"
 console_error_panic_hook = "0.1.7"
-deku = { version = "0.18.1", features = ["logging"] }
+deku = { version = "0.19.1", features = ["logging"] }
 env_logger = "0.10.1"
 inflate = "0.4.5"
 js-sys = "0.3.60"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -43,6 +43,7 @@ rand = "0.8.5"
 getrandom = { version = "0.2.15", features = ["js"] }
 noclip-macros = { version = "*", path = "./noclip-macros" }
 texture2ddecoder = { git = "https://github.com/wgreenberg/texture2ddecoder" }
+anyhow = "1.0.99"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,7 +35,6 @@ log = "0.4.21"
 lz4_flex = { version = "0.10.0", default-features = false, features = ["safe-decode", "checked-decode"] }
 lzma-rs = { version = "0.3.0", features = ["raw_decoder"] }
 naga = { git = "https://github.com/magcius/wgpu", branch = "issue-4349", features = ["glsl-in", "wgsl-out"] }
-num_enum = "0.5.7"
 wasm-bindgen = "=0.2.100"
 web-sys = { version = "0.3.48", features = ["console"] }
 nalgebra-glm = "0.19.0"

--- a/rust/src/halo/bitmap.rs
+++ b/rust/src/halo/bitmap.rs
@@ -1,12 +1,14 @@
-use std::{io::{Cursor, Seek, SeekFrom}, convert::TryFrom};
-use byteorder::{ReadBytesExt, LittleEndian};
+use std::io::{Cursor, Seek};
+
 use num_enum::{IntoPrimitive, TryFromPrimitive};
+use deku::prelude::*;
 use wasm_bindgen::prelude::*;
+use crate::{halo::common::*, unity::types::common::NullTerminatedAsciiString};
+use crate::halo::bitmap_utils;
 
-use crate::halo::common::*;
-use crate::halo::util::*;
-
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Clone, Copy)]
+#[wasm_bindgen(js_name = "HaloBitmapType")]
+#[derive(Debug, IntoPrimitive, TryFromPrimitive, Clone, Copy, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum BitmapType {
     Tex2D = 0x0,
@@ -16,8 +18,9 @@ pub enum BitmapType {
     InterfaceBitmaps = 0x4,
 }
 
-#[wasm_bindgen]
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Clone, Copy)]
+#[wasm_bindgen(js_name = "HaloBitmapEncodingFormat")]
+#[derive(Debug, IntoPrimitive, TryFromPrimitive, Clone, Copy, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum BitmapEncodingFormat {
     Dxt1 = 0x0,
@@ -28,7 +31,9 @@ pub enum BitmapEncodingFormat {
     Monochrome = 0x5,
 }
 
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone)]
+#[wasm_bindgen(js_name = "HaloBitmapUsage")]
+#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum BitmapUsage {
     AlphaBlend = 0x0,
@@ -39,7 +44,8 @@ pub enum BitmapUsage {
     Vectormap = 0x5,
 }
 
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone)]
+#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum BitmapSpriteBudgetSize {
     Sq32x32 = 0x0,
@@ -51,14 +57,17 @@ pub enum BitmapSpriteBudgetSize {
     Sq2048x2048 = 0x6,
 }
 
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone)]
+#[wasm_bindgen(js_name = "HaloBitmapSpriteUsage")]
+#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum BitmapSpriteUsage {
     BlendAddSubtractMax = 0x0,
     MultiplyMin = 0x1,
     DoubleMultiply = 0x2,
 }
-#[derive(Debug, Clone)]
+
+#[derive(Debug, Clone, DekuRead)]
 pub struct Sprite {
     pub bitmap_index: u16,
     pub left: f32,
@@ -68,39 +77,17 @@ pub struct Sprite {
     pub registration_point: Point2D,
 }
 
-impl Deserialize for Sprite {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(Sprite{
-            bitmap_index: data.read_u16::<LittleEndian>()?,
-            left: data.read_f32::<LittleEndian>()?,
-            right: data.read_f32::<LittleEndian>()?,
-            top: data.read_f32::<LittleEndian>()?,
-            bottom: data.read_f32::<LittleEndian>()?,
-            registration_point: Point2D::deserialize(data)?,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DekuRead)]
 pub struct BitmapGroup {
-    pub name: String,
+    pub name: NullTerminatedAsciiString,
     pub first_bitmap_index: u16,
     pub bitmap_count: u16,
     pub sprites: Block<Sprite>,
 }
 
-impl Deserialize for BitmapGroup {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(BitmapGroup {
-            name: read_null_terminated_string(data)?,
-            first_bitmap_index: data.read_u16::<LittleEndian>()?,
-            bitmap_count: data.read_u16::<LittleEndian>()?,
-            sprites: Block::deserialize(data)?,
-        })
-    }
-}
-
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone)]
+#[wasm_bindgen(js_name = "HaloBitmapClass")]
+#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[deku(id_type = "u32")]
 #[repr(u32)]
 pub enum BitmapClass {
     None = 0xFFFFFFFF,
@@ -191,7 +178,8 @@ pub enum BitmapClass {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone)]
+#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum BitmapDataType {
     Tex2D = 0x0,
@@ -201,7 +189,8 @@ pub enum BitmapDataType {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone)]
+#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum BitmapFormat {
     A8 = 0x0,
@@ -241,7 +230,8 @@ impl BitmapFormat {
     }
 }
 
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloBitmapMetadata")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct BitmapData {
     pub bitmap_class: BitmapClass,
     pub width: u16,
@@ -252,110 +242,72 @@ pub struct BitmapData {
     pub flags: u16,
     pub registration_point: Point2DInt,
     pub mipmap_count: u16,
+    #[deku(pad_bytes_before = "2")]
     pub pixel_data_offset: Pointer,
     pub pixel_data_size: u32,
     pub bitmap_tag_id: u32,
+    #[deku(pad_bytes_after = "8")]
     pub pointer: Pointer,
 }
 
+#[wasm_bindgen(js_class = "HaloBitmapMetadata")]
 impl BitmapData {
     pub fn is_external(&self) -> bool {
         (self.flags & 0x100) > 0
     }
 }
 
-impl Deserialize for BitmapData {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let bitmap_class = BitmapClass::try_from(data.read_u32::<LittleEndian>()?)?;
-        let width = data.read_u16::<LittleEndian>()?;
-        let height = data.read_u16::<LittleEndian>()?;
-        let depth = data.read_u16::<LittleEndian>()?;
-        let bitmap_type = BitmapDataType::try_from(data.read_u16::<LittleEndian>()?)?;
-        let format = BitmapFormat::try_from(data.read_u16::<LittleEndian>()?)?;
-        let flags = data.read_u16::<LittleEndian>()?;
-        let registration_point = Point2DInt::deserialize(data)?;
-        let mipmap_count = data.read_u16::<LittleEndian>()?;
-        data.seek(SeekFrom::Current(2))?;
-        let pixel_data_offset = data.read_u32::<LittleEndian>()? as Pointer;
-        let pixel_data_size = data.read_u32::<LittleEndian>()?;
-        let bitmap_tag_id = data.read_u32::<LittleEndian>()?;
-        let pointer = data.read_u32::<LittleEndian>()? as Pointer;
-        data.seek(SeekFrom::Current(8))?;
-        Ok(BitmapData {
-            bitmap_class,
-            width,
-            height,
-            depth,
-            bitmap_type,
-            format,
-            flags,
-            registration_point,
-            mipmap_count,
-            pixel_data_offset,
-            pixel_data_size,
-            bitmap_tag_id,
-            pointer,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloBitmap")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct Bitmap {
     pub bitmap_type: BitmapType,
     pub encoding_format: BitmapEncodingFormat,
     pub usage: BitmapUsage,
     pub flags: u16,
-    /*
-    pub detail_fade_factor: f32,
-    pub sharpen_amount: f32,
-    pub bump_height: f32,
-    sprite_budget_size: BitmapSpriteBudgetSize,
-    sprite_budget_count: u16,
-    pub color_plate_width: u16, // non-cached
-    pub color_plate_height: u16, // non-cached
-    compressed_color_plate_pointer: Pointer, // non-cached
-    processed_pixel_data: Pointer, // non-cached
-    pub blur_filter_size: f32,
-    pub alpha_bias: f32,
-    */
+    pub _detail_fade_factor: f32,
+    pub _sharpen_amount: f32,
+    pub _bump_height: f32,
+    _sprite_budget_size: BitmapSpriteBudgetSize,
+    _sprite_budget_count: u16,
+    pub _color_plate_width: u16, // non-cached
+    pub _color_plate_height: u16, // non-cached
+    _compressed_color_plate_pointer: Pointer, // non-cached
+    _processed_pixel_data: Pointer, // non-cached
+    pub _blur_filter_size: f32,
+    pub _alpha_bias: f32,
     pub mipmap_count: u16,
     pub sprite_usage: BitmapSpriteUsage,
     pub sprite_spacing: u16,
-    pub bitmap_group_sequence: Block<BitmapGroup>,
-    pub data: Block<BitmapData>,
+    #[deku(pad_bytes_before = "34")]
+    pub(crate) bitmap_group_sequence: Block<BitmapGroup>,
+    pub(crate) data: Block<BitmapData>,
 }
 
+#[wasm_bindgen(js_class = "HaloBitmap")]
 impl Bitmap {
-    pub fn get_dimensions(&self) -> (u32, u32) {
-        todo!();
+    pub fn get_metadata_for_index(&self, index: usize) -> BitmapData {
+        self.data.items.as_ref().unwrap()[index].clone()
+    }
+
+    pub fn get_tag_id(&self) -> u32 {
+        self.data.items.as_ref().unwrap()[0].bitmap_tag_id
     }
 }
 
-impl Deserialize for Bitmap {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let start = data.position();
-        let bitmap_type = BitmapType::try_from(data.read_u16::<LittleEndian>()?)?;
-        let encoding_format = BitmapEncodingFormat::try_from(data.read_u16::<LittleEndian>()?)?;
-        let usage = BitmapUsage::try_from(data.read_u16::<LittleEndian>()?)?;
-        let flags = data.read_u16::<LittleEndian>()?;
-        let _detail_fade_factor = data.read_f32::<LittleEndian>()?;
-        let _sharpen_amount = data.read_f32::<LittleEndian>()?;
-        let _bump_height = data.read_f32::<LittleEndian>()?;
-        let _sprite_budget_size = BitmapSpriteBudgetSize::try_from(data.read_u16::<LittleEndian>()?)?;
-        let _sprite_budget_count = data.read_u16::<LittleEndian>()?;
-        let _color_plate_width = data.read_u16::<LittleEndian>()?; // non-cache
-        let _color_plate_height = data.read_u16::<LittleEndian>()?; // non-cache
-        let _compressed_color_plate_pointer = data.read_u32::<LittleEndian>()? as Pointer; // non-cache
-        let _processed_pixel_data = data.read_u32::<LittleEndian>()? as Pointer; // non-cache
-        let _blur_filter_size = data.read_f32::<LittleEndian>()?;
-        let _alpha_bias = data.read_f32::<LittleEndian>()?;
-        let mipmap_count = data.read_u16::<LittleEndian>()?;
-        let sprite_usage = BitmapSpriteUsage::try_from(data.read_u16::<LittleEndian>()?)?;
-        let sprite_spacing = data.read_u16::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 84))?;
-        let bitmap_group_sequence = Block::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 96))?;
-        let data = Block::deserialize(data)?;
-        Ok(Bitmap { bitmap_type, encoding_format, usage, flags, mipmap_count, sprite_usage, sprite_spacing, bitmap_group_sequence, data })
+pub fn get_and_convert_bitmap_data(reader: &mut deku::reader::Reader<Cursor<Vec<u8>>>, bitmap_data: &BitmapData) -> Vec<u8> {
+    let offset = bitmap_data.pixel_data_offset as u64;
+    let length = bitmap_data.pixel_data_size as usize;
+    let mut bytes = vec![0; length];
+    reader.seek(std::io::SeekFrom::Start(offset)).unwrap();
+    reader.read_bytes(length, &mut bytes, deku::ctx::Order::Msb0).unwrap();
+    match bitmap_data.format {
+        BitmapFormat::P8 | BitmapFormat::P8Bump => bitmap_utils::convert_p8_data(&bytes),
+        BitmapFormat::A8r8g8b8 => bitmap_utils::convert_a8r8g8b8_data(&bytes),
+        BitmapFormat::X8r8g8b8 => bitmap_utils::convert_x8r8g8b8_data(&bytes),
+        BitmapFormat::A8 => bitmap_utils::convert_a8_data(&bytes),
+        BitmapFormat::Y8 => bitmap_utils::convert_y8_data(&bytes),
+        BitmapFormat::A8y8 => bitmap_utils::convert_a8y8_data(&bytes),
+        BitmapFormat::R5g6b5 => bitmap_utils::convert_r5g6b5_data(&bytes),
+        _ => bytes,
     }
 }

--- a/rust/src/halo/bitmap.rs
+++ b/rust/src/halo/bitmap.rs
@@ -1,13 +1,12 @@
 use std::io::{Cursor, Seek};
 
-use num_enum::{IntoPrimitive, TryFromPrimitive};
 use deku::prelude::*;
 use wasm_bindgen::prelude::*;
 use crate::{halo::common::*, unity::types::common::NullTerminatedAsciiString};
 use crate::halo::bitmap_utils;
 
 #[wasm_bindgen(js_name = "HaloBitmapType")]
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Clone, Copy, DekuRead)]
+#[derive(Debug, Clone, Copy, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum BitmapType {
@@ -19,7 +18,7 @@ pub enum BitmapType {
 }
 
 #[wasm_bindgen(js_name = "HaloBitmapEncodingFormat")]
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Clone, Copy, DekuRead)]
+#[derive(Debug, Clone, Copy, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum BitmapEncodingFormat {
@@ -32,7 +31,7 @@ pub enum BitmapEncodingFormat {
 }
 
 #[wasm_bindgen(js_name = "HaloBitmapUsage")]
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum BitmapUsage {
@@ -44,7 +43,7 @@ pub enum BitmapUsage {
     Vectormap = 0x5,
 }
 
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum BitmapSpriteBudgetSize {
@@ -58,7 +57,7 @@ pub enum BitmapSpriteBudgetSize {
 }
 
 #[wasm_bindgen(js_name = "HaloBitmapSpriteUsage")]
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum BitmapSpriteUsage {
@@ -86,7 +85,7 @@ pub struct BitmapGroup {
 }
 
 #[wasm_bindgen(js_name = "HaloBitmapClass")]
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u32")]
 #[repr(u32)]
 pub enum BitmapClass {
@@ -178,7 +177,7 @@ pub enum BitmapClass {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum BitmapDataType {
@@ -189,7 +188,7 @@ pub enum BitmapDataType {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum BitmapFormat {

--- a/rust/src/halo/common.rs
+++ b/rust/src/halo/common.rs
@@ -1,9 +1,8 @@
-use std::io::{Cursor, Seek, SeekFrom};
-use byteorder::{ReadBytesExt, LittleEndian};
-use num_enum::{TryFromPrimitive, TryFromPrimitiveError};
+use std::{error::Error, fmt::Display, io::{Cursor, Seek, SeekFrom}};
+use deku::prelude::*;
+use anyhow::Result;
 use wasm_bindgen::prelude::*;
 
-pub type Result<T> = std::result::Result<T, MapReaderError>;
 pub type Pointer = u32;
 
 #[derive(Debug, Clone)]
@@ -13,44 +12,25 @@ pub enum MapReaderError {
     InvalidTag(String),
 }
 
-impl From<std::io::Error> for MapReaderError {
-    fn from(err: std::io::Error) -> Self {
-        MapReaderError::IO(err.to_string())
+impl Display for MapReaderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
-impl<T: TryFromPrimitive> From<TryFromPrimitiveError<T>> for MapReaderError {
-    fn from(err: TryFromPrimitiveError<T>) -> Self {
-        MapReaderError::IO(err.to_string())
-    }
-}
+impl Error for MapReaderError {}
 
-pub trait Deserialize {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized;
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DekuRead)]
 pub struct Block<T> {
-    pub items: Option<Vec<T>>,
+    pub count: u32,
+    #[deku(pad_bytes_after = "4")]
     pub base_pointer: Pointer,
-    pub count: usize,
+    #[deku(skip)]
+    pub items: Option<Vec<T>>,
 }
 
-impl<T> Deserialize for Block<T> {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let count = data.read_u32::<LittleEndian>()? as usize;
-        let base_pointer = data.read_u32::<LittleEndian>()? as Pointer;
-        data.seek(SeekFrom::Current(4))?;
-        Ok(Block {
-            count, 
-            base_pointer,
-            items: None,
-        })
-    }
-}
-
-impl<T: Deserialize + std::fmt::Debug> Block<T> {
-    pub fn read_items(&mut self, data: &mut Cursor<Vec<u8>>, offset: i64) -> Result<()> {
+impl<'a, T: DekuContainerRead<'a> + std::fmt::Debug> Block<T> {
+    pub fn read_items(&mut self, data: &mut Reader<Cursor<Vec<u8>>>, offset: i64) -> Result<()> {
         let mut items: Vec<T> = Vec::with_capacity(self.count as usize);
         if self.count > 0 {
             let pointer = offset + self.base_pointer as i64;
@@ -59,7 +39,7 @@ impl<T: Deserialize + std::fmt::Debug> Block<T> {
             }
             data.seek(SeekFrom::Start((self.base_pointer as i64 + offset) as u64))?;
             for _ in 0..self.count {
-                items.push(T::deserialize(data)?);
+                items.push(T::from_reader_with_ctx(data, ())?);
             }
         }
         self.items = Some(items);
@@ -67,92 +47,46 @@ impl<T: Deserialize + std::fmt::Debug> Block<T> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloVector3D")]
+#[derive(Debug, Copy, Clone, DekuRead)]
 pub struct Vector3D {
     pub i: f32,
     pub j: f32,
     pub k: f32,
 }
 
-impl Deserialize for Vector3D {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(Vector3D {
-            i: data.read_f32::<LittleEndian>()?,
-            j: data.read_f32::<LittleEndian>()?,
-            k: data.read_f32::<LittleEndian>()?,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DekuRead)]
 pub struct TagDataOffset {
     pub size: u32,
     pub external: u32,
+    #[deku(pad_bytes_after = "8")]
     pub file_offset: u32,
 }
 
-impl Deserialize for TagDataOffset {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let offset = TagDataOffset {
-            size: data.read_u32::<LittleEndian>()?,
-            external: data.read_u32::<LittleEndian>()?,
-            file_offset: data.read_u32::<LittleEndian>()?,
-        };
-        data.seek(SeekFrom::Current(8))?;
-        Ok(offset)
-    }
-}
-
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloPlane3D")]
+#[derive(Debug, Copy, Clone, DekuRead)]
 pub struct Plane3D {
     pub norm: Vector3D,
     pub w: f32, // distance from origin (along normal)
 }
 
-impl Deserialize for Plane3D {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(Plane3D {
-            norm: Vector3D::deserialize(data)?,
-            w: data.read_f32::<LittleEndian>()?,
-        })
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, DekuRead)]
 pub struct Tri {
     pub v0: u16,
     pub v1: u16,
     pub v2: u16,
 }
 
-impl Deserialize for Tri {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(Tri {
-            v0: data.read_u16::<LittleEndian>()?,
-            v1: data.read_u16::<LittleEndian>()?,
-            v2: data.read_u16::<LittleEndian>()?,
-        })
-    }
-}
-#[wasm_bindgen]
-#[derive(Debug, Clone, Copy)]
+#[wasm_bindgen(js_name = "HaloColorRGB")]
+#[derive(Debug, Clone, Copy, DekuRead)]
 pub struct ColorRGB {
     pub r: f32,
     pub g: f32,
     pub b: f32,
 }
 
-impl Deserialize for ColorRGB {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(ColorRGB {
-            r: data.read_f32::<LittleEndian>()?,
-            g: data.read_f32::<LittleEndian>()?,
-            b: data.read_f32::<LittleEndian>()?,
-        })
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
+#[wasm_bindgen(js_name = "HaloColorARGB")]
+#[derive(Debug, Clone, Copy, DekuRead)]
 #[wasm_bindgen]
 pub struct ColorARGB {
     pub a: f32,
@@ -161,79 +95,32 @@ pub struct ColorARGB {
     pub b: f32,
 }
 
-impl Deserialize for ColorARGB {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(ColorARGB {
-            a: data.read_f32::<LittleEndian>()?,
-            r: data.read_f32::<LittleEndian>()?,
-            g: data.read_f32::<LittleEndian>()?,
-            b: data.read_f32::<LittleEndian>()?,
-        })
-    }
-}
-#[wasm_bindgen]
-#[derive(Debug, Copy, Clone)]
+#[wasm_bindgen(js_name = "HaloPoint2D")]
+#[derive(Debug, Copy, Clone, DekuRead)]
 pub struct Point2D {
     pub x: f32,
     pub y: f32,
 }
 
-impl Deserialize for Point2D {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(Point2D {
-            x: data.read_f32::<LittleEndian>()?,
-            y: data.read_f32::<LittleEndian>()?,
-        })
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
+#[wasm_bindgen(js_name = "HaloPoint2DInt")]
+#[derive(Debug, Copy, Clone, DekuRead)]
 pub struct Point2DInt {
     pub x: i16,
     pub y: i16,
 }
 
-impl Deserialize for Point2DInt {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(Point2DInt {
-            x: data.read_i16::<LittleEndian>()?,
-            y: data.read_i16::<LittleEndian>()?,
-        })
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Copy, Clone)]
+#[wasm_bindgen(js_name = "HaloPoint3D")]
+#[derive(Debug, Copy, Clone, DekuRead)]
 pub struct Point3D {
     pub x: f32,
     pub y: f32,
     pub z: f32,
 }
 
-impl Deserialize for Point3D {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(Point3D {
-            x: data.read_f32::<LittleEndian>()?,
-            y: data.read_f32::<LittleEndian>()?,
-            z: data.read_f32::<LittleEndian>()?,
-        })
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone, Copy)]
+#[wasm_bindgen(js_name = "HaloEuler3D")]
+#[derive(Debug, Clone, Copy, DekuRead)]
 pub struct Euler3D {
     pub yaw: f32,
     pub pitch: f32,
     pub roll: f32,
-}
-
-impl Deserialize for Euler3D {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(Euler3D {
-            yaw: data.read_f32::<LittleEndian>()?,
-            pitch: data.read_f32::<LittleEndian>()?,
-            roll: data.read_f32::<LittleEndian>()?,
-        })
-    }
 }

--- a/rust/src/halo/map.rs
+++ b/rust/src/halo/map.rs
@@ -1,6 +1,5 @@
 use std::{convert::TryInto, io::{Cursor, Seek, SeekFrom}};
 use deku::prelude::*;
-use num_enum::TryFromPrimitive;
 use anyhow::Result;
 use wasm_bindgen::prelude::*;
 
@@ -292,7 +291,7 @@ pub struct ResourceHeader {
     pub path: Option<String>,
 }
 
-#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ScenarioType {

--- a/rust/src/halo/model.rs
+++ b/rust/src/halo/model.rs
@@ -1,214 +1,94 @@
-use std::io::{Cursor, Seek, SeekFrom};
-use byteorder::{ReadBytesExt, LittleEndian};
+use deku::prelude::*;
 use crate::halo::common::*;
 use crate::halo::tag::*;
+use wasm_bindgen::prelude::*;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DekuRead)]
 pub struct SkyAnimations {
     pub animation_index: i16,
     pub period: f32,
 }
 
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloSky")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct Sky {
     pub model: TagDependency,
     pub animation_graph: TagDependency,
+    #[deku(pad_bytes_before = "24")]
     pub indoor_ambient_radiosity_color: ColorRGB,
     pub indoor_ambient_radiosity_power: f32,
     pub outdoor_ambient_radiosity_color: ColorRGB,
     pub outdoor_ambient_radiosity_power: f32,
     pub outdoor_fog_color: ColorRGB,
+    #[deku(pad_bytes_before = "8")]
     pub outdoor_fog_max_density: f32,
     pub outdoor_fog_start_distance: f32,
     pub outdoor_fog_opaque_distance: f32,
     pub indoor_fog_color: ColorRGB,
+    #[deku(pad_bytes_before = "8")]
     pub indoor_fog_max_density: f32,
     pub indoor_fog_start_distance: f32,
+    #[deku(pad_bytes_after = "56")]
     pub indoor_fog_opaque_distance: f32,
 }
 
-impl Deserialize for Sky {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let start = data.position();
-        let model = TagDependency::deserialize(data)?;
-        let animation_graph = TagDependency::deserialize(data)?;
-        data.seek(SeekFrom::Current(24))?;
-        let indoor_ambient_radiosity_color = ColorRGB::deserialize(data)?;
-        let indoor_ambient_radiosity_power = data.read_f32::<LittleEndian>()?;
-        let outdoor_ambient_radiosity_color = ColorRGB::deserialize(data)?;
-        let outdoor_ambient_radiosity_power = data.read_f32::<LittleEndian>()?;
-        let outdoor_fog_color = ColorRGB::deserialize(data)?;
-        data.seek(SeekFrom::Current(8))?;
-        let outdoor_fog_max_density = data.read_f32::<LittleEndian>()?;
-        let outdoor_fog_start_distance = data.read_f32::<LittleEndian>()?;
-        let outdoor_fog_opaque_distance = data.read_f32::<LittleEndian>()?;
-        let indoor_fog_color = ColorRGB::deserialize(data)?;
-        data.seek(SeekFrom::Current(8))?;
-        let indoor_fog_max_density = data.read_f32::<LittleEndian>()?;
-        let indoor_fog_start_distance = data.read_f32::<LittleEndian>()?;
-        let indoor_fog_opaque_distance = data.read_f32::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 208))?;
-        // TODO handle lens flares + animations
-        Ok(Sky {
-            model,
-            animation_graph,
-            indoor_ambient_radiosity_color,
-            indoor_ambient_radiosity_power,
-            outdoor_ambient_radiosity_color,
-            outdoor_ambient_radiosity_power,
-            outdoor_fog_color,
-            outdoor_fog_max_density,
-            outdoor_fog_start_distance,
-            outdoor_fog_opaque_distance,
-            indoor_fog_color,
-            indoor_fog_max_density,
-            indoor_fog_start_distance,
-            indoor_fog_opaque_distance,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloModel")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct GbxModel {
+    #[deku(pad_bytes_before = "48")]
     pub base_bitmap_u_scale: f32,
     pub base_bitmap_v_scale: f32,
-    pub geometries: Block<GbxModelGeometry>,
-    pub shaders: Block<GbxModelShader>,
+    #[deku(pad_bytes_before = "152")]
+    pub(crate) geometries: Block<GbxModelGeometry>,
+    pub(crate) shaders: Block<GbxModelShader>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DekuRead)]
 pub struct GbxModelGeometry {
+    #[deku(pad_bytes_before = "36")]
     pub parts: Block<GbxModelPart>,
 }
 
-impl Deserialize for GbxModelGeometry {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let start = data.position();
-        data.seek(SeekFrom::Start(start + 36))?;
-        let parts: Block<GbxModelPart> = Block::deserialize(data)?;
-        Ok(GbxModelGeometry { parts })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloModelPart")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct GbxModelPart {
+    #[deku(pad_bytes_before = "4")]
     pub shader_index: u16,
+    #[deku(pad_bytes_before = "14")]
     pub centroid: Point3D,
-    pub tri_count: u32,
+    #[deku(pad_bytes_before = "40")]
+    pub off_by_two_tri_count: u32, // always off by 2
     pub tri_offset: u32,
+    #[deku(pad_bytes_before = "8")]
     pub vert_count: u32,
+    #[deku(pad_bytes_before = "8", pad_bytes_after = "28")]
     pub vert_offset: u32,
 }
 
-impl Deserialize for GbxModelPart {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let start = data.position();
-        data.seek(SeekFrom::Start(start + 4))?;
-        let shader_index = data.read_u16::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 20))?;
-        let centroid = Point3D::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 72))?;
-        let tri_count = data.read_u32::<LittleEndian>()? + 2; // it's always off by 2????
-        let tri_offset = data.read_u32::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 88))?;
-        let vert_count = data.read_u32::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 100))?;
-        dbg!(data.position());
-        let vert_offset = data.read_u32::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 132))?;
-        Ok(GbxModelPart {
-            shader_index,
-            centroid,
-            tri_count,
-            tri_offset,
-            vert_count,
-            vert_offset,
-        })
+#[wasm_bindgen(js_class = "HaloModelPart")]
+impl GbxModelPart {
+    pub fn tri_count(&self) -> u32 {
+        self.off_by_two_tri_count + 2
     }
 }
 
-impl Deserialize for GbxModel {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        data.seek(SeekFrom::Current(4))?; // Bool32('flags',
-        data.seek(SeekFrom::Current(4))?; // SInt32('node_list_checksum'),
-        data.seek(SeekFrom::Current(4))?; // Float('superhigh_lod_cutoff', SIDETIP="pixels"),
-        data.seek(SeekFrom::Current(4))?; // Float('high_lod_cutoff', SIDETIP="pixels"),
-        data.seek(SeekFrom::Current(4))?; // Float('medium_lod_cutoff', SIDETIP="pixels"),
-        data.seek(SeekFrom::Current(4))?; // Float('low_lod_cutoff', SIDETIP="pixels"),
-        data.seek(SeekFrom::Current(4))?; // Float('superlow_lod_cutoff', SIDETIP="pixels"),
-        data.seek(SeekFrom::Current(2))?; // SInt16('superlow_lod_nodes', SIDETIP="nodes"),
-        data.seek(SeekFrom::Current(2))?; // SInt16('low_lod_nodes', SIDETIP="nodes"),
-        data.seek(SeekFrom::Current(2))?; // SInt16('medium_lod_nodes', SIDETIP="nodes"),
-        data.seek(SeekFrom::Current(2))?; // SInt16('high_lod_nodes', SIDETIP="nodes"),
-        data.seek(SeekFrom::Current(2))?; // SInt16('superhigh_lod_nodes', SIDETIP="nodes"),
-        data.seek(SeekFrom::Current(10))?; // Pad(10),
-        let base_bitmap_u_scale = data.read_f32::<LittleEndian>()?; // Float('base_map_u_scale'),
-        let base_bitmap_v_scale = data.read_f32::<LittleEndian>()?; // Float('base_map_v_scale'),
-        data.seek(SeekFrom::Current(116))?; // Pad(116),
-        data.seek(SeekFrom::Current(12))?; // reflexive("markers", marker, 256, DYN_NAME_PATH=".name"),
-        data.seek(SeekFrom::Current(12))?;// reflexive("nodes", node, 64, DYN_NAME_PATH=".name"),
-        data.seek(SeekFrom::Current(12))?;// reflexive("regions", region, 32, DYN_NAME_PATH=".name"),
-        let geometries: Block<GbxModelGeometry> = Block::deserialize(data)?;
-        let shaders: Block<GbxModelShader> = Block::deserialize(data)?;
-        data.seek(SeekFrom::Start(232))?;// reflexive("regions", region, 32, DYN_NAME_PATH=".name"),
-        Ok(GbxModel {
-            base_bitmap_u_scale,
-            base_bitmap_v_scale,
-            geometries,
-            shaders,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DekuRead)]
 pub struct GbxModelShader {
     pub shader: TagDependency,
+    #[deku(pad_bytes_after = "14")]
     pub permutation: u16,
 }
 
-impl Deserialize for GbxModelShader {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let shader = TagDependency::deserialize(data)?;
-        let permutation = data.read_u16::<LittleEndian>()?;
-        data.seek(SeekFrom::Current(14))?;
-        Ok(GbxModelShader {
-            shader,
-            permutation,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloScenery")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct Scenery {
+    #[deku(pad_bytes_before = "2")]
     pub flags: u16,
     pub bounding_radius: f32,
     pub bounding_offset: Point3D,
     pub origin_offset: Point3D,
-    pub model: TagDependency,
+    #[deku(assert = "model.tag_class == TagClass::GbxModel", pad_bytes_before = "8")]
+    pub(crate) model: TagDependency,
+    #[deku(assert = "modifier_shader.tag_class == TagClass::Shader", pad_bytes_before = "88")]
     pub modifier_shader: TagDependency,
-}
-
-impl Deserialize for Scenery {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let start = data.position();
-        data.seek(SeekFrom::Start(start + 2))?;
-        let flags = data.read_u16::<LittleEndian>()?;
-        let bounding_radius = data.read_f32::<LittleEndian>()?;
-        let bounding_offset = Point3D::deserialize(data)?;
-        let origin_offset = Point3D::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 40))?;
-        let model = TagDependency::deserialize(data)?;
-        assert_eq!(model.tag_class, TagClass::GbxModel);
-        data.seek(SeekFrom::Start(start + 144))?;
-        let modifier_shader = TagDependency::deserialize(data)?;
-        assert_eq!(modifier_shader.tag_class, TagClass::Shader);
-        Ok(Scenery {
-            flags,
-            bounding_radius,
-            bounding_offset,
-            origin_offset,
-            model,
-            modifier_shader,
-        })
-    }
 }

--- a/rust/src/halo/scenario.rs
+++ b/rust/src/halo/scenario.rs
@@ -1,11 +1,10 @@
-use num_enum::{IntoPrimitive, TryFromPrimitive};
 use deku::prelude::*;
 use wasm_bindgen::prelude::*;
 
 use crate::{halo::common::*, unity::types::common::NullTerminatedAsciiString};
 use crate::halo::tag::*;
 
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ObjectType {
@@ -178,7 +177,7 @@ pub struct LightmapVertex {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Clone, Copy, TryFromPrimitive, PartialEq, DekuRead)]
+#[derive(Debug, Clone, Copy, PartialEq, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum RenderedVerticesType {

--- a/rust/src/halo/scenario.rs
+++ b/rust/src/halo/scenario.rs
@@ -1,12 +1,12 @@
-use std::{io::{Cursor, Seek, SeekFrom}, convert::TryFrom};
-use byteorder::{ReadBytesExt, LittleEndian};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
+use deku::prelude::*;
+use wasm_bindgen::prelude::*;
 
-use crate::halo::common::*;
-use crate::halo::util::*;
+use crate::{halo::common::*, unity::types::common::NullTerminatedAsciiString};
 use crate::halo::tag::*;
 
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone)]
+#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ObjectType {
     Biped = 0x0	,
@@ -23,228 +23,104 @@ pub enum ObjectType {
     SoundScenery = 0xB,
 }
 
-#[derive(Debug)]
+#[derive(Debug, DekuRead)]
 pub struct ObjectName {
-    pub name: String,
+    pub name: NullTerminatedAsciiString,
     pub object_type: ObjectType,
     pub index: u16,
 }
 
-impl Deserialize for ObjectName {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(ObjectName {
-            name: read_null_terminated_string(data)?,
-            object_type: ObjectType::try_from(data.read_u16::<LittleEndian>()?)?,
-            index: data.read_u16::<LittleEndian>()?,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloSceneryInstance")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct ScenarioScenery {
     pub scenery_type: u16,
     pub name_index: u16,
     pub not_placed: u32,
     pub position: Point3D,
     pub rotation: Euler3D,
+    #[deku(pad_bytes_after = "38")]
+    pub _appearance_player_index: u16,
 }
 
-impl Deserialize for ScenarioScenery {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let start = data.position();
-        let scenery_type = data.read_u16::<LittleEndian>()?;
-        let name_index = data.read_u16::<LittleEndian>()?;
-        let not_placed = data.read_u32::<LittleEndian>()?;
-        let position = Point3D::deserialize(data)?;
-        let rotation = Euler3D::deserialize(data)?;
-        let _appearance_player_index = data.read_u16::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 72))?;
-        Ok(ScenarioScenery {
-            scenery_type,
-            name_index,
-            not_placed,
-            position,
-            rotation,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DekuRead)]
 pub struct ObjectSwatch {
+    #[deku(pad_bytes_after = "32")]
     pub obj: TagDependency,
 }
 
-impl Deserialize for ObjectSwatch {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let obj = TagDependency::deserialize(data)?;
-        data.seek(SeekFrom::Current(32))?;
-        Ok(ObjectSwatch { obj })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DekuRead)]
 pub struct Scenario {
+    #[deku(pad_bytes_before = "48")]
     pub skies: Block<TagDependency>,
+    #[deku(pad_bytes_before = "468")]
     pub scenery: Block<ScenarioScenery>,
     pub scenery_palette: Block<ObjectSwatch>,
+    #[deku(pad_bytes_before = "156")]
     pub light_fixtures: Block<ScenarioLightFixture>,
     pub light_fixture_palette: Block<ObjectSwatch>,
+    #[deku(pad_bytes_before = "204")]
     pub decals: Block<ScenarioDecal>,
     pub decal_palette: Block<ObjectSwatch>,
     pub detail_object_collection_palette: Block<ObjectSwatch>,
+    #[deku(pad_bytes_before = "472")]
     pub structure_bsp_references: Block<ScenarioStructureBSPReference>,
 }
 
-impl Deserialize for Scenario {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let start = data.position();
-        data.seek(SeekFrom::Start(start + 48))?;
-        let skies: Block<TagDependency> = Block::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 528))?;
-        let scenery: Block<ScenarioScenery> = Block::deserialize(data)?;
-        let scenery_palette: Block<ObjectSwatch> = Block::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 708))?;
-        let light_fixtures: Block<ScenarioLightFixture> = Block::deserialize(data)?;
-        let light_fixture_palette: Block<ObjectSwatch> = Block::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 936))?;
-        let decals: Block<ScenarioDecal> = Block::deserialize(data)?;
-        let decal_palette: Block<ObjectSwatch> = Block::deserialize(data)?;
-        let detail_object_collection_palette: Block<ObjectSwatch> = Block::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 1444))?; // skip to BSPs
-        let structure_bsps: Block<ScenarioStructureBSPReference> = Block::deserialize(data)?;
-        Ok(Scenario {
-            skies,
-            scenery,
-            scenery_palette,
-            light_fixtures,
-            light_fixture_palette,
-            decals,
-            decal_palette,
-            detail_object_collection_palette,
-            structure_bsp_references: structure_bsps,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DekuRead)]
 pub struct ScenarioStructureBSPReference {
     pub start: u32,
     pub size: u32,
     pub address: u32,
+    #[deku(pad_bytes_before = "4")]
     pub structure_bsp: TagDependency,
 }
 
-impl Deserialize for ScenarioStructureBSPReference {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let start = data.read_u32::<LittleEndian>()?;
-        let size = data.read_u32::<LittleEndian>()?;
-        let address = data.read_u32::<LittleEndian>()?;
-        data.seek(SeekFrom::Current(4))?;
-        let structure_bsp = TagDependency::deserialize(data)?;
-        Ok(ScenarioStructureBSPReference {
-            start, size, address, structure_bsp,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DekuRead)]
 pub struct BSPHeader {
     pub bsp_offset: u32,
+    #[deku(pad_bytes_before = "4")]
     pub rendered_vertices_offset: u32,
+    #[deku(pad_bytes_before = "4")]
     pub lightmap_vertices_offset: u32,
+    #[deku(assert = "*_class == TagClass::ScenarioStructureBsp")]
+    pub _class: TagClass,
 }
 
-impl Deserialize for BSPHeader {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let bsp_offset = data.read_u32::<LittleEndian>()?;
-        data.seek(SeekFrom::Current(4))?;
-        let rendered_vertices_offset = data.read_u32::<LittleEndian>()?;
-        data.seek(SeekFrom::Current(4))?;
-        let lightmap_vertices_offset = data.read_u32::<LittleEndian>()?;
-        assert_eq!(data.read_u32::<LittleEndian>()?, TagClass::ScenarioStructureBsp.into());
-        Ok(BSPHeader {
-            bsp_offset,
-            rendered_vertices_offset,
-            lightmap_vertices_offset,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloBSP")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct BSP {
     pub lightmaps_bitmap: TagDependency,
+    #[deku(pad_bytes_before = "28")]
     pub default_ambient_color: ColorRGB,
+    #[deku(pad_bytes_before = "4")]
     pub default_distant_light0_color: ColorRGB,
     pub default_distant_light0_direction: Vector3D,
     pub default_distant_light1_color: ColorRGB,
     pub default_distant_light1_direction: Vector3D,
+    #[deku(pad_bytes_before = "12")]
     pub default_reflection_tint: ColorARGB,
     pub default_shadow_vector: Vector3D,
     pub default_shadow_color: ColorRGB,
-    pub surfaces: Block<Tri>,
-    pub lightmaps: Block<BSPLightmap>,
-
-    pub header: Option<BSPHeader>,
+    #[deku(pad_bytes_before = "88")]
+    pub(crate) surfaces: Block<Tri>,
+    #[deku(pad_bytes_after = "364")]
+    pub(crate) lightmaps: Block<BSPLightmap>,
+    #[deku(skip)]
+    pub(crate) header: Option<BSPHeader>,
 }
 
-impl Deserialize for BSP {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let start = data.position();
-        let lightmaps_bitmap = TagDependency::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 44))?;
-        let default_ambient_color = ColorRGB::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 60))?;
-        let default_distant_light0_color = ColorRGB::deserialize(data)?;
-        let default_distant_light0_direction = Vector3D::deserialize(data)?;
-        let default_distant_light1_color = ColorRGB::deserialize(data)?;
-        let default_distant_light1_direction = Vector3D::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 120))?;
-        let default_reflection_tint = ColorARGB::deserialize(data)?;
-        let default_shadow_vector = Vector3D::deserialize(data)?;
-        let default_shadow_color = ColorRGB::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 236))?;
-        data.seek(SeekFrom::Start(start + 248))?;
-        let surfaces: Block<Tri> = Block::deserialize(data)?;
-        let lightmaps: Block<BSPLightmap> = Block::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 636))?;
-        Ok(BSP {
-            lightmaps_bitmap,
-            default_ambient_color,
-            default_distant_light0_color,
-            default_distant_light0_direction,
-            default_distant_light1_color,
-            default_distant_light1_direction,
-            default_reflection_tint,
-            default_shadow_vector,
-            default_shadow_color,
-            surfaces,
-            lightmaps,
-            header: None,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloLightmap")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct BSPLightmap {
-    pub bitmap: u16,
-    pub materials: Block<BSPMaterial>,
+    pub bitmap_index: u16,
+    #[deku(pad_bytes_before = "18")]
+    pub(crate) materials: Block<BSPMaterial>,
 }
 
-impl Deserialize for BSPLightmap {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let bitmap = data.read_u16::<LittleEndian>()?;
-        data.seek(SeekFrom::Current(18))?;
-        let materials = Block::deserialize(data)?;
-        Ok(BSPLightmap {
-            bitmap,
-            materials,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloMaterial")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct BSPMaterial {
-    pub shader: TagDependency,
+    pub(crate) shader: TagDependency,
     pub shader_permutation: u16,
     pub flags: u16,
     pub surfaces: i32,
@@ -252,82 +128,39 @@ pub struct BSPMaterial {
     pub centroid: Point3D,
     pub ambient_color: ColorRGB,
     pub distant_light_count: u16,
+    #[deku(pad_bytes_before = "2")]
     pub distant_light0_color: ColorRGB,
     pub distant_light0_direction: Vector3D,
     pub distant_light1_color: ColorRGB,
     pub distant_light1_direction: Vector3D,
+    #[deku(pad_bytes_before = "12")]
     pub reflection_tint: ColorARGB,
     pub shadow_vector: Vector3D,
     pub shadow_color: ColorRGB,
     pub plane: Plane3D,
+    #[deku(pad_bytes_before = "4", assert = "*rendered_vertices_type == RenderedVerticesType::StructureBSPUncompressedRenderedVertices")]
     pub rendered_vertices_type: RenderedVerticesType,
-    pub rendered_vertices: Block<RenderedVertex>,
-    pub lightmap_vertices: Block<LightmapVertex>,
-    pub uncompressed_vertices: TagDataOffset,
-    pub compressed_vertices: TagDataOffset,
+    #[deku(pad_bytes_before = "2")]
+    pub(crate) rendered_vertices: Block<RenderedVertex>,
+    #[deku(pad_bytes_before = "8")]
+    pub(crate) lightmap_vertices: Block<LightmapVertex>,
+    #[deku(pad_bytes_before = "4", assert = "_uncompressed_vertices.file_offset != 0")]
+    pub(crate) _uncompressed_vertices: TagDataOffset,
+    pub(crate) _compressed_vertices: TagDataOffset,
 }
 
-impl Deserialize for BSPMaterial {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let start = data.position();
-        let shader = TagDependency::deserialize(data).unwrap();
-        let shader_permutation = data.read_u16::<LittleEndian>()?;
-        let flags = data.read_u16::<LittleEndian>()?;
-        let surfaces = data.read_i32::<LittleEndian>()?;
-        let surface_count = data.read_i32::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 28))?;
-        let centroid = Point3D::deserialize(data)?;
-        let ambient_color = ColorRGB::deserialize(data)?;
-        let distant_light_count = data.read_u16::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 56))?;
-        let distant_light0_color = ColorRGB::deserialize(data)?;
-        let distant_light0_direction = Vector3D::deserialize(data)?;
-        let distant_light1_color = ColorRGB::deserialize(data)?;
-        let distant_light1_direction = Vector3D::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 116))?;
-        let reflection_tint = ColorARGB::deserialize(data)?;
-        let shadow_vector = Vector3D::deserialize(data)?;
-        let shadow_color = ColorRGB::deserialize(data)?;
-        let plane = Plane3D::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 176))?;
-        let rendered_vertices_type = RenderedVerticesType::try_from(data.read_u16::<LittleEndian>()?)?;
-        data.seek(SeekFrom::Start(start + 180))?;
-        let rendered_vertices: Block<RenderedVertex> = Block::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 200))?;
-        let lightmap_vertices: Block<LightmapVertex> = Block::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 216))?;
-        let uncompressed_vertices = TagDataOffset::deserialize(data)?;
-        assert_ne!(uncompressed_vertices.file_offset, 0);
-        assert_eq!(rendered_vertices_type, RenderedVerticesType::StructureBSPUncompressedRenderedVertices);
-        data.seek(SeekFrom::Start(start + 236))?;
-        let compressed_vertices = TagDataOffset::deserialize(data)?;
-        Ok(BSPMaterial {
-            shader,
-            shader_permutation,
-            flags,
-            surfaces,
-            surface_count,
-            centroid,
-            ambient_color,
-            distant_light_count,
-            distant_light0_color,
-            distant_light0_direction,
-            distant_light1_color,
-            distant_light1_direction,
-            reflection_tint,
-            shadow_vector,
-            shadow_color,
-            plane,
-            rendered_vertices_type,
-            rendered_vertices,
-            lightmap_vertices,
-            uncompressed_vertices,
-            compressed_vertices,
-        })
+#[wasm_bindgen(js_class = "HaloMaterial")]
+impl BSPMaterial {
+    pub fn get_num_indices(&self) -> i32 {
+        self.surface_count * 3
+    }
+
+    pub fn get_index_offset(&self) -> i32 {
+        self.surfaces * 3
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DekuRead)]
 pub struct RenderedVertex {
     pub position: Vector3D,
     pub normal: Vector3D,
@@ -337,37 +170,16 @@ pub struct RenderedVertex {
     pub v: f32,
 }
 
-impl Deserialize for RenderedVertex {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(RenderedVertex {
-            position: Vector3D::deserialize(data)?,
-            normal: Vector3D::deserialize(data)?,
-            binormal: Vector3D::deserialize(data)?,
-            tangent: Vector3D::deserialize(data)?,
-            u: data.read_f32::<LittleEndian>()?,
-            v: data.read_f32::<LittleEndian>()?,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DekuRead)]
 pub struct LightmapVertex {
     pub normal: Vector3D,
     pub u: f32,
     pub v: f32,
 }
 
-impl Deserialize for LightmapVertex {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(LightmapVertex {
-            normal: Vector3D::deserialize(data)?,
-            u: data.read_f32::<LittleEndian>()?,
-            v: data.read_f32::<LittleEndian>()?,
-        })
-    }
-}
-
-#[derive(Debug, Clone, Copy, TryFromPrimitive, PartialEq)]
+#[wasm_bindgen]
+#[derive(Debug, Clone, Copy, TryFromPrimitive, PartialEq, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum RenderedVerticesType {
     StructureBSPUncompressedRenderedVertices = 0,
@@ -378,7 +190,7 @@ pub enum RenderedVerticesType {
     ModelCompressed = 5,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DekuRead)]
 pub struct ScenarioDecal {
     pub decal_type: u16,
     pub yaw: i8,
@@ -386,19 +198,7 @@ pub struct ScenarioDecal {
     pub position: Point3D,
 }
 
-impl Deserialize for ScenarioDecal {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(ScenarioDecal {
-            decal_type: data.read_u16::<LittleEndian>()?,
-            yaw: data.read_i8()?,
-            pitch: data.read_i8()?,
-            position: Point3D::deserialize(data)?,
-        })
-    }
-}
-
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DekuRead)]
 pub struct ScenarioLightFixture {
     pub light_type: u16,
     pub name: u16,
@@ -414,25 +214,4 @@ pub struct ScenarioLightFixture {
     pub intensity: f32,
     pub falloff_angle: f32,
     pub cutoff_angle: f32,
-}
-
-impl Deserialize for ScenarioLightFixture {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(ScenarioLightFixture {
-            light_type: data.read_u16::<LittleEndian>()?,
-            name: data.read_u16::<LittleEndian>()?,
-            not_placed: data.read_u16::<LittleEndian>()?,
-            desired_permutation: data.read_u16::<LittleEndian>()?,
-            position: Point3D::deserialize(data)?,
-            rotation: Euler3D::deserialize(data)?,
-            bsp_indices: data.read_u16::<LittleEndian>()?,
-            power_group: data.read_u16::<LittleEndian>()?,
-            position_group: data.read_u16::<LittleEndian>()?,
-            device_flags: data.read_u32::<LittleEndian>()?,
-            color: ColorRGB::deserialize(data)?,
-            intensity: data.read_f32::<LittleEndian>()?,
-            falloff_angle: data.read_f32::<LittleEndian>()?,
-            cutoff_angle: data.read_f32::<LittleEndian>()?,
-        })
-    }
 }

--- a/rust/src/halo/shader.rs
+++ b/rust/src/halo/shader.rs
@@ -1,62 +1,42 @@
-use std::{io::{Cursor, Seek, SeekFrom}, convert::TryFrom};
-
-
+use deku::prelude::*;
 use wasm_bindgen::prelude::*;
-use byteorder::LittleEndian;
-use byteorder::ReadBytesExt;
 use num_enum::TryFromPrimitive;
 use super::tag::*;
 use super::common::*;
 
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloShaderTransparencyChicago")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct ShaderTransparentChicago {
-    // shader properties
     pub radiosity_flags: u16,
     pub radiosity_detail_level: RadiosityDetailLevel,
     pub radiosity_light_power: f32,
     pub radiosity_light_color: ColorRGB,
     pub radiosity_tint_color: ColorRGB,
-
+    #[deku(pad_bytes_before = "8")]
     pub numeric_counter_limit: u8,
     pub flags: u8,
     pub first_map_type: ShaderTransparentGenericMapType,
     pub framebuffer_blend_function: FramebufferBlendFunction,
     pub framebuffer_fade_mode: FramebufferFadeMode,
     pub framebuffer_fade_source: FunctionSource,
+    #[deku(pad_bytes_before = "2")]
     pub lens_flare_spacing: f32,
     pub lens_flare: TagDependency,
-    pub extra_layers: Block<TagDependency>, // only chicago transparent shaders allowed here
-    pub maps: Block<ShaderTransparentChicagoMap>, // max of 4
+    pub(crate) extra_layers: Block<TagDependency>, // only chicago transparent shaders allowed here
+    #[deku(pad_bytes_after = "10")]
+    pub(crate) bitmaps: Block<ShaderTransparentChicagoBitmap>, // max of 4
 }
 
-impl Deserialize for ShaderTransparentChicago {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let mut start = data.position();
-        let radiosity_flags = data.read_u16::<LittleEndian>()?;
-        let radiosity_detail_level = RadiosityDetailLevel::try_from(data.read_u16::<LittleEndian>()?)?;
-        let radiosity_light_power = data.read_f32::<LittleEndian>()?;
-        let radiosity_light_color = ColorRGB::deserialize(data)?;
-        let radiosity_tint_color = ColorRGB::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 40))?;
-        start = data.position();
-        let numeric_counter_limit = data.read_u8()?;
-        let flags = data.read_u8()?;
-        let first_map_type = ShaderTransparentGenericMapType::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let framebuffer_blend_function = FramebufferBlendFunction::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let framebuffer_fade_mode = FramebufferFadeMode::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let framebuffer_fade_source = FunctionSource::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        data.seek(SeekFrom::Start(start + 12))?;
-        let lens_flare_spacing = data.read_f32::<LittleEndian>()?;
-        let lens_flare = TagDependency::deserialize(data)?;
-        let extra_layers: Block<TagDependency> = Block::deserialize(data)?;
-        let maps: Block<ShaderTransparentChicagoMap> = Block::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 66))?;
-        Ok(ShaderTransparentChicago { radiosity_flags, radiosity_detail_level, radiosity_light_power, radiosity_light_color, radiosity_tint_color, numeric_counter_limit, flags, first_map_type, framebuffer_blend_function, framebuffer_fade_mode, framebuffer_fade_source, lens_flare_spacing, lens_flare, extra_layers, maps })
+#[wasm_bindgen(js_class = "HaloShaderTransparencyChicago")]
+impl ShaderTransparentChicago {
+    pub fn get_bitmaps(&self) -> Vec<ShaderTransparentChicagoBitmap> {
+        self.bitmaps.items.as_ref().cloned().unwrap()
     }
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[derive(Debug, Clone, Copy, TryFromPrimitive, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderTransparentChicagoColorFunction {
     Current = 0,
@@ -74,18 +54,22 @@ pub enum ShaderTransparentChicagoColorFunction {
     BlendNextMapAlphaInverse = 12,
 }
 
-#[derive(Debug, Clone)]
-pub struct ShaderTransparentChicagoMap {
+#[wasm_bindgen(js_name = "HaloShaderTransparentChicagoBitmap")]
+#[derive(Debug, Clone, DekuRead)]
+pub struct ShaderTransparentChicagoBitmap {
     pub flags: u16,
+    #[deku(pad_bytes_before = "42")]
     pub color_function: ShaderTransparentChicagoColorFunction,
     pub alpha_function: ShaderTransparentChicagoColorFunction,
+    #[deku(pad_bytes_before = "36")]
     pub map_u_scale: f32,
     pub map_v_scale: f32,
     pub map_u_offset: f32,
     pub map_v_offset: f32,
     pub map_rotation: f32,
     pub mipmap_bias: f32,
-    pub map: TagDependency,
+    pub bitmap: TagDependency,
+    #[deku(pad_bytes_before = "40")]
     pub u_animation_source: FunctionSource,
     pub u_animation_function: AnimationFunction,
     pub u_animation_period: f32,
@@ -104,127 +88,52 @@ pub struct ShaderTransparentChicagoMap {
     pub rotation_animation_center: Point2D,
 }
 
-impl Deserialize for ShaderTransparentChicagoMap {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let start = data.position();
-        let flags = data.read_u16::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 44))?;
-        let color_function = ShaderTransparentChicagoColorFunction::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let alpha_function = ShaderTransparentChicagoColorFunction::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        data.seek(SeekFrom::Start(start + 84))?;
-        let map_u_scale = data.read_f32::<LittleEndian>()?;
-        let map_v_scale = data.read_f32::<LittleEndian>()?;
-        let map_u_offset = data.read_f32::<LittleEndian>()?;
-        let map_v_offset = data.read_f32::<LittleEndian>()?;
-        let map_rotation = data.read_f32::<LittleEndian>()?;
-        let mipmap_bias = data.read_f32::<LittleEndian>()?;
-        let map = TagDependency::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 164))?;
-        let u_animation_source = FunctionSource::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let u_animation_function = AnimationFunction::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let u_animation_period = data.read_f32::<LittleEndian>()?;
-        let u_animation_phase = data.read_f32::<LittleEndian>()?;
-        let u_animation_scale = data.read_f32::<LittleEndian>()?;
-        let v_animation_source = FunctionSource::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let v_animation_function = AnimationFunction::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let v_animation_period = data.read_f32::<LittleEndian>()?;
-        let v_animation_phase = data.read_f32::<LittleEndian>()?;
-        let v_animation_scale = data.read_f32::<LittleEndian>()?;
-        let rotation_animation_source = FunctionSource::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let rotation_animation_function = AnimationFunction::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let rotation_animation_period = data.read_f32::<LittleEndian>()?;
-        let rotation_animation_phase = data.read_f32::<LittleEndian>()?;
-        let rotation_animation_scale = data.read_f32::<LittleEndian>()?;
-        let rotation_animation_center = Point2D::deserialize(data)?;
-        Ok(ShaderTransparentChicagoMap {
-            flags,
-            color_function,
-            alpha_function,
-            map_u_scale,
-            map_v_scale,
-            map_u_offset,
-            map_v_offset,
-            map_rotation,
-            mipmap_bias,
-            map,
-            u_animation_source,
-            u_animation_function,
-            u_animation_period,
-            u_animation_phase,
-            u_animation_scale,
-            v_animation_source,
-            v_animation_function,
-            v_animation_period,
-            v_animation_phase,
-            v_animation_scale,
-            rotation_animation_source,
-            rotation_animation_function,
-            rotation_animation_period,
-            rotation_animation_phase,
-            rotation_animation_scale,
-            rotation_animation_center,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloShaderTransparencyGeneric")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct ShaderTransparentGeneric {
-    // shader properties
     pub radiosity_flags: u16,
     pub radiosity_detail_level: RadiosityDetailLevel,
     pub radiosity_light_power: f32,
     pub radiosity_light_color: ColorRGB,
     pub radiosity_tint_color: ColorRGB,
-
+    #[deku(pad_bytes_before = "8")]
     pub numeric_counter_limit: u8,
     pub flags: u8,
     pub first_map_type: ShaderTransparentGenericMapType,
     pub framebuffer_blend_function: FramebufferBlendFunction,
     pub framebuffer_fade_mode: FramebufferFadeMode,
     pub framebuffer_fade_source: FunctionSource,
+    #[deku(pad_bytes_before = "2")]
     pub lens_flare_spacing: f32,
     pub lens_flare: TagDependency,
-    pub extra_layers: Block<TagDependency>, // max of 4
-    pub maps: Block<ShaderTransparentGenericMap>, // max of 4
-    pub stages: Block<ShaderTransparentGenericStage>, // max of 7
+    pub(crate) extra_layers: Block<TagDependency>, // max of 4
+    pub(crate) bitmaps: Block<ShaderTransparentGenericBitmap>, // max of 4
+    pub(crate) stages: Block<ShaderTransparentGenericStage>, // max of 7
 }
 
-impl Deserialize for ShaderTransparentGeneric {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let mut start = data.position();
-        let radiosity_flags = data.read_u16::<LittleEndian>()?;
-        let radiosity_detail_level = RadiosityDetailLevel::try_from(data.read_u16::<LittleEndian>()?)?;
-        let radiosity_light_power = data.read_f32::<LittleEndian>()?;
-        let radiosity_light_color = ColorRGB::deserialize(data)?;
-        let radiosity_tint_color = ColorRGB::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 40))?;
-        start = data.position();
-        let numeric_counter_limit = data.read_u8()?;
-        let flags = data.read_u8()?;
-        let first_map_type = ShaderTransparentGenericMapType::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let framebuffer_blend_function = FramebufferBlendFunction::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let framebuffer_fade_mode = FramebufferFadeMode::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let framebuffer_fade_source = FunctionSource::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        data.seek(SeekFrom::Start(start + 12))?;
-        let lens_flare_spacing = data.read_f32::<LittleEndian>()?;
-        let lens_flare = TagDependency::deserialize(data)?;
-        let extra_layers: Block<TagDependency> = Block::deserialize(data)?;
-        let maps: Block<ShaderTransparentGenericMap> = Block::deserialize(data)?;
-        let stages: Block<ShaderTransparentGenericStage> = Block::deserialize(data)?;
-        Ok(ShaderTransparentGeneric { radiosity_flags, radiosity_detail_level, radiosity_light_power, radiosity_light_color, radiosity_tint_color, numeric_counter_limit, flags, first_map_type, framebuffer_blend_function, framebuffer_fade_mode, framebuffer_fade_source, lens_flare_spacing, lens_flare, extra_layers, maps, stages })
+#[wasm_bindgen(js_class = "HaloShaderTransparencyGeneric")]
+impl ShaderTransparentGeneric {
+    pub fn get_stages(&self) -> Vec<ShaderTransparentGenericStage> {
+        self.stages.items.as_ref().cloned().unwrap()
+    }
+
+    pub fn get_bitmaps(&self) -> Vec<ShaderTransparentGenericBitmap> {
+        self.bitmaps.items.as_ref().cloned().unwrap()
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct ShaderTransparentGenericMap {
+#[wasm_bindgen(js_name = "HaloShaderTransparentGenericMap")]
+#[derive(Debug, Clone, DekuRead)]
+pub struct ShaderTransparentGenericBitmap {
     pub flags: u16,
+    #[deku(pad_bytes_before = "2")]
     pub map_u_scale: f32,
     pub map_v_scale: f32,
     pub map_u_offset: f32,
     pub map_v_offset: f32,
     pub map_rotation: f32,
     pub mipmap_bias: f32,
-    pub map: TagDependency,
+    pub bitmap: TagDependency,
     pub u_animation_source: FunctionSource,
     pub u_animation_function: AnimationFunction,
     pub u_animation_period: f32,
@@ -243,66 +152,11 @@ pub struct ShaderTransparentGenericMap {
     pub rotation_animation_center: Point2D,
 }
 
-impl Deserialize for ShaderTransparentGenericMap {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let start = data.position();
-        let flags = data.read_u16::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 4))?;
-        let map_u_scale = data.read_f32::<LittleEndian>()?;
-        let map_v_scale = data.read_f32::<LittleEndian>()?;
-        let map_u_offset = data.read_f32::<LittleEndian>()?;
-        let map_v_offset = data.read_f32::<LittleEndian>()?;
-        let map_rotation = data.read_f32::<LittleEndian>()?;
-        let map_bias = data.read_f32::<LittleEndian>()?;
-        let map = TagDependency::deserialize(data)?;
-        let u_animation_source = FunctionSource::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let u_animation_function = AnimationFunction::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let u_animation_period = data.read_f32::<LittleEndian>()?;
-        let u_animation_phase = data.read_f32::<LittleEndian>()?;
-        let u_animation_scale = data.read_f32::<LittleEndian>()?;
-        let v_animation_source = FunctionSource::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let v_animation_function = AnimationFunction::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let v_animation_period = data.read_f32::<LittleEndian>()?;
-        let v_animation_phase = data.read_f32::<LittleEndian>()?;
-        let v_animation_scale = data.read_f32::<LittleEndian>()?;
-        let rotation_animation_source = FunctionSource::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let rotation_animation_function = AnimationFunction::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let rotation_animation_period = data.read_f32::<LittleEndian>()?;
-        let rotation_animation_phase = data.read_f32::<LittleEndian>()?;
-        let rotation_animation_scale = data.read_f32::<LittleEndian>()?;
-        let rotation_animation_center = Point2D::deserialize(data)?;
-        Ok(ShaderTransparentGenericMap {
-            flags,
-            map_u_scale,
-            map_v_scale,
-            map_u_offset,
-            map_v_offset,
-            map_rotation,
-            mipmap_bias: map_bias,
-            map,
-            u_animation_source,
-            u_animation_function,
-            u_animation_period,
-            u_animation_phase,
-            u_animation_scale,
-            v_animation_source,
-            v_animation_function,
-            v_animation_period,
-            v_animation_phase,
-            v_animation_scale,
-            rotation_animation_source,
-            rotation_animation_function,
-            rotation_animation_period,
-            rotation_animation_phase,
-            rotation_animation_scale,
-            rotation_animation_center,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloShaderTransparentGenericStage")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct ShaderTransparentGenericStage {
     pub flags: u16,
+    #[deku(pad_bytes_before = "2")]
     pub color0_source: FunctionSource,
     pub color0_animation_function: AnimationFunction,
     pub color0_animation_period: f32,
@@ -324,62 +178,22 @@ pub struct ShaderTransparentGenericStage {
     pub output_ab_cd_mux_sum: ShaderOutput,
     pub output_mapping_color: ShaderOutputMapping,
     pub input_a_alpha: ShaderAlphaInput,
-    pub input_a_mapping_alpha: ShaderMapping, 
+    pub input_a_mapping_alpha: ShaderMapping,
     pub input_b_alpha: ShaderAlphaInput,
-    pub input_b_mapping_alpha: ShaderMapping, 
+    pub input_b_mapping_alpha: ShaderMapping,
     pub input_c_alpha: ShaderAlphaInput,
-    pub input_c_mapping_alpha: ShaderMapping, 
+    pub input_c_mapping_alpha: ShaderMapping,
     pub input_d_alpha: ShaderAlphaInput,
-    pub input_d_mapping_alpha: ShaderMapping, 
+    pub input_d_mapping_alpha: ShaderMapping,
     pub output_ab_alpha: ShaderOutput,
     pub output_cd_alpha: ShaderOutput,
     pub output_ab_cd_mux_sum_alpha: ShaderOutput,
     pub output_mapping_alpha: ShaderOutputMapping,
 }
 
-impl Deserialize for ShaderTransparentGenericStage {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let start = data.position();
-        let flags = data.read_u16::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 4))?;
-        let color0_source = FunctionSource::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let color0_animation_function = AnimationFunction::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let color0_animation_period = data.read_f32::<LittleEndian>()?;
-        let color0_animation_lower_bound = ColorARGB::deserialize(data)?;
-        let color0_animation_upper_bound = ColorARGB::deserialize(data)?;
-        let color1 = ColorARGB::deserialize(data)?;
-        let input_a = ShaderInput::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let input_a_mapping = ShaderMapping::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let input_b = ShaderInput::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let input_b_mapping = ShaderMapping::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let input_c = ShaderInput::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let input_c_mapping = ShaderMapping::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let input_d = ShaderInput::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let input_d_mapping = ShaderMapping::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let output_ab = ShaderOutput::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let output_ab_function = ShaderOutputFunction::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let output_cd = ShaderOutput::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let output_cd_function = ShaderOutputFunction::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let output_ab_cd_mux_sum = ShaderOutput::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let output_mapping_color = ShaderOutputMapping::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let input_a_alpha = ShaderAlphaInput::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let input_a_mapping_alpha = ShaderMapping::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let input_b_alpha = ShaderAlphaInput::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let input_b_mapping_alpha = ShaderMapping::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let input_c_alpha = ShaderAlphaInput::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let input_c_mapping_alpha = ShaderMapping::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let input_d_alpha = ShaderAlphaInput::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let input_d_mapping_alpha = ShaderMapping::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let output_ab_alpha = ShaderOutput::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let output_cd_alpha = ShaderOutput::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let output_ab_cd_mux_sum_alpha = ShaderOutput::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        let output_mapping_alpha = ShaderOutputMapping::try_from_primitive(data.read_u16::<LittleEndian>()?)?;
-        Ok(ShaderTransparentGenericStage { flags, color0_source, color0_animation_function, color0_animation_period, color0_animation_lower_bound, color0_animation_upper_bound, color1, input_a, input_a_mapping, input_b, input_b_mapping, input_c, input_c_mapping, input_d, input_d_mapping, output_ab, output_ab_function, output_cd, output_cd_function, output_ab_cd_mux_sum, output_mapping_color, input_a_alpha, input_a_mapping_alpha, input_b_alpha, input_b_mapping_alpha, input_c_alpha, input_c_mapping_alpha, input_d_alpha, input_d_mapping_alpha, output_ab_alpha, output_cd_alpha, output_ab_cd_mux_sum_alpha, output_mapping_alpha })
-    }
-}
-
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderOutputMapping {
     Identity = 0,
@@ -391,7 +205,8 @@ pub enum ShaderOutputMapping {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderOutputFunction {
     Multiply = 0,
@@ -399,7 +214,8 @@ pub enum ShaderOutputFunction {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderOutput {
     Discard = 0,
@@ -414,7 +230,8 @@ pub enum ShaderOutput {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderMapping {
     UnsignedIdentity = 0,
@@ -428,7 +245,8 @@ pub enum ShaderMapping {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderInput {
     Zero = 0x0,
@@ -459,7 +277,8 @@ pub enum ShaderInput {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderAlphaInput {
     Zero = 0,
@@ -490,7 +309,8 @@ pub enum ShaderAlphaInput {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum FramebufferFadeMode {
     None = 0,
@@ -499,7 +319,8 @@ pub enum FramebufferFadeMode {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum FramebufferBlendFunction {
     AlphaBlend = 0,
@@ -513,7 +334,8 @@ pub enum FramebufferBlendFunction {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderTransparentGenericMapType {
     Map2D = 0,
@@ -523,7 +345,8 @@ pub enum ShaderTransparentGenericMapType {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum RadiosityDetailLevel {
     High = 0,
@@ -532,31 +355,36 @@ pub enum RadiosityDetailLevel {
     Turd = 3, // smh
 }
 
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloShaderModel")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct ShaderModel {
-    // shader properties
     pub radiosity_flags: u16,
     pub radiosity_detail_level: RadiosityDetailLevel,
     pub radiosity_light_power: f32,
     pub radiosity_light_color: ColorRGB,
     pub radiosity_tint_color: ColorRGB,
-    
-    // shader model properties
+    #[deku(pad_bytes_before = "8")]
     pub flags: u16,
+    #[deku(pad_bytes_before = "14")]
     pub translucency: f32,
+    #[deku(pad_bytes_before = "54")]
     pub animation_function: AnimationFunction,
     pub animation_period: f32,
     pub animation_color_lower_bound: ColorRGB,
     pub animation_color_upper_bound: ColorRGB,
+    #[deku(pad_bytes_before = "12")]
     pub map_u_scale: f32,
     pub map_v_scale: f32,
     pub base_map: TagDependency,
+    #[deku(pad_bytes_before = "8")]
     pub multipurpose_map: TagDependency,
+    #[deku(pad_bytes_before = "8")]
     pub detail_function: DetailBitmapFunction,
     pub detail_mask: DetailBitmapMask,
     pub detail_map_scale: f32,
     pub detail_map: TagDependency,
     pub detail_map_v_scale: f32,
+    #[deku(pad_bytes_before = "12")]
     pub u_animation_source: FunctionSource,
     pub u_animation_function: AnimationFunction,
     pub u_animation_period: f32,
@@ -573,17 +401,20 @@ pub struct ShaderModel {
     pub rotation_animation_phase: f32,
     pub rotation_animation_scale: f32,
     pub rotation_animation_center: Point2D,
+    #[deku(pad_bytes_before = "8")]
     pub reflection_falloff_distance: f32,
     pub reflection_cutoff_distance: f32,
     pub perpendicular_brightness: f32,
     pub perpendicular_tint_color: ColorRGB,
     pub parallel_brightness: f32,
     pub parallel_tint_color: ColorRGB,
+    #[deku(pad_bytes_after = "68")]
     pub reflection_cube_map: TagDependency,
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum AnimationFunction {
     One = 0x0,
@@ -601,7 +432,8 @@ pub enum AnimationFunction {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum DetailBitmapMask {
     None = 0x0,
@@ -616,7 +448,8 @@ pub enum DetailBitmapMask {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum FunctionSource {
     None = 0,
@@ -626,151 +459,60 @@ pub enum FunctionSource {
     D = 4,
 }
 
-impl Deserialize for ShaderModel {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let mut start = data.position();
-        let radiosity_flags = data.read_u16::<LittleEndian>()?;
-        let radiosity_detail_level = RadiosityDetailLevel::try_from(data.read_u16::<LittleEndian>()?)?;
-        let radiosity_light_power = data.read_f32::<LittleEndian>()?;
-        let radiosity_light_color = ColorRGB::deserialize(data)?;
-        let radiosity_tint_color = ColorRGB::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 40))?;
-        start = data.position();
-        let flags = data.read_u16::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 16))?;
-        let translucency = data.read_f32::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 74))?;
-        let animation_function = AnimationFunction::try_from(data.read_u16::<LittleEndian>()?)?;
-        let animation_period = data.read_f32::<LittleEndian>()?;
-        let animation_color_lower_bound = ColorRGB::deserialize(data)?;
-        let animation_color_upper_bound = ColorRGB::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 116))?;
-        let map_u_scale = data.read_f32::<LittleEndian>()?;
-        let map_v_scale = data.read_f32::<LittleEndian>()?;
-        let base_map = TagDependency::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 148))?;
-        let multipurpose_map = TagDependency::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 172))?;
-        let detail_function = DetailBitmapFunction::try_from(data.read_u16::<LittleEndian>()?)?;
-        let detail_mask = DetailBitmapMask::try_from(data.read_u16::<LittleEndian>()?)?;
-        let detail_map_scale = data.read_f32::<LittleEndian>()?;
-        let detail_map = TagDependency::deserialize(data)?;
-        let detail_map_v_scale = data.read_f32::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 212))?;
-        let u_animation_source = FunctionSource::try_from(data.read_u16::<LittleEndian>()?)?;
-        let u_animation_function = AnimationFunction::try_from(data.read_u16::<LittleEndian>()?)?;
-        let u_animation_period = data.read_f32::<LittleEndian>()?;
-        let u_animation_phase = data.read_f32::<LittleEndian>()?;
-        let u_animation_scale = data.read_f32::<LittleEndian>()?;
-        let v_animation_source = FunctionSource::try_from(data.read_u16::<LittleEndian>()?)?;
-        let v_animation_function = AnimationFunction::try_from(data.read_u16::<LittleEndian>()?)?;
-        let v_animation_period = data.read_f32::<LittleEndian>()?;
-        let v_animation_phase = data.read_f32::<LittleEndian>()?;
-        let v_animation_scale = data.read_f32::<LittleEndian>()?;
-        let rotation_animation_source = FunctionSource::try_from(data.read_u16::<LittleEndian>()?)?;
-        let rotation_animation_function = AnimationFunction::try_from(data.read_u16::<LittleEndian>()?)?;
-        let rotation_animation_period = data.read_f32::<LittleEndian>()?;
-        let rotation_animation_phase = data.read_f32::<LittleEndian>()?;
-        let rotation_animation_scale = data.read_f32::<LittleEndian>()?;
-        let rotation_animation_center = Point2D::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 276))?;
-        let reflection_falloff_distance = data.read_f32::<LittleEndian>()?;
-        let reflection_cutoff_distance = data.read_f32::<LittleEndian>()?;
-        let perpendicular_brightness = data.read_f32::<LittleEndian>()?;
-        let perpendicular_tint_color = ColorRGB::deserialize(data)?;
-        let parallel_brightness = data.read_f32::<LittleEndian>()?;
-        let parallel_tint_color = ColorRGB::deserialize(data)?;
-        let reflection_cube_map = TagDependency::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 400))?;
-        Ok(ShaderModel {
-            radiosity_flags,
-            radiosity_detail_level,
-            radiosity_light_power,
-            radiosity_light_color,
-            radiosity_tint_color,
-            flags,
-            translucency,
-            animation_function,
-            animation_period,
-            animation_color_lower_bound,
-            animation_color_upper_bound,
-            map_u_scale,
-            map_v_scale,
-            base_map,
-            multipurpose_map,
-            detail_function,
-            detail_mask,
-            detail_map_scale,
-            detail_map,
-            detail_map_v_scale,
-            u_animation_source,
-            u_animation_function,
-            u_animation_period,
-            u_animation_phase,
-            u_animation_scale,
-            v_animation_source,
-            v_animation_function,
-            v_animation_period,
-            v_animation_phase,
-            v_animation_scale,
-            rotation_animation_source,
-            rotation_animation_function,
-            rotation_animation_period,
-            rotation_animation_phase,
-            rotation_animation_scale,
-            rotation_animation_center,
-            reflection_falloff_distance,
-            reflection_cutoff_distance,
-            perpendicular_brightness,
-            perpendicular_tint_color,
-            parallel_brightness,
-            parallel_tint_color,
-            reflection_cube_map,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloShaderEnvironment")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct ShaderEnvironment {
-    // shader properties
     pub radiosity_flags: u16,
     pub radiosity_detail_level: RadiosityDetailLevel,
     pub radiosity_light_power: f32,
     pub radiosity_light_color: ColorRGB,
     pub radiosity_tint_color: ColorRGB,
-
-    // shader environment properties
+    #[deku(pad_bytes_before = "8")]
     pub flags: u16,
     pub shader_environment_type: ShaderEnvironmentType,
     pub lens_flare_spacing: f32,
     pub lens_flare: TagDependency,
+    #[deku(pad_bytes_before = "44")]
     pub diffuse_flags: u16,
+    #[deku(pad_bytes_before = "26")]
     pub base_bitmap: TagDependency,
+    #[deku(pad_bytes_before = "24")]
     pub detail_bitmap_function: DetailBitmapFunction,
+    #[deku(pad_bytes_before = "2")]
     pub primary_detail_bitmap_scale: f32,
     pub primary_detail_bitmap: TagDependency,
     pub secondary_detail_bitmap_scale: f32,
     pub secondary_detail_bitmap: TagDependency,
-    pub micro_detail_scale: f32,
+    #[deku(pad_bytes_before = "24")]
     pub micro_detail_bitmap_function: DetailBitmapFunction,
+    #[deku(pad_bytes_before = "2")]
+    pub micro_detail_bitmap_scale: f32,
     pub micro_detail_bitmap: TagDependency,
     pub material_color: ColorRGB,
+    #[deku(pad_bytes_before = "12")]
     pub bump_map_scale: f32,
     pub bump_map: TagDependency,
+    #[deku(pad_bytes_before = "324")]
     pub specular_flags: u16,
+    #[deku(pad_bytes_before = "18")]
     pub brightness: f32,
+    #[deku(pad_bytes_before = "20")]
     pub perpendicular_color: ColorRGB,
     pub parallel_color: ColorRGB,
+    #[deku(pad_bytes_before = "16")]
     pub reflection_flags: u16,
     pub reflection_type: ShaderEnvironmentReflectionType,
     pub lightmap_brightness_scale: f32,
+    #[deku(pad_bytes_before = "28")]
     pub perpendicular_brightness: f32,
     pub parallel_brightness: f32,
+    #[deku(pad_bytes_before = "40")]
     pub reflection_cube_map: TagDependency,
 }
 
 #[wasm_bindgen]
-#[derive(Copy, Clone, Debug, TryFromPrimitive)]
+#[derive(Copy, Clone, Debug, TryFromPrimitive, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderEnvironmentReflectionType {
     BumpedCubeMap = 0,
@@ -778,95 +520,9 @@ pub enum ShaderEnvironmentReflectionType {
     BumpedRadiosity = 2,
 }
 
-impl Deserialize for ShaderEnvironment {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let mut start = data.position();
-        let radiosity_flags = data.read_u16::<LittleEndian>()?;
-        let radiosity_detail_level = RadiosityDetailLevel::try_from(data.read_u16::<LittleEndian>()?)?;
-        let radiosity_light_power = data.read_f32::<LittleEndian>()?;
-        let radiosity_light_color = ColorRGB::deserialize(data)?;
-        let radiosity_tint_color = ColorRGB::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 40))?;
-        start = data.position();
-        let flags = data.read_u16::<LittleEndian>()?;
-        let shader_environment_type = ShaderEnvironmentType::try_from(data.read_u16::<LittleEndian>()?)?;
-        let lens_flare_spacing = data.read_f32::<LittleEndian>()?;
-        let lens_flare = TagDependency::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 68))?;
-        let diffuse_flags = data.read_u16::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 96))?;
-        let base_bitmap = TagDependency::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 136))?;
-        let detail_bitmap_function = DetailBitmapFunction::try_from(data.read_u16::<LittleEndian>()?)?;
-        data.seek(SeekFrom::Start(start + 140))?;
-        let primary_detail_bitmap_scale = data.read_f32::<LittleEndian>()?;
-        let primary_detail_bitmap = TagDependency::deserialize(data)?;
-        let secondary_detail_bitmap_scale = data.read_f32::<LittleEndian>()?;
-        let secondary_detail_bitmap = TagDependency::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 204))?;
-        let micro_detail_bitmap_function = DetailBitmapFunction::try_from(data.read_u16::<LittleEndian>()?)?;
-        data.seek(SeekFrom::Start(start + 208))?;
-        let micro_detail_scale = data.read_f32::<LittleEndian>()?;
-        let micro_detail_bitmap = TagDependency::deserialize(data)?;
-        let material_color = ColorRGB::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 252))?;
-        let bump_map_scale = data.read_f32::<LittleEndian>()?;
-        let bump_map = TagDependency::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 596))?;
-        let specular_flags = data.read_u16::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 616))?;
-        let brightness = data.read_f32::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 640))?;
-        let perpendicular_color = ColorRGB::deserialize(data)?;
-        let parallel_color = ColorRGB::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 680))?;
-        let reflection_flags = data.read_u16::<LittleEndian>()?;
-        let reflection_type = ShaderEnvironmentReflectionType::try_from(data.read_u16::<LittleEndian>()?)?;
-        let lightmap_brightness_scale = data.read_f32::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 716))?;
-        let perpendicular_brightness = data.read_f32::<LittleEndian>()?;
-        let parallel_brightness = data.read_f32::<LittleEndian>()?;
-        data.seek(SeekFrom::Start(start + 764))?;
-        let reflection_cube_map = TagDependency::deserialize(data)?;
-        Ok(ShaderEnvironment {
-            radiosity_flags,
-            radiosity_detail_level,
-            radiosity_light_power,
-            radiosity_light_color,
-            radiosity_tint_color,
-            flags,
-            shader_environment_type,
-            lens_flare_spacing,
-            lens_flare,
-            diffuse_flags,
-            base_bitmap,
-            detail_bitmap_function,
-            primary_detail_bitmap_scale,
-            primary_detail_bitmap,
-            secondary_detail_bitmap_scale,
-            secondary_detail_bitmap,
-            micro_detail_scale,
-            micro_detail_bitmap_function,
-            micro_detail_bitmap,
-            material_color,
-            bump_map_scale,
-            bump_map,
-            specular_flags,
-            brightness,
-            perpendicular_color,
-            parallel_color,
-            reflection_flags,
-            reflection_type,
-            lightmap_brightness_scale,
-            perpendicular_brightness,
-            parallel_brightness,
-            reflection_cube_map,
-        })
-    }
-}
-
 #[wasm_bindgen]
-#[derive(Debug, TryFromPrimitive, Copy, Clone)]
+#[derive(Debug, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum DetailBitmapFunction {
     DoubleBiasedMultiply = 0,
@@ -875,7 +531,8 @@ pub enum DetailBitmapFunction {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, TryFromPrimitive, Copy, Clone)]
+#[derive(Debug, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderEnvironmentType {
     Normal = 0,
@@ -883,119 +540,56 @@ pub enum ShaderEnvironmentType {
     BlendedBaseSpecular = 2,
 }
 
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloShaderTransparentWaterRipple")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct ShaderTransparentWaterRipple {
+    #[deku(pad_bytes_before = "4")]
     pub contribution_factor: f32,
+    #[deku(pad_bytes_before = "32")]
     pub animation_angle: f32,
     pub animation_velocity: f32,
     pub map_u_offset: f32,
     pub map_v_offset: f32,
     pub map_repeats: u16,
+    #[deku(pad_bytes_after = "16")]
     pub map_index: u16,
 }
 
-impl Deserialize for ShaderTransparentWaterRipple {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        data.seek(SeekFrom::Current(2 + 2))?;
-        let contribution_factor = data.read_f32::<LittleEndian>()?;
-        data.seek(SeekFrom::Current(32))?;
-        let animation_angle = data.read_f32::<LittleEndian>()?;
-        let animation_velocity = data.read_f32::<LittleEndian>()?;
-        let map_u_offset = data.read_f32::<LittleEndian>()?;
-        let map_v_offset = data.read_f32::<LittleEndian>()?;
-        let map_repeats = data.read_u16::<LittleEndian>()?;
-        let map_index = data.read_u16::<LittleEndian>()?;
-        data.seek(SeekFrom::Current(16))?;
-        Ok(ShaderTransparentWaterRipple {
-            contribution_factor,
-            animation_angle,
-            animation_velocity,
-            map_u_offset,
-            map_v_offset,
-            map_repeats,
-            map_index,
-        })
-    }
-}
-
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloShaderTransparentWater")]
+#[derive(Debug, Clone, DekuRead)]
 pub struct ShaderTransparentWater {
-    // shader properties
     pub radiosity_flags: u16,
     pub radiosity_detail_level: RadiosityDetailLevel,
     pub radiosity_light_power: f32,
     pub radiosity_light_color: ColorRGB,
     pub radiosity_tint_color: ColorRGB,
-
+    #[deku(pad_bytes_before = "8")]
     pub flags: u16,
+    #[deku(pad_bytes_before = "34")]
     pub base_bitmap: TagDependency,
+    #[deku(pad_bytes_before = "16")]
     pub view_perpendicular_brightness: f32,
     pub view_perpendicular_tint_color: ColorRGB,
     pub view_parallel_brightness: f32,
     pub view_parallel_tint_color: ColorRGB,
+    #[deku(pad_bytes_before = "16")]
     pub reflection_bitmap: TagDependency,
+    #[deku(pad_bytes_before = "16")]
     pub ripple_animation_angle: f32,
     pub ripple_animation_velocity: f32,
     pub ripple_scale: f32,
     pub ripple_bitmap: TagDependency,
     pub ripple_mipmap_levels: u16,
+    #[deku(pad_bytes_before = "2")]
     pub ripple_mipmap_fade_factor: f32,
     pub ripple_mipmap_detail_bias: f32,
-    pub ripples: Block<ShaderTransparentWaterRipple>, // max of 4
+    #[deku(pad_bytes_before = "64", pad_bytes_after = "16")]
+    pub(crate) ripples: Block<ShaderTransparentWaterRipple>, // max of 4
 }
 
-impl Deserialize for ShaderTransparentWater {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let start = data.position();
-        let radiosity_flags = data.read_u16::<LittleEndian>()?;
-        let radiosity_detail_level = RadiosityDetailLevel::try_from(data.read_u16::<LittleEndian>()?)?;
-        let radiosity_light_power = data.read_f32::<LittleEndian>()?;
-        let radiosity_light_color = ColorRGB::deserialize(data)?;
-        let radiosity_tint_color = ColorRGB::deserialize(data)?;
-        data.seek(SeekFrom::Start(start + 40))?;
-        let flags = dbg!(data.read_u16::<LittleEndian>()?);
-        data.seek(SeekFrom::Current(2 + 32))?;
-        let base_bitmap = dbg!(TagDependency::deserialize(data)?);
-        data.seek(SeekFrom::Current(16))?;
-        let view_perpendicular_brightness = data.read_f32::<LittleEndian>()?;
-        let view_perpendicular_tint_color = ColorRGB::deserialize(data)?;
-        let view_parallel_brightness = data.read_f32::<LittleEndian>()?;
-        let view_parallel_tint_color = ColorRGB::deserialize(data)?;
-        data.seek(SeekFrom::Current(16))?;
-        let reflection_bitmap = TagDependency::deserialize(data)?;
-        data.seek(SeekFrom::Current(16))?;
-        let ripple_animation_angle = data.read_f32::<LittleEndian>()?;
-        let ripple_animation_velocity = data.read_f32::<LittleEndian>()?;
-        let ripple_scale = data.read_f32::<LittleEndian>()?;
-        let ripple_bitmap = TagDependency::deserialize(data)?;
-        let ripple_mipmap_levels = data.read_u16::<LittleEndian>()?;
-        data.seek(SeekFrom::Current(2))?;
-        let ripple_mipmap_fade_factor = data.read_f32::<LittleEndian>()?;
-        let ripple_mipmap_detail_bias = data.read_f32::<LittleEndian>()?;
-        data.seek(SeekFrom::Current(64))?;
-        let ripples: Block<ShaderTransparentWaterRipple> = Block::deserialize(data)?;
-        data.seek(SeekFrom::Current(16))?;
-        Ok(ShaderTransparentWater {
-            radiosity_flags,
-            radiosity_detail_level,
-            radiosity_light_power,
-            radiosity_light_color,
-            radiosity_tint_color,
-            flags,
-            base_bitmap,
-            view_perpendicular_brightness,
-            view_perpendicular_tint_color,
-            view_parallel_brightness,
-            view_parallel_tint_color,
-            reflection_bitmap,
-            ripple_animation_angle,
-            ripple_animation_velocity,
-            ripple_scale,
-            ripple_bitmap,
-            ripple_mipmap_levels,
-            ripple_mipmap_fade_factor,
-            ripple_mipmap_detail_bias,
-            ripples,
-        })
+#[wasm_bindgen(js_class = "HaloShaderTransparentWater")]
+impl ShaderTransparentWater {
+    pub fn get_ripples(&self) -> Vec<ShaderTransparentWaterRipple> {
+        self.ripples.items.as_ref().cloned().unwrap()
     }
 }

--- a/rust/src/halo/shader.rs
+++ b/rust/src/halo/shader.rs
@@ -1,6 +1,5 @@
 use deku::prelude::*;
 use wasm_bindgen::prelude::*;
-use num_enum::TryFromPrimitive;
 use super::tag::*;
 use super::common::*;
 
@@ -35,7 +34,7 @@ impl ShaderTransparentChicago {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Clone, Copy, TryFromPrimitive, DekuRead)]
+#[derive(Debug, Clone, Copy, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderTransparentChicagoColorFunction {
@@ -192,7 +191,7 @@ pub struct ShaderTransparentGenericStage {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderOutputMapping {
@@ -205,7 +204,7 @@ pub enum ShaderOutputMapping {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderOutputFunction {
@@ -214,7 +213,7 @@ pub enum ShaderOutputFunction {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderOutput {
@@ -230,7 +229,7 @@ pub enum ShaderOutput {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderMapping {
@@ -245,7 +244,7 @@ pub enum ShaderMapping {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderInput {
@@ -277,7 +276,7 @@ pub enum ShaderInput {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderAlphaInput {
@@ -309,7 +308,7 @@ pub enum ShaderAlphaInput {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum FramebufferFadeMode {
@@ -319,7 +318,7 @@ pub enum FramebufferFadeMode {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum FramebufferBlendFunction {
@@ -334,7 +333,7 @@ pub enum FramebufferBlendFunction {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderTransparentGenericMapType {
@@ -345,7 +344,7 @@ pub enum ShaderTransparentGenericMapType {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum RadiosityDetailLevel {
@@ -413,7 +412,7 @@ pub struct ShaderModel {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum AnimationFunction {
@@ -432,7 +431,7 @@ pub enum AnimationFunction {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum DetailBitmapMask {
@@ -448,7 +447,7 @@ pub enum DetailBitmapMask {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Copy, Clone, TryFromPrimitive, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum FunctionSource {
@@ -511,7 +510,7 @@ pub struct ShaderEnvironment {
 }
 
 #[wasm_bindgen]
-#[derive(Copy, Clone, Debug, TryFromPrimitive, DekuRead)]
+#[derive(Copy, Clone, Debug, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderEnvironmentReflectionType {
@@ -521,7 +520,7 @@ pub enum ShaderEnvironmentReflectionType {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum DetailBitmapFunction {
@@ -531,7 +530,7 @@ pub enum DetailBitmapFunction {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, TryFromPrimitive, Copy, Clone, DekuRead)]
+#[derive(Debug, Copy, Clone, DekuRead)]
 #[deku(id_type = "u16")]
 #[repr(u16)]
 pub enum ShaderEnvironmentType {

--- a/rust/src/halo/tag.rs
+++ b/rust/src/halo/tag.rs
@@ -1,5 +1,4 @@
 use std::convert::TryFrom;
-use num_enum::{IntoPrimitive, TryFromPrimitive};
 use deku::prelude::*;
 use wasm_bindgen::prelude::*;
 
@@ -19,7 +18,7 @@ pub struct TagDependency {
 }
 
 #[wasm_bindgen(js_name = "HaloTagClass")]
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, PartialEq, Hash, Eq, DekuRead)]
+#[derive(Debug, Copy, Clone, PartialEq, Hash, Eq, DekuRead)]
 #[deku(id_type = "u32")]
 #[repr(u32)]
 pub enum TagClass {

--- a/rust/src/halo/tag.rs
+++ b/rust/src/halo/tag.rs
@@ -1,6 +1,7 @@
-use std::{io::{Cursor, Seek, SeekFrom}, convert::TryFrom};
-use byteorder::{ReadBytesExt, LittleEndian};
+use std::convert::TryFrom;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
+use deku::prelude::*;
+use wasm_bindgen::prelude::*;
 
 use crate::halo::common::*;
 use crate::halo::scenario::*;
@@ -8,7 +9,8 @@ use crate::halo::bitmap::*;
 use crate::halo::shader::*;
 use crate::halo::model::*;
 
-#[derive(Debug, Clone)]
+#[wasm_bindgen(js_name = "HaloTagDependency")]
+#[derive(Debug, Clone, Copy, DekuRead)]
 pub struct TagDependency {
     pub tag_class: TagClass,
     pub path_pointer: Pointer,
@@ -16,18 +18,9 @@ pub struct TagDependency {
     pub tag_id: u32,
 }
 
-impl Deserialize for TagDependency {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(TagDependency {
-            tag_class: TagClass::deserialize(data)?,
-            path_pointer: data.read_u32::<LittleEndian>()?,
-            global_id: data.read_u32::<LittleEndian>()?,
-            tag_id: data.read_u32::<LittleEndian>()?,
-        })
-    }
-}
-
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, PartialEq, Hash, Eq)]
+#[wasm_bindgen(js_name = "HaloTagClass")]
+#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, PartialEq, Hash, Eq, DekuRead)]
+#[deku(id_type = "u32")]
 #[repr(u32)]
 pub enum TagClass {
     Actor = 0x61637472,
@@ -75,7 +68,7 @@ pub enum TagClass {
     Model = 0x6D6F6465,
     MultiplayerScenarioDescription = 0x6D706C79,
     PreferencesNetworkGame = 0x6E677072,
-    #[num_enum(alternatives = [0xFFFFFFFF])]
+    #[deku(id_pat = "0 | 0xFFFFFFFF")]
     Null = 0,
     Object = 0x6F626A65,
     Particle = 0x70617274,
@@ -117,13 +110,7 @@ pub enum TagClass {
     WeaponHudInterface = 0x77706869,
 }
 
-impl Deserialize for TagClass {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        Ok(TagClass::try_from(data.read_u32::<LittleEndian>()?)?)
-    }
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DekuRead)]
 pub struct TagHeader {
     pub primary_class: TagClass,
     pub secondary_class: TagClass,
@@ -131,26 +118,11 @@ pub struct TagHeader {
     pub tag_id: u32,
     pub tag_path: u32,
     pub tag_data: u32,
+    #[deku(pad_bytes_after = "4")]
     pub indexed: u32, // seems to always be 0 in bloodgulch
 
+    #[deku(skip)]
     pub path: String, // read in after deserialization
-}
-
-impl Deserialize for TagHeader {
-    fn deserialize(data: &mut Cursor<Vec<u8>>) -> Result<Self> where Self: Sized {
-        let tag = TagHeader {
-            primary_class: TagClass::deserialize(data)?,
-            secondary_class: TagClass::deserialize(data)?,
-            tertiary_class: TagClass::deserialize(data)?,
-            tag_id: data.read_u32::<LittleEndian>()?,
-            tag_path: data.read_u32::<LittleEndian>()?,
-            tag_data: data.read_u32::<LittleEndian>()?,
-            indexed: data.read_u32::<LittleEndian>()?,
-            path: String::new(),
-        };
-        data.seek(SeekFrom::Current(0x4))?;
-        Ok(tag)
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/rust/src/halo/util.rs
+++ b/rust/src/halo/util.rs
@@ -1,7 +1,6 @@
 use std::io::Read;
 use byteorder::ReadBytesExt;
-
-use crate::halo::common::*;
+use anyhow::Result;
 
 pub fn read_null_terminated_string_with_size<T: Read>(data: &mut T, len: usize) -> Result<String> {
     let mut str_buf = vec![0; len];

--- a/rust/src/halo/wasm.rs
+++ b/rust/src/halo/wasm.rs
@@ -1,12 +1,9 @@
-use js_sys::{Uint16Array, Array};
+use js_sys::Array;
 use wasm_bindgen::prelude::*;
 
 use crate::halo::map::*;
 use crate::halo::scenario::*;
-use crate::halo::common::*;
-use crate::halo::shader::*;
 use crate::halo::bitmap::*;
-use crate::halo::bitmap_utils::*;
 use crate::halo::tag::*;
 use crate::halo::model::*;
 
@@ -15,635 +12,7 @@ pub struct HaloSceneManager {
     mgr: MapManager,
 }
 
-#[wasm_bindgen]
-pub struct HaloBitmapReader {
-    inner: ResourceMapReader,
-}
-
-#[wasm_bindgen]
-impl HaloBitmapReader {
-    pub fn new(data: Vec<u8>) -> Self {
-        HaloBitmapReader { inner: ResourceMapReader::new(data) }
-    }
-
-    pub fn get_and_convert_bitmap_data(&mut self, bitmap: &HaloBitmap, submap: usize) -> Vec<u8> {
-        let bitmap_data = &bitmap.inner.data.items.as_ref().unwrap()[submap];
-        get_and_convert_bitmap_data(self.inner.data.get_ref(), bitmap_data)
-    }
-
-    pub fn destroy(self) {}
-}
-
-fn get_and_convert_bitmap_data(bytes: &[u8], bitmap_data: &BitmapData) -> Vec<u8> {
-    let offset = bitmap_data.pixel_data_offset as usize;
-    let length = bitmap_data.pixel_data_size as usize;
-    let byte_range = &bytes[offset..offset+length];
-    match bitmap_data.format {
-        BitmapFormat::P8 | BitmapFormat::P8Bump => convert_p8_data(byte_range),
-        BitmapFormat::A8r8g8b8 => convert_a8r8g8b8_data(byte_range),
-        BitmapFormat::X8r8g8b8 => convert_x8r8g8b8_data(byte_range),
-        BitmapFormat::A8 => convert_a8_data(byte_range),
-        BitmapFormat::Y8 => convert_y8_data(byte_range),
-        BitmapFormat::A8y8 => convert_a8y8_data(byte_range),
-        BitmapFormat::R5g6b5 => convert_r5g6b5_data(byte_range),
-        _ => Vec::from(byte_range),
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloSky {
-    inner: Sky,
-    model: Option<GbxModel>,
-}
-
-#[wasm_bindgen]
-impl HaloSky {
-    #[wasm_bindgen(getter)] pub fn outdoor_fog_color(&self) -> ColorRGB { self.inner.outdoor_fog_color }
-    #[wasm_bindgen(getter)] pub fn outdoor_fog_max_density(&self) -> f32 { self.inner.outdoor_fog_max_density }
-    #[wasm_bindgen(getter)] pub fn outdoor_fog_start_distance(&self) -> f32 { self.inner.outdoor_fog_start_distance }
-    #[wasm_bindgen(getter)] pub fn outdoor_fog_opaque_distance(&self) -> f32 { self.inner.outdoor_fog_opaque_distance }
-    #[wasm_bindgen(getter)] pub fn indoor_fog_color(&self) -> ColorRGB { self.inner.indoor_fog_color }
-    #[wasm_bindgen(getter)] pub fn indoor_fog_max_density(&self) -> f32 { self.inner.indoor_fog_max_density }
-    #[wasm_bindgen(getter)] pub fn indoor_fog_start_distance(&self) -> f32 { self.inner.indoor_fog_start_distance }
-    #[wasm_bindgen(getter)] pub fn indoor_fog_opaque_distance(&self) -> f32 { self.inner.indoor_fog_opaque_distance }
-    pub fn get_model(&self) -> Option<HaloModel> {
-        self.model.as_ref().map(|model| HaloModel { inner: model.clone() })
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloMaterial {
-    inner: BSPMaterial,
-}
-
-#[wasm_bindgen]
-impl HaloMaterial {
-    fn new(material: &BSPMaterial) -> HaloMaterial {
-        HaloMaterial {
-            inner: material.clone(),
-        }
-    }
-
-    pub fn get_num_indices(&self) -> i32 {
-        self.inner.surface_count * 3
-    }
-
-    pub fn get_index_offset(&self) -> i32 {
-        self.inner.surfaces * 3
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloModel {
-    inner: GbxModel
-}
-
-#[wasm_bindgen]
-impl HaloModel {
-    pub fn get_base_bitmap_u_scale(&self) -> f32 {
-        self.inner.base_bitmap_u_scale
-    }
-
-    pub fn get_base_bitmap_v_scale(&self) -> f32 {
-        self.inner.base_bitmap_v_scale
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloSceneryInstance {
-    inner: ScenarioScenery,
-}
-
-#[wasm_bindgen]
-impl HaloSceneryInstance {
-    #[wasm_bindgen(getter)] pub fn scenery_type(&self) -> u16 { self.inner.scenery_type }
-    #[wasm_bindgen(getter)] pub fn not_placed(&self) -> u32 { self.inner.not_placed }
-    #[wasm_bindgen(getter)] pub fn position(&self) -> Point3D { self.inner.position }
-    #[wasm_bindgen(getter)] pub fn rotation(&self) -> Euler3D { self.inner.rotation }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloScenery {
-    inner: Scenery,
-}
-
-#[wasm_bindgen]
-impl HaloScenery {
-    #[wasm_bindgen(getter)] pub fn flags(&self) -> u16 { self.inner.flags }
-    #[wasm_bindgen(getter)] pub fn bounding_radius(&self) -> f32 { self.inner.bounding_radius }
-    #[wasm_bindgen(getter)] pub fn bounding_offset(&self) -> Point3D { self.inner.bounding_offset }
-    #[wasm_bindgen(getter)] pub fn origin_offset(&self) -> Point3D { self.inner.origin_offset }
-
-    fn new(inner: &Scenery) -> HaloScenery {
-        HaloScenery { inner: inner.clone() }
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloModelPart {
-    inner: GbxModelPart,
-}
-
-#[wasm_bindgen]
-impl HaloModelPart {
-    #[wasm_bindgen(getter)] pub fn shader_index(&self) -> u16 { self.inner.shader_index }
-    #[wasm_bindgen(getter)] pub fn centroid(&self) -> Point3D { self.inner.centroid }
-    #[wasm_bindgen(getter)] pub fn tri_count(&self) -> u32 { self.inner.tri_count }
-    #[wasm_bindgen(getter)] pub fn tri_offset(&self) -> u32 { self.inner.tri_offset }
-    #[wasm_bindgen(getter)] pub fn vert_count(&self) -> u32 { self.inner.vert_count }
-    #[wasm_bindgen(getter)] pub fn vert_offset(&self) -> u32 { self.inner.vert_offset }
-
-    fn new(inner: &GbxModelPart) -> HaloModelPart {
-        HaloModelPart { inner: inner.clone() }
-    }
-
-    pub fn update_tri_count(&mut self, new_count: u32) {
-        self.inner.tri_count = new_count;
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloShaderTransparentChicagoMap {
-    inner: ShaderTransparentChicagoMap,
-}
-
-#[wasm_bindgen]
-impl HaloShaderTransparentChicagoMap {
-    #[wasm_bindgen(getter)] pub fn flags(&self) -> u16 { self.inner.flags }
-    #[wasm_bindgen(getter)] pub fn color_function(&self) -> ShaderTransparentChicagoColorFunction { self.inner.color_function }
-    #[wasm_bindgen(getter)] pub fn alpha_function(&self) -> ShaderTransparentChicagoColorFunction { self.inner.alpha_function }
-    #[wasm_bindgen(getter)] pub fn map_u_scale(&self) -> f32 { self.inner.map_u_scale }
-    #[wasm_bindgen(getter)] pub fn map_v_scale(&self) -> f32 { self.inner.map_v_scale }
-    #[wasm_bindgen(getter)] pub fn map_u_offset(&self) -> f32 { self.inner.map_u_offset }
-    #[wasm_bindgen(getter)] pub fn map_v_offset(&self) -> f32 { self.inner.map_v_offset }
-    #[wasm_bindgen(getter)] pub fn map_rotation(&self) -> f32 { self.inner.map_rotation }
-    #[wasm_bindgen(getter)] pub fn mipmap_bias(&self) -> f32 { self.inner.mipmap_bias }
-    #[wasm_bindgen(getter)] pub fn u_animation_source(&self) -> FunctionSource { self.inner.u_animation_source }
-    #[wasm_bindgen(getter)] pub fn u_animation_function(&self) -> AnimationFunction { self.inner.u_animation_function }
-    #[wasm_bindgen(getter)] pub fn u_animation_period(&self) -> f32 { self.inner.u_animation_period }
-    #[wasm_bindgen(getter)] pub fn u_animation_phase(&self) -> f32 { self.inner.u_animation_phase }
-    #[wasm_bindgen(getter)] pub fn u_animation_scale(&self) -> f32 { self.inner.u_animation_scale }
-    #[wasm_bindgen(getter)] pub fn v_animation_source(&self) -> FunctionSource { self.inner.v_animation_source }
-    #[wasm_bindgen(getter)] pub fn v_animation_function(&self) -> AnimationFunction { self.inner.v_animation_function }
-    #[wasm_bindgen(getter)] pub fn v_animation_period(&self) -> f32 { self.inner.v_animation_period }
-    #[wasm_bindgen(getter)] pub fn v_animation_phase(&self) -> f32 { self.inner.v_animation_phase }
-    #[wasm_bindgen(getter)] pub fn v_animation_scale(&self) -> f32 { self.inner.v_animation_scale }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_source(&self) -> FunctionSource { self.inner.rotation_animation_source }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_function(&self) -> AnimationFunction { self.inner.rotation_animation_function }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_period(&self) -> f32 { self.inner.rotation_animation_period }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_phase(&self) -> f32 { self.inner.rotation_animation_phase }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_scale(&self) -> f32 { self.inner.rotation_animation_scale }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_center(&self) -> Point2D { self.inner.rotation_animation_center }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloShaderTransparencyChicago {
-    inner: ShaderTransparentChicago,
-    path: String,
-    maps: Vec<HaloShaderTransparentChicagoMap>,
-    bitmaps: Vec<Option<Bitmap>>,
-}
-
-#[wasm_bindgen]
-impl HaloShaderTransparencyChicago {
-    #[wasm_bindgen(getter)] pub fn radiosity_flags(&self) -> u16 { self.inner.radiosity_flags }
-    #[wasm_bindgen(getter)] pub fn radiosity_detail_level(&self) -> RadiosityDetailLevel { self.inner.radiosity_detail_level }
-    #[wasm_bindgen(getter)] pub fn radiosity_light_power(&self) -> f32 { self.inner.radiosity_light_power }
-    #[wasm_bindgen(getter)] pub fn radiosity_light_color(&self) -> ColorRGB { self.inner.radiosity_light_color }
-    #[wasm_bindgen(getter)] pub fn radiosity_tint_color(&self) -> ColorRGB { self.inner.radiosity_tint_color }
-    #[wasm_bindgen(getter)] pub fn numeric_counter_limit(&self) -> u8 { self.inner.numeric_counter_limit }
-    #[wasm_bindgen(getter)] pub fn flags(&self) -> u8 { self.inner.flags }
-    #[wasm_bindgen(getter)] pub fn first_map_type(&self) -> ShaderTransparentGenericMapType { self.inner.first_map_type }
-    #[wasm_bindgen(getter)] pub fn framebuffer_blend_function(&self) -> FramebufferBlendFunction { self.inner.framebuffer_blend_function }
-    #[wasm_bindgen(getter)] pub fn framebuffer_fade_mode(&self) -> FramebufferFadeMode { self.inner.framebuffer_fade_mode }
-    #[wasm_bindgen(getter)] pub fn framebuffer_fade_source(&self) -> FunctionSource { self.inner.framebuffer_fade_source }
-    #[wasm_bindgen(getter)] pub fn lens_flare_spacing(&self) -> f32 { self.inner.lens_flare_spacing }
-    #[wasm_bindgen(getter)] pub fn path(&self) -> String { self.path.clone() }
-
-    pub fn get_bitmap(&self, i: usize) -> Option<HaloBitmap> {
-        match self.bitmaps.get(i) {
-            Some(maybe_bitmap) => maybe_bitmap.as_ref().map(|b| HaloBitmap { inner: b.clone() }),
-            None => None,
-        }
-    }
-
-    pub fn get_map(&self, i: usize) -> Option<HaloShaderTransparentChicagoMap> {
-        self.maps.get(i).cloned()
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloShaderTransparentGenericMap {
-    inner: ShaderTransparentGenericMap,
-}
-
-#[wasm_bindgen]
-impl HaloShaderTransparentGenericMap {
-    #[wasm_bindgen(getter)] pub fn flags(&self) -> u16 { self.inner.flags }
-    #[wasm_bindgen(getter)] pub fn map_u_scale(&self) -> f32 { self.inner.map_u_scale }
-    #[wasm_bindgen(getter)] pub fn map_v_scale(&self) -> f32 { self.inner.map_v_scale }
-    #[wasm_bindgen(getter)] pub fn map_u_offset(&self) -> f32 { self.inner.map_u_offset }
-    #[wasm_bindgen(getter)] pub fn map_v_offset(&self) -> f32 { self.inner.map_v_offset }
-    #[wasm_bindgen(getter)] pub fn map_rotation(&self) -> f32 { self.inner.map_rotation }
-    #[wasm_bindgen(getter)] pub fn mipmap_bias(&self) -> f32 { self.inner.mipmap_bias }
-    #[wasm_bindgen(getter)] pub fn u_animation_source(&self) -> FunctionSource { self.inner.u_animation_source }
-    #[wasm_bindgen(getter)] pub fn u_animation_function(&self) -> AnimationFunction { self.inner.u_animation_function }
-    #[wasm_bindgen(getter)] pub fn u_animation_period(&self) -> f32 { self.inner.u_animation_period }
-    #[wasm_bindgen(getter)] pub fn u_animation_phase(&self) -> f32 { self.inner.u_animation_phase }
-    #[wasm_bindgen(getter)] pub fn u_animation_scale(&self) -> f32 { self.inner.u_animation_scale }
-    #[wasm_bindgen(getter)] pub fn v_animation_source(&self) -> FunctionSource { self.inner.v_animation_source }
-    #[wasm_bindgen(getter)] pub fn v_animation_function(&self) -> AnimationFunction { self.inner.v_animation_function }
-    #[wasm_bindgen(getter)] pub fn v_animation_period(&self) -> f32 { self.inner.v_animation_period }
-    #[wasm_bindgen(getter)] pub fn v_animation_phase(&self) -> f32 { self.inner.v_animation_phase }
-    #[wasm_bindgen(getter)] pub fn v_animation_scale(&self) -> f32 { self.inner.v_animation_scale }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_source(&self) -> FunctionSource { self.inner.rotation_animation_source }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_function(&self) -> AnimationFunction { self.inner.rotation_animation_function }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_period(&self) -> f32 { self.inner.rotation_animation_period }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_phase(&self) -> f32 { self.inner.rotation_animation_phase }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_scale(&self) -> f32 { self.inner.rotation_animation_scale }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_center(&self) -> Point2D { self.inner.rotation_animation_center }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloShaderTransparentGenericStage {
-    inner: ShaderTransparentGenericStage,
-}
-
-#[wasm_bindgen]
-impl HaloShaderTransparentGenericStage {
-    #[wasm_bindgen(getter)] pub fn flags(&self) -> u16 { self.inner.flags }
-    #[wasm_bindgen(getter)] pub fn color0_source(&self) -> FunctionSource { self.inner.color0_source }
-    #[wasm_bindgen(getter)] pub fn color0_animation_function(&self) -> AnimationFunction { self.inner.color0_animation_function }
-    #[wasm_bindgen(getter)] pub fn color0_animation_period(&self) -> f32 { self.inner.color0_animation_period }
-    #[wasm_bindgen(getter)] pub fn color0_animation_lower_bound(&self) -> ColorARGB { self.inner.color0_animation_lower_bound }
-    #[wasm_bindgen(getter)] pub fn color0_animation_upper_bound(&self) -> ColorARGB { self.inner.color0_animation_upper_bound }
-    #[wasm_bindgen(getter)] pub fn color1(&self) -> ColorARGB { self.inner.color1 }
-    #[wasm_bindgen(getter)] pub fn input_a(&self) -> ShaderInput { self.inner.input_a }
-    #[wasm_bindgen(getter)] pub fn input_a_mapping(&self) -> ShaderMapping { self.inner.input_a_mapping }
-    #[wasm_bindgen(getter)] pub fn input_b(&self) -> ShaderInput { self.inner.input_b }
-    #[wasm_bindgen(getter)] pub fn input_b_mapping(&self) -> ShaderMapping { self.inner.input_b_mapping }
-    #[wasm_bindgen(getter)] pub fn input_c(&self) -> ShaderInput { self.inner.input_c }
-    #[wasm_bindgen(getter)] pub fn input_c_mapping(&self) -> ShaderMapping { self.inner.input_c_mapping }
-    #[wasm_bindgen(getter)] pub fn input_d(&self) -> ShaderInput { self.inner.input_d }
-    #[wasm_bindgen(getter)] pub fn input_d_mapping(&self) -> ShaderMapping { self.inner.input_d_mapping }
-    #[wasm_bindgen(getter)] pub fn output_ab(&self) -> ShaderOutput { self.inner.output_ab }
-    #[wasm_bindgen(getter)] pub fn output_ab_function(&self) -> ShaderOutputFunction { self.inner.output_ab_function }
-    #[wasm_bindgen(getter)] pub fn output_cd(&self) -> ShaderOutput { self.inner.output_cd }
-    #[wasm_bindgen(getter)] pub fn output_cd_function(&self) -> ShaderOutputFunction { self.inner.output_cd_function }
-    #[wasm_bindgen(getter)] pub fn output_ab_cd_mux_sum(&self) -> ShaderOutput { self.inner.output_ab_cd_mux_sum }
-    #[wasm_bindgen(getter)] pub fn output_mapping_color(&self) -> ShaderOutputMapping { self.inner.output_mapping_color }
-    #[wasm_bindgen(getter)] pub fn input_a_alpha(&self) -> ShaderAlphaInput { self.inner.input_a_alpha }
-    #[wasm_bindgen(getter)] pub fn input_a_mapping_alpha(&self) -> ShaderMapping { self.inner.input_a_mapping_alpha }
-    #[wasm_bindgen(getter)] pub fn input_b_alpha(&self) -> ShaderAlphaInput { self.inner.input_b_alpha }
-    #[wasm_bindgen(getter)] pub fn input_b_mapping_alpha(&self) -> ShaderMapping { self.inner.input_b_mapping_alpha }
-    #[wasm_bindgen(getter)] pub fn input_c_alpha(&self) -> ShaderAlphaInput { self.inner.input_c_alpha }
-    #[wasm_bindgen(getter)] pub fn input_c_mapping_alpha(&self) -> ShaderMapping { self.inner.input_c_mapping_alpha }
-    #[wasm_bindgen(getter)] pub fn input_d_alpha(&self) -> ShaderAlphaInput { self.inner.input_d_alpha }
-    #[wasm_bindgen(getter)] pub fn input_d_mapping_alpha(&self) -> ShaderMapping { self.inner.input_d_mapping_alpha }
-    #[wasm_bindgen(getter)] pub fn output_ab_alpha(&self) -> ShaderOutput { self.inner.output_ab_alpha }
-    #[wasm_bindgen(getter)] pub fn output_cd_alpha(&self) -> ShaderOutput { self.inner.output_cd_alpha }
-    #[wasm_bindgen(getter)] pub fn output_ab_cd_mux_sum_alpha(&self) -> ShaderOutput { self.inner.output_ab_cd_mux_sum_alpha }
-    #[wasm_bindgen(getter)] pub fn output_mapping_alpha(&self) -> ShaderOutputMapping { self.inner.output_mapping_alpha }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloShaderTransparencyGeneric {
-    inner: ShaderTransparentGeneric,
-    path: String,
-    maps: Vec<HaloShaderTransparentGenericMap>,
-    stages: Vec<HaloShaderTransparentGenericStage>,
-    bitmaps: Vec<Bitmap>,
-}
-
-#[wasm_bindgen]
-impl HaloShaderTransparencyGeneric {
-    #[wasm_bindgen(getter)] pub fn radiosity_flags(&self) -> u16 { self.inner.radiosity_flags }
-    #[wasm_bindgen(getter)] pub fn radiosity_detail_level(&self) -> RadiosityDetailLevel { self.inner.radiosity_detail_level }
-    #[wasm_bindgen(getter)] pub fn radiosity_light_power(&self) -> f32 { self.inner.radiosity_light_power }
-    #[wasm_bindgen(getter)] pub fn radiosity_light_color(&self) -> ColorRGB { self.inner.radiosity_light_color }
-    #[wasm_bindgen(getter)] pub fn radiosity_tint_color(&self) -> ColorRGB { self.inner.radiosity_tint_color }
-    #[wasm_bindgen(getter)] pub fn numeric_counter_limit(&self) -> u8 { self.inner.numeric_counter_limit }
-    #[wasm_bindgen(getter)] pub fn flags(&self) -> u8 { self.inner.flags }
-    #[wasm_bindgen(getter)] pub fn first_map_type(&self) -> ShaderTransparentGenericMapType { self.inner.first_map_type }
-    #[wasm_bindgen(getter)] pub fn framebuffer_blend_function(&self) -> FramebufferBlendFunction { self.inner.framebuffer_blend_function }
-    #[wasm_bindgen(getter)] pub fn framebuffer_fade_mode(&self) -> FramebufferFadeMode { self.inner.framebuffer_fade_mode }
-    #[wasm_bindgen(getter)] pub fn framebuffer_fade_source(&self) -> FunctionSource { self.inner.framebuffer_fade_source }
-    #[wasm_bindgen(getter)] pub fn lens_flare_spacing(&self) -> f32 { self.inner.lens_flare_spacing }
-    #[wasm_bindgen(getter)] pub fn path(&self) -> String { self.path.clone() }
-
-    pub fn get_bitmap(&self, i: usize) -> Option<HaloBitmap> {
-        self.bitmaps.get(i).map(|b| HaloBitmap { inner: b.clone() })
-    }
-
-    pub fn get_map(&self, i: usize) -> Option<HaloShaderTransparentGenericMap> {
-        self.maps.get(i).cloned()
-    }
-
-    pub fn get_stage(&self, i: usize) -> Option<HaloShaderTransparentGenericStage> {
-        self.stages.get(i).cloned()
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloShaderModel {
-    inner: ShaderModel,
-    base_bitmap: Option<Bitmap>,
-    multipurpose_map: Option<Bitmap>,
-    detail_bitmap: Option<Bitmap>,
-    reflection_cube_map: Option<Bitmap>,
-}
-
-#[wasm_bindgen]
-impl HaloShaderModel {
-    #[wasm_bindgen(getter)] pub fn flags(&self) -> u16 { self.inner.flags }
-    #[wasm_bindgen(getter)] pub fn translucency(&self) -> f32 { self.inner.translucency }
-    #[wasm_bindgen(getter)] pub fn animation_function(&self) -> AnimationFunction { self.inner.animation_function }
-    #[wasm_bindgen(getter)] pub fn animation_period(&self) -> f32 { self.inner.animation_period }
-    #[wasm_bindgen(getter)] pub fn animation_color_lower_bound(&self) -> ColorRGB { self.inner.animation_color_lower_bound }
-    #[wasm_bindgen(getter)] pub fn animation_color_upper_bound(&self) -> ColorRGB { self.inner.animation_color_upper_bound }
-    #[wasm_bindgen(getter)] pub fn map_u_scale(&self) -> f32 { self.inner.map_u_scale }
-    #[wasm_bindgen(getter)] pub fn map_v_scale(&self) -> f32 { self.inner.map_v_scale }
-    #[wasm_bindgen(getter)] pub fn detail_function(&self) -> DetailBitmapFunction { self.inner.detail_function }
-    #[wasm_bindgen(getter)] pub fn detail_mask(&self) -> DetailBitmapMask { self.inner.detail_mask }
-    #[wasm_bindgen(getter)] pub fn detail_bitmap_scale(&self) -> f32 { self.inner.detail_map_scale }
-    #[wasm_bindgen(getter)] pub fn detail_bitmap_v_scale(&self) -> f32 { self.inner.detail_map_v_scale }
-    #[wasm_bindgen(getter)] pub fn u_animation_source(&self) -> FunctionSource { self.inner.u_animation_source }
-    #[wasm_bindgen(getter)] pub fn u_animation_function(&self) -> AnimationFunction { self.inner.u_animation_function }
-    #[wasm_bindgen(getter)] pub fn u_animation_period(&self) -> f32 { self.inner.u_animation_period }
-    #[wasm_bindgen(getter)] pub fn u_animation_phase(&self) -> f32 { self.inner.u_animation_phase }
-    #[wasm_bindgen(getter)] pub fn u_animation_scale(&self) -> f32 { self.inner.u_animation_scale }
-    #[wasm_bindgen(getter)] pub fn v_animation_source(&self) -> FunctionSource { self.inner.v_animation_source }
-    #[wasm_bindgen(getter)] pub fn v_animation_function(&self) -> AnimationFunction { self.inner.v_animation_function }
-    #[wasm_bindgen(getter)] pub fn v_animation_period(&self) -> f32 { self.inner.v_animation_period }
-    #[wasm_bindgen(getter)] pub fn v_animation_phase(&self) -> f32 { self.inner.v_animation_phase }
-    #[wasm_bindgen(getter)] pub fn v_animation_scale(&self) -> f32 { self.inner.v_animation_scale }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_source(&self) -> FunctionSource { self.inner.rotation_animation_source }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_function(&self) -> AnimationFunction { self.inner.rotation_animation_function }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_period(&self) -> f32 { self.inner.rotation_animation_period }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_phase(&self) -> f32 { self.inner.rotation_animation_phase }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_scale(&self) -> f32 { self.inner.rotation_animation_scale }
-    #[wasm_bindgen(getter)] pub fn rotation_animation_center(&self) -> Point2D { self.inner.rotation_animation_center }
-    #[wasm_bindgen(getter)] pub fn reflection_falloff_distance(&self) -> f32 { self.inner.reflection_falloff_distance }
-    #[wasm_bindgen(getter)] pub fn reflection_cutoff_distance(&self) -> f32 { self.inner.reflection_cutoff_distance }
-    #[wasm_bindgen(getter)] pub fn perpendicular_brightness(&self) -> f32 { self.inner.perpendicular_brightness }
-    #[wasm_bindgen(getter)] pub fn perpendicular_tint_color(&self) -> ColorRGB { self.inner.perpendicular_tint_color }
-    #[wasm_bindgen(getter)] pub fn parallel_brightness(&self) -> f32 { self.inner.parallel_brightness }
-    #[wasm_bindgen(getter)] pub fn parallel_tint_color(&self) -> ColorRGB { self.inner.parallel_tint_color }
-    #[wasm_bindgen(getter)] pub fn has_base_bitmap(&self) -> bool { self.base_bitmap.is_some() }
-    #[wasm_bindgen(getter)] pub fn has_detail_bitmap(&self) -> bool { self.detail_bitmap.is_some() }
-    #[wasm_bindgen(getter)] pub fn has_multipurpose_map(&self) -> bool { self.multipurpose_map.is_some() }
-    #[wasm_bindgen(getter)] pub fn has_reflection_cube_map(&self) -> bool { self.reflection_cube_map.is_some() }
-
-    pub fn get_base_bitmap(&self) -> Option<HaloBitmap> {
-        self.base_bitmap.as_ref()
-            .map(|map| HaloBitmap::new(map.clone()))
-    }
-    pub fn get_detail_bitmap(&self) -> Option<HaloBitmap> {
-        self.detail_bitmap.as_ref()
-            .map(|map| HaloBitmap::new(map.clone()))
-    }
-    pub fn get_multipurpose_map(&self) -> Option<HaloBitmap> {
-        self.multipurpose_map.as_ref()
-            .map(|map| HaloBitmap::new(map.clone()))
-    }
-    pub fn get_reflection_cube_map(&self) -> Option<HaloBitmap> {
-        self.reflection_cube_map.as_ref()
-            .map(|map| HaloBitmap::new(map.clone()))
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloShaderEnvironment {
-    inner: ShaderEnvironment,
-    path: String,
-    base_bitmap: Bitmap,
-    bump_map: Option<Bitmap>,
-    primary_detail_bitmap: Option<Bitmap>,
-    secondary_detail_bitmap: Option<Bitmap>,
-    micro_detail_bitmap: Option<Bitmap>,
-    reflection_cube_map: Option<Bitmap>,
-}
-
-#[wasm_bindgen]
-impl HaloShaderEnvironment {
-    #[wasm_bindgen(getter)] pub fn flags(&self) -> u16 { self.inner.flags }
-    #[wasm_bindgen(getter)] pub fn shader_environment_type(&self) -> ShaderEnvironmentType { self.inner.shader_environment_type }
-    #[wasm_bindgen(getter)] pub fn diffuse_flags(&self) -> u16 { self.inner.diffuse_flags }
-    #[wasm_bindgen(getter)] pub fn specular_flags(&self) -> u16 { self.inner.specular_flags }
-    #[wasm_bindgen(getter)] pub fn brightness(&self) -> f32 { self.inner.brightness }
-    #[wasm_bindgen(getter)] pub fn primary_detail_bitmap_scale(&self) -> f32 { self.inner.primary_detail_bitmap_scale }
-    #[wasm_bindgen(getter)] pub fn detail_bitmap_function(&self) -> DetailBitmapFunction { self.inner.detail_bitmap_function }
-    #[wasm_bindgen(getter)] pub fn secondary_detail_bitmap_scale(&self) -> f32 { self.inner.secondary_detail_bitmap_scale }
-    #[wasm_bindgen(getter)] pub fn micro_detail_bitmap_scale(&self) -> f32 { self.inner.micro_detail_scale }
-    #[wasm_bindgen(getter)] pub fn micro_detail_bitmap_function(&self) -> DetailBitmapFunction { self.inner.micro_detail_bitmap_function }
-    #[wasm_bindgen(getter)] pub fn bump_map_scale(&self) -> f32 { self.inner.bump_map_scale }
-    #[wasm_bindgen(getter)] pub fn has_primary_detail_bitmap(&self) -> bool { self.primary_detail_bitmap.is_some() }
-    #[wasm_bindgen(getter)] pub fn has_secondary_detail_bitmap(&self) -> bool { self.secondary_detail_bitmap.is_some() }
-    #[wasm_bindgen(getter)] pub fn has_micro_detail_bitmap(&self) -> bool { self.micro_detail_bitmap.is_some() }
-    #[wasm_bindgen(getter)] pub fn has_bump_map(&self) -> bool { self.bump_map.is_some() }
-    #[wasm_bindgen(getter)] pub fn has_reflection_cube_map(&self) -> bool { self.reflection_cube_map.is_some() }
-    #[wasm_bindgen(getter)] pub fn perpendicular_color(&self) -> ColorRGB { self.inner.perpendicular_color }
-    #[wasm_bindgen(getter)] pub fn parallel_color(&self) -> ColorRGB { self.inner.parallel_color }
-    #[wasm_bindgen(getter)] pub fn reflection_flags(&self) -> u16 { self.inner.reflection_flags }
-    #[wasm_bindgen(getter)] pub fn reflection_type(&self) -> ShaderEnvironmentReflectionType { self.inner.reflection_type }
-    #[wasm_bindgen(getter)] pub fn lightmap_brightness_scale(&self) -> f32 { self.inner.lightmap_brightness_scale }
-    #[wasm_bindgen(getter)] pub fn perpendicular_brightness(&self) -> f32 { self.inner.perpendicular_brightness }
-    #[wasm_bindgen(getter)] pub fn parallel_brightness(&self) -> f32 { self.inner.parallel_brightness }
-    #[wasm_bindgen(getter)] pub fn path(&self) -> String { self.path.clone() }
-
-    pub fn get_base_bitmap(&self) -> HaloBitmap {
-        HaloBitmap::new(self.base_bitmap.clone())
-    }
-
-    pub fn get_primary_detail_bitmap(&self) -> Option<HaloBitmap> {
-        self.primary_detail_bitmap.as_ref()
-            .map(|map| HaloBitmap::new(map.clone()))
-    }
-
-    pub fn get_bump_map(&self) -> Option<HaloBitmap> {
-        self.bump_map.as_ref()
-            .map(|map| HaloBitmap::new(map.clone()))
-    }
-
-    pub fn get_secondary_detail_bitmap(&self) -> Option<HaloBitmap> {
-        self.secondary_detail_bitmap.as_ref()
-            .map(|map| HaloBitmap::new(map.clone()))
-    }
-
-    pub fn get_micro_detail_bitmap(&self) -> Option<HaloBitmap> {
-        self.micro_detail_bitmap.as_ref()
-            .map(|map| HaloBitmap::new(map.clone()))
-    }
-
-    pub fn get_reflection_cube_map(&self) -> Option<HaloBitmap> {
-        self.reflection_cube_map.as_ref()
-            .map(|map| HaloBitmap::new(map.clone()))
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloShaderTransparentWaterRipple {
-    inner: ShaderTransparentWaterRipple,
-}
-
-#[wasm_bindgen]
-impl HaloShaderTransparentWaterRipple {
-    pub fn contribution_factor(&self) -> f32 { self.inner.contribution_factor }
-    pub fn animation_angle(&self) -> f32 { self.inner.animation_angle }
-    pub fn animation_velocity(&self) -> f32 { self.inner.animation_velocity }
-    pub fn map_u_offset(&self) -> f32 { self.inner.map_u_offset }
-    pub fn map_v_offset(&self) -> f32 { self.inner.map_v_offset }
-    pub fn map_repeats(&self) -> u16 { self.inner.map_repeats }
-    pub fn map_index(&self) -> u16 { self.inner.map_index }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloShaderTransparentWater {
-    inner: ShaderTransparentWater,
-    path: String,
-    base_bitmap: Option<Bitmap>,
-    reflection_bitmap: Option<Bitmap>,
-    ripple_bitmap: Option<Bitmap>,
-    ripples: Vec<HaloShaderTransparentWaterRipple>,
-}
-
-#[wasm_bindgen]
-impl HaloShaderTransparentWater {
-    #[wasm_bindgen(getter)] pub fn flags(&self) -> u16 { self.inner.flags }
-    #[wasm_bindgen(getter)] pub fn view_perpendicular_brightness(&self) -> f32 { self.inner.view_perpendicular_brightness }
-    #[wasm_bindgen(getter)] pub fn view_perpendicular_tint_color(&self) -> ColorRGB { self.inner.view_perpendicular_tint_color }
-    #[wasm_bindgen(getter)] pub fn view_parallel_brightness(&self) -> f32 { self.inner.view_parallel_brightness }
-    #[wasm_bindgen(getter)] pub fn view_parallel_tint_color(&self) -> ColorRGB { self.inner.view_parallel_tint_color }
-    #[wasm_bindgen(getter)] pub fn ripple_animation_angle(&self) -> f32 { self.inner.ripple_animation_angle }
-    #[wasm_bindgen(getter)] pub fn ripple_animation_velocity(&self) -> f32 { self.inner.ripple_animation_velocity }
-    #[wasm_bindgen(getter)] pub fn ripple_scale(&self) -> f32 { self.inner.ripple_scale }
-    #[wasm_bindgen(getter)] pub fn ripple_mipmap_levels(&self) -> u16 { self.inner.ripple_mipmap_levels }
-    #[wasm_bindgen(getter)] pub fn ripple_mipmap_fade_factor(&self) -> f32 { self.inner.ripple_mipmap_fade_factor }
-    #[wasm_bindgen(getter)] pub fn ripple_mipmap_detail_bias(&self) -> f32 { self.inner.ripple_mipmap_detail_bias }
-    #[wasm_bindgen(getter)] pub fn path(&self) -> String { self.path.clone() }
-
-    pub fn get_base_bitmap(&self) -> Option<HaloBitmap> {
-        self.base_bitmap.as_ref()
-            .map(|map| HaloBitmap::new(map.clone()))
-    }
-
-    pub fn get_reflection_bitmap(&self) -> Option<HaloBitmap> {
-        self.reflection_bitmap.as_ref()
-            .map(|map| HaloBitmap::new(map.clone()))
-    }
-
-    pub fn get_ripple_bitmap(&self) -> Option<HaloBitmap> {
-        self.ripple_bitmap.as_ref()
-            .map(|map| HaloBitmap::new(map.clone()))
-    }
-
-    pub fn get_ripple(&self, i: usize) -> Option<HaloShaderTransparentWaterRipple> {
-        self.ripples.get(i).cloned()
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloLightmap {
-    inner: BSPLightmap,
-}
-
-#[wasm_bindgen]
-impl HaloLightmap {
-    fn new(lightmap: &BSPLightmap) -> HaloLightmap {
-        HaloLightmap {
-            inner: lightmap.clone(),
-        }
-    }
-
-    pub fn get_bitmap_index(&self) -> u16 {
-        self.inner.bitmap
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloBSP {
-    inner: BSP,
-    lightmaps_bitmap: Option<Bitmap>,
-}
-
-#[wasm_bindgen]
-impl HaloBSP {
-    fn new(bsp: BSP, lightmaps_bitmap: Option<Bitmap>) -> HaloBSP {
-        HaloBSP { inner: bsp, lightmaps_bitmap }
-    }
-
-    pub fn get_lightmaps_bitmap(&self) -> Option<HaloBitmap> {
-        self.lightmaps_bitmap.as_ref().map(|bitmap| HaloBitmap::new(bitmap.clone()))
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloBitmap {
-    inner: Bitmap,
-}
-
-#[wasm_bindgen]
-impl HaloBitmap {
-    fn new(inner: Bitmap) -> Self {
-        HaloBitmap { inner }
-    }
-
-    #[wasm_bindgen(getter)] pub fn mipmap_count(&self) -> u16 { self.inner.mipmap_count }
-
-    pub fn get_metadata_for_index(&self, index: usize) -> HaloBitmapMetadata {
-        HaloBitmapMetadata::new(&self.inner.data.items.as_ref().unwrap()[index])
-    }
-
-    pub fn get_tag_id(&self) -> u32 {
-        self.inner.data.items.as_ref().unwrap()[0].bitmap_tag_id
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct HaloBitmapMetadata {
-    inner: BitmapData
-}
-
-#[wasm_bindgen]
-impl HaloBitmapMetadata {
-    fn new(inner: &BitmapData) -> Self {
-        HaloBitmapMetadata { inner: inner.clone() }
-    }
-
-    #[wasm_bindgen(getter)] pub fn width(&self) -> u16 { self.inner.width }
-    #[wasm_bindgen(getter)] pub fn height(&self) -> u16 { self.inner.height }
-    #[wasm_bindgen(getter)] pub fn depth(&self) -> u16 { self.inner.depth }
-    #[wasm_bindgen(getter)] pub fn bitmap_type(&self) -> BitmapDataType { self.inner.bitmap_type }
-    #[wasm_bindgen(getter)] pub fn bitmap_tag_id(&self) -> u32 { self.inner.bitmap_tag_id }
-    #[wasm_bindgen(getter)] pub fn format(&self) -> BitmapFormat { self.inner.format }
-    #[wasm_bindgen(getter)] pub fn flags(&self) -> u16 { self.inner.flags }
-    #[wasm_bindgen(getter)] pub fn mipmap_count(&self) -> u16 { self.inner.mipmap_count }
-
-    pub fn is_external(&self) -> bool {
-        self.inner.is_external()
-    }
-}
-
-#[wasm_bindgen]
+#[wasm_bindgen(js_class = "HaloSceneManager")]
 impl HaloSceneManager {
     pub fn new(map_data: Vec<u8>) -> Self {
         let mgr = MapManager::new(map_data).unwrap();
@@ -653,85 +22,22 @@ impl HaloSceneManager {
     fn get_shader(&mut self, shader_hdr: TagHeader) -> JsValue {
         match self.mgr.read_tag(&shader_hdr) {
             Ok(tag) => match tag.data {
-                TagData::ShaderEnvironment(s) => {
-                    if s.base_bitmap.path_pointer != 0 {
-                        JsValue::from(HaloShaderEnvironment {
-                            base_bitmap: self.resolve_bitmap_dependency(&s.base_bitmap).unwrap(),
-                            bump_map: self.resolve_bitmap_dependency(&s.bump_map),
-                            primary_detail_bitmap: self.resolve_bitmap_dependency(&s.primary_detail_bitmap),
-                            secondary_detail_bitmap: self.resolve_bitmap_dependency(&s.secondary_detail_bitmap),
-                            micro_detail_bitmap: self.resolve_bitmap_dependency(&s.micro_detail_bitmap),
-                            reflection_cube_map: self.resolve_bitmap_dependency(&s.reflection_cube_map),
-                            path: shader_hdr.path.clone(),
-                            inner: s.clone(),
-                        })
-                    } else {
-                        JsValue::NULL
-                    }
+                TagData::ShaderEnvironment(s) if s.base_bitmap.path_pointer != 0 => {
+                    JsValue::from(s)
                 },
-                TagData::ShaderModel(s) => JsValue::from(HaloShaderModel {
-                    base_bitmap: self.resolve_bitmap_dependency(&s.base_map),
-                    detail_bitmap: self.resolve_bitmap_dependency(&s.detail_map),
-                    multipurpose_map: self.resolve_bitmap_dependency(&s.multipurpose_map),
-                    reflection_cube_map: self.resolve_bitmap_dependency(&s.reflection_cube_map),
-                    inner: s,
-                }),
-                TagData::ShaderTransparentGeneric(s) => {
-                    let mut maps = Vec::new();
-                    let mut bitmaps = Vec::new();
-                    let mut stages = Vec::new();
-                    for map in s.maps.items.as_ref().unwrap() {
-                        bitmaps.push(self.resolve_bitmap_dependency(&map.map).unwrap());
-                        maps.push(HaloShaderTransparentGenericMap { inner: map.clone() });
-                    }
-                    for stage in s.stages.items.as_ref().unwrap() {
-                        stages.push(HaloShaderTransparentGenericStage { inner: stage.clone() });
-                    }
-                    JsValue::from(HaloShaderTransparencyGeneric {
-                        inner: s,
-                        path: shader_hdr.path.clone(),
-                        maps,
-                        bitmaps,
-                        stages,
-                    })
-                },
-                TagData::ShaderTransparentChicago(s) => {
-                    let mut maps = Vec::new();
-                    let mut bitmaps = Vec::new();
-                    for chicago_map in s.maps.items.as_ref().unwrap() {
-                        bitmaps.push(self.resolve_bitmap_dependency(&chicago_map.map));
-                        maps.push(HaloShaderTransparentChicagoMap { inner: chicago_map.clone() });
-                    }
-                    JsValue::from(HaloShaderTransparencyChicago {
-                        inner: s,
-                        path: shader_hdr.path.clone(),
-                        maps,
-                        bitmaps,
-                    })
-                },
-                TagData::ShaderTransparentWater(s) => {
-                    let mut ripples = Vec::new();
-                    for ripple in s.ripples.items.as_ref().unwrap() {
-                        ripples.push(HaloShaderTransparentWaterRipple { inner: ripple.clone() });
-                    }
-                    JsValue::from(HaloShaderTransparentWater {
-                        path: shader_hdr.path.clone(),
-                        base_bitmap: self.resolve_bitmap_dependency(&s.base_bitmap),
-                        reflection_bitmap: self.resolve_bitmap_dependency(&s.reflection_bitmap),
-                        ripple_bitmap: self.resolve_bitmap_dependency(&s.ripple_bitmap),
-                        ripples,
-                        inner: s,
-                    })
-                },
+                TagData::ShaderModel(s) => JsValue::from(s),
+                TagData::ShaderTransparentGeneric(s) => JsValue::from(s),
+                TagData::ShaderTransparentChicago(s) => JsValue::from(s),
+                TagData::ShaderTransparentWater(s) => JsValue::from(s),
                 _ => JsValue::NULL,
             },
-            _ => JsValue::NULL,
+            Err(_) => JsValue::NULL,
         }
     }
 
-    pub fn get_model_shaders(&mut self, model: &HaloModel) -> Array {
+    pub fn get_model_shaders(&mut self, model: &GbxModel) -> Array {
         let result = Array::new();
-        for model_shader in model.inner.shaders.items.as_ref().unwrap() {
+        for model_shader in model.shaders.items.as_ref().unwrap() {
             // FIXME do we need the permutation value?
             let shader_hdr = self.mgr.resolve_dependency(&model_shader.shader).unwrap();
             let js_value = self.get_shader(shader_hdr);
@@ -740,69 +46,61 @@ impl HaloSceneManager {
         result
     }
 
-    pub fn get_material_shader(&mut self, material: &HaloMaterial) -> JsValue {
-        let shader_hdr = self.mgr.resolve_dependency(&material.inner.shader).unwrap();
+    pub fn get_material_shader(&mut self, material: &BSPMaterial) -> JsValue {
+        let shader_hdr = self.mgr.resolve_dependency(&material.shader).unwrap();
         self.get_shader(shader_hdr)
     }
 
-    pub fn get_model_parts(&mut self, model: &HaloModel) -> Array {
-        let result = Array::new();
-        for geometry in model.inner.geometries.items.as_ref().unwrap() {
+    pub fn get_model_parts(&mut self, model: &GbxModel) -> Vec<GbxModelPart> {
+        let mut result = Vec::new();
+        for geometry in model.geometries.items.as_ref().unwrap() {
             for part in geometry.parts.items.as_ref().unwrap() {
-                result.push(&JsValue::from(HaloModelPart::new(part)));
+                result.push(part.clone());
             }
         }
         result
     }
 
-    pub fn get_scenery_model(&mut self, scenery: &HaloScenery) -> Option<HaloModel> {
-        self.resolve_model_dependency(&scenery.inner.model)
-            .map(|model| HaloModel { inner: model })
+    pub fn get_scenery_model(&mut self, scenery: &Scenery) -> Option<GbxModel> {
+        self.resolve_model_dependency(&scenery.model)
     }
 
-    pub fn get_scenery_palette(&mut self) -> Array {
+    pub fn get_scenery_palette(&mut self) -> Vec<Scenery> {
         let scenario_tag = self.mgr.get_scenario().unwrap();
         let scenario = match scenario_tag.data {
             TagData::Scenario(s) => s,
             _ => unreachable!(),
         };
-        let palette = Array::new();
+        let mut result = Vec::new();
         for palette_entry in scenario.scenery_palette.items.as_ref().unwrap() {
             let scenery_header = self.mgr.resolve_dependency(&palette_entry.obj).unwrap();
             let scenery_tag = self.mgr.read_tag(&scenery_header).unwrap();
             match scenery_tag.data {
-                TagData::Scenery(s) => palette.push(&JsValue::from(HaloScenery::new(&s))),
+                TagData::Scenery(s) => result.push(s),
                 _ => unreachable!(),
             };
         }
-        palette
+        result
     }
 
-    pub fn get_scenery_instances(&mut self) -> Array {
+    pub fn get_scenery_instances(&mut self) -> Vec<ScenarioScenery> {
         let scenario_tag = self.mgr.get_scenario().unwrap();
-        let scenario = match scenario_tag.data {
-            TagData::Scenario(s) => s,
-            _ => unreachable!(),
+        let TagData::Scenario(scenario) = scenario_tag.data else {
+            unreachable!();
         };
-        let instances = Array::new();
-        for scenery in scenario.scenery.items.as_ref().unwrap() {
-            instances.push(&JsValue::from(HaloSceneryInstance { inner: scenery.clone() }));
-        }
-        instances
+        scenario.scenery.items.as_ref().cloned().unwrap()
     }
 
-    pub fn get_skies(&mut self) -> Array {
-        let result = Array::new();
-        let scenario_tag = self.mgr.get_scenario().unwrap();
-        let scenario_data = match scenario_tag.data { TagData::Scenario(s) => s, _ => unreachable!(), };
+    pub fn get_skies(&mut self) -> Vec<Sky> {
+        let mut result = Vec::new();
+        let TagData::Scenario(scenario_data) = self.mgr.get_scenario().unwrap().data else {
+            unreachable!();
+        };
         for dependency in scenario_data.skies.items.as_ref().unwrap() {
             let sky_header = self.mgr.resolve_dependency(dependency).unwrap();
             match self.mgr.read_tag(&sky_header).unwrap().data {
                 TagData::Sky(s) => {
-                    result.push(&JsValue::from(HaloSky {
-                        model: self.resolve_model_dependency(&s.model),
-                        inner: s,
-                    }));
+                    result.push(s);
                 },
                 _ => unreachable!(),
             }
@@ -810,93 +108,76 @@ impl HaloSceneManager {
         result
     }
 
-    pub fn get_bsps(&mut self) -> Array {
+    pub fn get_bsps(&mut self) -> Vec<BSP> {
         let scenario_tag = self.mgr.get_scenario().unwrap();
-        let bsps: Vec<BSP> = self.mgr.get_scenario_bsps(&scenario_tag).unwrap().iter()
+        self.mgr.get_scenario_bsps(&scenario_tag).unwrap().iter()
             .map(|tag| match &tag.data {
                 TagData::BSP(bsp) => bsp.clone(),
                 _ => unreachable!(),
-            }).collect();
-        let result = Array::new();
-        for bsp in &bsps {
-            let lightmaps_bitmap = self.resolve_bitmap_dependency(&bsp.lightmaps_bitmap);
-            result.push(&JsValue::from(HaloBSP::new(bsp.clone(), lightmaps_bitmap)));
-        }
-        result
+            }).collect()
     }
 
-    pub fn get_bsp_lightmaps(&self, bsp: &HaloBSP) -> Array {
-        bsp.inner.lightmaps.items.as_ref().unwrap().iter()
-            .map(|lightmap| JsValue::from(HaloLightmap::new(lightmap)))
-            .collect()
+    pub fn get_bsp_lightmaps(&self, bsp: &BSP) -> Vec<BSPLightmap> {
+        bsp.lightmaps.items.as_ref().cloned().unwrap()
     }
 
-    pub fn get_lightmap_materials(&self, lightmap: &HaloLightmap) -> Array {
-        lightmap.inner.materials.items.as_ref().unwrap().iter()
-            .map(|material| JsValue::from(HaloMaterial::new(material)))
-            .collect()
+    pub fn get_lightmap_materials(&self, lightmap: &BSPLightmap) -> Vec<BSPMaterial> {
+        lightmap.materials.items.as_ref().cloned().unwrap()
     }
 
-    pub fn get_model_part_indices(&mut self, part: &HaloModelPart) -> Uint16Array {
-        let offset = part.inner.tri_offset + self.mgr.tag_index_header.model_data_file_offset + self.mgr.tag_index_header.vertex_data_size;
-        let count = part.inner.tri_count;
-        let tri_data = self.mgr.read_map_u16s(offset as u64, count as usize).unwrap();
-        Uint16Array::from(&tri_data[..])
+    pub fn get_model_part_indices(&mut self, part: &GbxModelPart) -> Vec<u16> {
+        let offset = part.tri_offset + self.mgr.tag_index_header.model_data_file_offset + self.mgr.tag_index_header.vertex_data_size;
+        let count = part.tri_count();
+        self.mgr.read_map_u16s(offset as u64, count as usize).unwrap()
     }
 
-    pub fn get_model_part_vertices(&mut self, part: &HaloModelPart) -> Vec<u8> {
-        let offset = part.inner.vert_offset + self.mgr.tag_index_header.model_data_file_offset;
-        let count = part.inner.vert_count;
+    pub fn get_model_part_vertices(&mut self, part: &GbxModelPart) -> Vec<u8> {
+        let offset = part.vert_offset + self.mgr.tag_index_header.model_data_file_offset;
+        let count = part.vert_count;
         let item_size = 68;
         self.mgr.read_map_bytes(offset as u64, item_size * count as usize).unwrap()
     }
 
-    pub fn get_bsp_indices(&self, bsp: &HaloBSP) -> Vec<u16> {
+    pub fn get_bsp_indices(&self, bsp: &BSP) -> Vec<u16> {
         let mut indices = Vec::new();
-        for tri in bsp.inner.surfaces.items.as_ref().unwrap() {
+        for tri in bsp.surfaces.items.as_ref().unwrap() {
             indices.extend_from_slice(&[tri.v0, tri.v1, tri.v2]);
         }
         indices
     }
 
-    fn resolve_model_dependency(&mut self, dependency: &TagDependency) -> Option<GbxModel> {
-        let hdr = match self.mgr.resolve_dependency(dependency) {
-            Some(hdr) => hdr,
-            None => return None,
-        };
+    pub fn resolve_model_dependency(&mut self, dependency: &TagDependency) -> Option<GbxModel> {
+        let hdr = self.mgr.resolve_dependency(dependency)?;
         match self.mgr.read_tag(&hdr).unwrap().data {
             TagData::GbxModel(model) => Some(model),
             _ => unreachable!(),
         }
     }
 
-    fn resolve_bitmap_dependency(&mut self, dependency: &TagDependency) -> Option<Bitmap> {
-        let hdr = match self.mgr.resolve_dependency(dependency) {
-            Some(hdr) => hdr,
-            None => return None,
-        };
+    pub fn resolve_bitmap_dependency(&mut self, dependency: &TagDependency) -> Option<Bitmap> {
+        let hdr = self.mgr.resolve_dependency(dependency)?;
         match self.mgr.read_tag(&hdr).unwrap().data {
             TagData::Bitmap(bitmap) => Some(bitmap),
             _ => unreachable!(),
         }
     }
 
-    pub fn get_and_convert_bitmap_data(&mut self, bitmap: &HaloBitmap, submap: usize) -> Vec<u8> {
-        let bitmap_data = &bitmap.inner.data.items.as_ref().unwrap()[submap];
-        get_and_convert_bitmap_data(self.mgr.reader.data.get_ref(), bitmap_data)
+    pub fn get_and_convert_bitmap_data(&mut self, bitmap: &Bitmap, submap: usize) -> Vec<u8> {
+        let bitmap_data = &bitmap.data.items.as_ref().unwrap()[submap];
+        get_and_convert_bitmap_data(&mut self.mgr.reader.data, bitmap_data)
     }
 
-    pub fn get_material_vertex_data(&mut self, material: &HaloMaterial, bsp: &HaloBSP) -> Vec<u8> {
-        let offset = bsp.inner.header.as_ref().unwrap().rendered_vertices_offset + material.inner.rendered_vertices.base_pointer;
-        let count = material.inner.rendered_vertices.count;
+    pub fn get_material_vertex_data(&mut self, material: &BSPMaterial, bsp: &BSP) -> Vec<u8> {
+        let offset = bsp.header.as_ref().unwrap().rendered_vertices_offset + material.rendered_vertices.base_pointer;
+        let count = material.rendered_vertices.count;
         let item_size = 56; // position + normal + binormal + tangent + uv
-        self.mgr.read_map_bytes(offset as u64, count * item_size).unwrap()
+        self.mgr.read_map_bytes(offset as u64, count as usize * item_size).unwrap()
     }
 
-    pub fn get_material_lightmap_data(&mut self, material: &HaloMaterial, bsp: &HaloBSP) -> Vec<u8> {
-        let offset = bsp.inner.header.as_ref().unwrap().rendered_vertices_offset + material.inner.lightmap_vertices.base_pointer;
-        let count = material.inner.rendered_vertices.count;
+    pub fn get_material_lightmap_data(&mut self, material: &BSPMaterial, bsp: &BSP) -> Vec<u8> {
+        let offset = bsp.header.as_ref().unwrap().rendered_vertices_offset + material.lightmap_vertices.base_pointer;
+        let count = material.rendered_vertices.count;
         let item_size = 20; // normal + uv
-        self.mgr.read_map_bytes(offset as u64, count * item_size).unwrap()
+        self.mgr.read_map_bytes(offset as u64, count as usize * item_size).unwrap()
     }
 }

--- a/rust/src/unity/mod.rs
+++ b/rust/src/unity/mod.rs
@@ -2,5 +2,5 @@
 
 mod version;
 mod asset_file;
-mod types;
+pub mod types;
 mod util;

--- a/rust/src/unity/types/binary.rs
+++ b/rust/src/unity/types/binary.rs
@@ -1,5 +1,5 @@
 
-use deku::prelude::*;
+use deku::{ctx::Order, prelude::*};
 
 // https://github.com/AssetRipper/TypeTreeDumps/blob/main/StructsDump/release/2019.4.39f1.dump
 // e.g. Outer Wilds
@@ -154,6 +154,7 @@ pub struct Mesh {
 }
 
 #[derive(DekuRead, Clone, Copy, Debug)]
+#[repr(i32)]
 #[deku(id_type = "i32")]
 pub enum IndexFormat {
     UInt16 = 0,
@@ -161,6 +162,7 @@ pub enum IndexFormat {
 }
 
 #[derive(DekuRead, Clone, Copy, Debug)]
+#[repr(u8)]
 #[deku(id_type = "u8")]
 pub enum MeshCompression {
     Off = 0,
@@ -225,7 +227,7 @@ impl<'a, Ctx> DekuReader<'a, Ctx> for ByteArray where Ctx: Copy {
     fn from_reader_with_ctx<R: std::io::Read + std::io::Seek>(reader: &mut Reader<R>, _ctx: Ctx) -> Result<Self, DekuError> {
         let count = i32::from_reader_with_ctx(reader, ())? as usize;
         let mut buf = vec![0x00; count];
-        reader.read_bytes(count, &mut buf)?;
+        reader.read_bytes(count, &mut buf, Order::Msb0)?;
         Ok(ByteArray{ data: buf })
     }
 }
@@ -382,6 +384,7 @@ pub struct GLTextureSettings {
 }
 
 #[derive(DekuRead, Clone, Debug)]
+#[repr(i32)]
 #[deku(id_type = "i32")]
 pub enum TextureFilterMode {
     Nearest = 0,
@@ -390,6 +393,7 @@ pub enum TextureFilterMode {
 }
 
 #[derive(DekuRead, Clone, Debug)]
+#[repr(i32)]
 #[deku(id_type = "i32")]
 pub enum TextureWrapMode {
     Repeat = 0,
@@ -400,6 +404,7 @@ pub enum TextureWrapMode {
 
 // copied from https://github.com/Unity-Technologies/UnityCsReference/blob/129a67089d125df5b95b659d3535deaf9968e86c/Editor/Mono/AssetPipeline/TextureImporterEnums.cs#L37
 #[derive(DekuRead, Clone, Debug)]
+#[repr(i32)]
 #[deku(id_type = "i32")]
 pub enum TextureFormat {
     // Alpha 8 bit texture format.
@@ -515,6 +520,7 @@ pub enum TextureFormat {
 }
 
 #[derive(DekuRead, Clone, Debug)]
+#[repr(i32)]
 #[deku(id_type = "i32")]
 pub enum ColorSpace {
     Linear = 0x00,

--- a/rust/src/wow/db.rs
+++ b/rust/src/wow/db.rs
@@ -1,6 +1,6 @@
 use std::{collections::{HashMap, HashSet}, io::{Cursor, Seek, SeekFrom}};
 
-use deku::prelude::*;
+use deku::{ctx::Order, prelude::*};
 use nalgebra_glm::Vec2;
 use crate::geometry::{point_dist_to_polygon, point_inside_polygon};
 
@@ -156,7 +156,7 @@ fn read_field_to_u32<R: std::io::Read + std::io::Seek>(reader: &mut Reader<R>, f
     assert!(field_size_bits <= 32);
 
     let mut buf = [0x00; 4];
-    reader.read_bytes(field_size_bytes, &mut buf)?;
+    reader.read_bytes(field_size_bytes, &mut buf, Order::Msb0)?;
     let v = u32::from_le_bytes(buf);
 
     let result = if field_size_bits == 32 {

--- a/rust/src/wow/m2.rs
+++ b/rust/src/wow/m2.rs
@@ -380,6 +380,7 @@ pub struct M2Material {
 
 #[wasm_bindgen(js_name = "WowM2BlendingMode")]
 #[derive(DekuRead, Debug, Copy, Clone)]
+#[repr(u16)]
 #[deku(id_type = "u16")]
 pub enum M2BlendingMode {
     Opaque = 0,


### PR DESCRIPTION
Deku vastly simplifies the deserialization code here. We can also rip out nearly all of the `wasm.rs` interface thanks to both improved QOL in wasm-bindgen and just uhhhh me knowing how to use wasm-bindgen better these days.