### PR TITLE
ct: fix crazybox resource name

### DIFF
--- a/src/CrazyTaxi/scenes.ts
+++ b/src/CrazyTaxi/scenes.ts
@@ -204,7 +204,7 @@ class SceneDesc implements Viewer.SceneDesc {
             "texDC0.all",
             `pol${this.id}.all`,
             `pol${this.id}_stream.all`,
-            `tex${this.id.toUpperCase()}.all`,
+            `tex${this.id === 'dc3' ? this.id : this.id.toUpperCase()}.all`,
             "misc.all",
             "white.tex",
         ]);


### PR DESCRIPTION
For some reason the crazybox levels have a lowercase tex filename