### PR TITLE
Add Top Gear Rally (N64)

### DIFF
--- a/src/Common/N64/RDP.ts
+++ b/src/Common/N64/RDP.ts
@@ -472,13 +472,7 @@ export function translateTileTexture(segmentBuffers: ArrayBufferSlice[], dramAdd
     default:
         throw new Error(`Unknown image format ${tile.fmt} / ${tile.siz}`);
     }
-    // Clone the tile state so the Texture has its own immutable snapshot.
-    // Without this, the Texture holds a mutable reference to DP_TileState
-    // which gets overwritten by subsequent SETTILE commands, corrupting
-    // the sampler wrap modes and texture cache lookups.
-    const snapshotTile = new TileState();
-    snapshotTile.copy(tile);
-    const out = new Texture(snapshotTile, dramAddr, dramPalAddr, tileW, tileH, dst);
+    const out = new Texture(tile, dramAddr, dramPalAddr, tileW, tileH, dst);
 
     return out;
 }

--- a/src/Common/N64/RDP.ts
+++ b/src/Common/N64/RDP.ts
@@ -472,7 +472,13 @@ export function translateTileTexture(segmentBuffers: ArrayBufferSlice[], dramAdd
     default:
         throw new Error(`Unknown image format ${tile.fmt} / ${tile.siz}`);
     }
-    const out = new Texture(tile, dramAddr, dramPalAddr, tileW, tileH, dst);
+    // Clone the tile state so the Texture has its own immutable snapshot.
+    // Without this, the Texture holds a mutable reference to DP_TileState
+    // which gets overwritten by subsequent SETTILE commands, corrupting
+    // the sampler wrap modes and texture cache lookups.
+    const snapshotTile = new TileState();
+    snapshotTile.copy(tile);
+    const out = new Texture(snapshotTile, dramAddr, dramPalAddr, tileW, tileH, dst);
 
     return out;
 }

--- a/src/DefaultSaveStates.json
+++ b/src/DefaultSaveStates.json
@@ -6917,5 +6917,17 @@
     "SaveState_Spyro3/58/1": "ShareData=AOE:7Ul^&3T+:c&9p&pcWYx?UQ4?OgUrn&fUJgHeWGQaYUZOpl9FW+IUs8$p=a",
     "SaveState_Spyro3/61/1": "ShareData=AD1&rUg]GgT&:LU90J21Wa(!Y6dTiDUY2~6UCrVPV{LVnUqe*f9T]rAUkyG7=a",
     "SaveState_Spyro3/64/1": "ShareData=AA4cb8{]OiT5[Z-9uHCWWUbr56mC&0Ul+vET5@+PWfglsUae:RTSdW(8-m3M=a",
-    "SaveState_Spyro3/67/1": "ShareData=AOmp!Ug16R9DIZEUWieoV{qesQ85M0UpT8UUC/t2WB-RG92hZL8*RC|UdMt4=a"
+    "SaveState_Spyro3/67/1": "ShareData=AOmp!Ug16R9DIZEUWieoV{qesQ85M0UpT8UUC/t2WB-RG92hZL8*RC|UdMt4=a",
+
+    "SaveState_TopGearRally/desert/1": "ShareData=AYQD/UUPqpT_wWu9hTE_XE-gqQx@&GUnqBuT4*DTV_;pKUvf,686^[,T|55hW~",
+    "SaveState_TopGearRally/mountain/1": "ShareData=AM~MJUn*DSTH-qq8:MU$Xgaw,5}8;8Us4cAT1dJ6V~xRGT~1Kw8@|eOUXC!}W~",
+    "SaveState_TopGearRally/coastline/1": "ShareData=AEnvx9lwo-8t@Z&9p!eoW;&uxQpn*7UWr,286+,AV?0)rUY!C08yuw79itbnW~",
+    "SaveState_TopGearRally/jungle/1": "ShareData=AM&k@943lsS1:gcTd$zNWyk?Q5xu03Ul3_i8;nP7Wl5!b80*T$8)obB9mVFPW~",
+    "SaveState_TopGearRally/stripmine/1": "ShareData=AVBy6Up&s+S^@JKT17LhWwwKoP(q9)Ua-]o9BOxDV)1n*9C|=dT]WX9UZ+G_XL",
+    "SaveState_TopGearRally/desert_m/1": "ShareData=ARVxT8?[I3UUa]c9i:5MXIsolQk@?LUqKn8UO&8KVx/2YUV?BITt/0a8?A]~={",
+    "SaveState_TopGearRally/mountain_m/1": "ShareData=AG1ns98LEBTu/SQ9L(QVXlI{k6Fn=qUiEBQT@2MmVvIo,UCZ3RT11/69tu;i={",
+    "SaveState_TopGearRally/coastline_m/1": "ShareData=ABFDUUaGXvUMx9s9rMxFW1wXgQ@LHjUm*ZWUG+=EWCwi=UedLp8/VtzUp(T^={",
+    "SaveState_TopGearRally/jungle_m/1": "ShareData=AK3MCUg9cl8Ky3D8/m[6W8!ubP}(;:UWGk;8)|t~We7!hT@/x-T-J,wUoRYj={",
+    "SaveState_TopGearRally/stripmine_m/1": "ShareData=AHyy[9i]v)8Z7@&T1u7WWxo-wQQ2B;Uh}SGT5bmIV$M^z9E2+mT8CfS9k=o2-X",
+    "SaveState_TopGearRally/season_winner/1": "ShareData=ASwYt9oRPi7xTv^TBD6OXU*mvRVuteUf6;3T1hTIV1OT*8df5TT++q29qC0kW~"
 }

--- a/src/TopGearRally/KNOWN_ISSUES.md
+++ b/src/TopGearRally/KNOWN_ISSUES.md
@@ -1,0 +1,41 @@
+# Known issues
+
+## Affecting all tracks
+
+- Billboard spline-animated models usually have a 'best' viewing angle, and when not viewed at that
+  angle, the skybox is often in the transparent section of the texture.
+- Weather is not properly implemented (commented out). This affects some signage in most tracks.
+- Reflection is probably implemented incorrectly.
+
+## Coastline
+
+- Missing lighthouse light and its animation.
+- Windmill blades clipped at bottom.
+
+## Jungle
+
+- Missing fire above the heads in the tunnel.
+- Some directional signs are just solid colours (yellow ones in this track).
+- Road texture is shown incorrect in some places (shortcut and towards end of track).
+- Second to last waterfall not animated; part of water body missing.
+
+## Desert
+
+- Light textures on the ceiling do not appear correctly in the second and last long tunnel.
+- 'FISH N CHIPS' sign is probably supposed to be mirrored when the backside is shown to camera or it
+  is supposed to be a billboard (as stored in the ROM, it rotates).
+
+## Mountain
+
+- Some signs show a different than expected texture (might be directional signs).
+- Most of the checkmark banner textures are mirrored.
+
+## Strip Mine
+
+- Animation splines are traced backwards.
+- START banner is cut off on the right.
+- Most of the checkmark banner textures are mirrored.
+
+## Season Winner
+
+- Camera flashes are not implemented correctly (original code is not designed for free camera).

--- a/src/TopGearRally/data.ts
+++ b/src/TopGearRally/data.ts
@@ -1,0 +1,327 @@
+import ArrayBufferSlice from "../ArrayBufferSlice.js";
+
+/**
+ * TGR track binary format parser.
+ *
+ * TGR1 header (32 bytes, little-endian):
+ *   +0x00  u32  magic 'TGR1' (0x31524754).
+ *   +0x04  u32  version (1).
+ *   +0x08  u32  pointerBase.
+ *   +0x0C  u32  dataSize.
+ *   +0x10  u32  instanceTableOffset.
+ *   +0x14  u32  instanceCount.
+ *   +0x18  u32  skyboxDLOffset.
+ *   +0x1C  u32  dataOffset (32).
+ *
+ * TGR2 header (48 bytes, little-endian) extends TGR1:
+ *   +0x00  u32  magic 'TGR2' (0x32524754).
+ *   +0x04-0x1C  same as TGR1 (dataOffset = 0x30).
+ *   +0x20  u32  winterPaletteOffset.
+ *   +0x24  u32  winterPaletteCount.
+ *   +0x28  u32  animTexOffset.
+ *   +0x2C  u32  animTexCount.
+ *
+ * Winter palette override entry (variable size):
+ *   +0x00  u32  destOffset (byte offset within track data).
+ *   +0x04  u16  size (0x20 for CI4, 0x200 for CI8).
+ *   +0x06  u16  padding.
+ *   +0x08  data[size].
+ *
+ * Animated texture channel (variable size):
+ *   +0x00  u32  destOffset.
+ *   +0x04  u32  texSize.
+ *   +0x08  u32  keyframeCount.
+ *   Per keyframe: +0x00 u32 timeMs, then texSize bytes of data.
+ */
+
+/** Single track instance with transform matrix, DL pointer, and flags. */
+export interface TGRTrackInstance {
+    /** 4x4 float matrix (row-major, big-endian in source data). */
+    matrix: Float32Array;
+    /** DL offset within track data (rebased from absolute N64 pointer). */
+    dlOffset: number;
+    /** Instance flags (u16 at instance+0x4C). */
+    flags: number;
+    /** Original index in the instance table (before filtering). */
+    rawIndex: number;
+}
+
+/** Animation table entry from track header+0x164. */
+export interface TGRAnimEntry {
+    /** Animation type (0-7). */
+    type: number;
+    /** Instance index (types 0-3,7) or pointer (types 4-5). */
+    data: number;
+    /** Speed as float bits (types 0-2), node count (type 4), etc. */
+    params: number;
+}
+
+/** Dual-rail spline path for type 3 (spline follower) animations. */
+export interface TGRSplineData {
+    /** Instance that follows this spline path. */
+    followerInstanceIndex: number;
+    /** Left rail: interleaved x,y,z float triplets in N64 space. */
+    leftRail: Float32Array;
+    /** Right rail: interleaved x,y,z float triplets in N64 space. */
+    rightRail: Float32Array;
+    /** Number of nodes in each rail. */
+    nodeCount: number;
+}
+
+/** Single keyframe within an animated texture channel. */
+export interface TGRAnimTexKeyframe {
+    /** Timestamp in milliseconds within the animation cycle. */
+    time: number;
+    /** Raw N64 texture data for this keyframe. */
+    texData: Uint8Array;
+}
+
+/** Animated texture channel with multiple keyframes. */
+export interface TGRAnimTexChannel {
+    /** Byte offset within track data where texture is written. */
+    destOffset: number;
+    /** Size of each keyframe's texture data in bytes. */
+    texSize: number;
+    /** Keyframes sorted by time. */
+    keyframes: TGRAnimTexKeyframe[];
+}
+
+/** Winter palette override entry (summer/winter texture variant). */
+export interface WinterPaletteOverride {
+    /** Byte offset within track data. */
+    destOffset: number;
+    /** Palette size in bytes (0x20 for CI4, 0x200 for CI8). */
+    size: number;
+    /** Raw winter palette bytes. */
+    data: Uint8Array;
+}
+
+/** Parsed track data with all geometry, textures, and animation info. */
+export interface TGRTrack {
+    /** N64 DRAM base address (typically 0x80025c00). */
+    pointerBase: number;
+    /** Raw track data blob (DLs, vertices, textures with summer palettes). */
+    dataBuffer: ArrayBufferSlice;
+    /** Renderable instances with valid DL pointers. */
+    instances: TGRTrackInstance[];
+    /** Skybox display list offset within track data. */
+    skyboxDLOffset: number;
+    /** Winter palette overrides for weather switching. */
+    winterOverrides: WinterPaletteOverride[];
+    /** Animation table entries from track header+0x164. */
+    animEntries: TGRAnimEntry[];
+    /** Spline follower paths parsed from animation entries. */
+    splines: TGRSplineData[];
+    /** Animated texture channels with per-keyframe data. */
+    animTexChannels: TGRAnimTexChannel[];
+}
+
+const TGR1_MAGIC = 0x31524754;
+const TGR2_MAGIC = 0x32524754;
+
+/**
+ * Parse a TGR1/TGR2 track binary into structured data.
+ * @param {ArrayBufferSlice} buffer Raw file contents.
+ * @returns {TGRTrack} Parsed track data.
+ */
+export function parseTGRTrack(buffer: ArrayBufferSlice): TGRTrack {
+    const view = buffer.createDataView();
+
+    const magic = view.getUint32(0x00, true);
+    if (magic !== TGR1_MAGIC && magic !== TGR2_MAGIC) {
+        throw new Error(`Invalid TGR track magic: 0x${magic.toString(16)}`);
+    }
+
+    const isTGR2 = magic === TGR2_MAGIC;
+
+    const pointerBase = view.getUint32(0x08, true);
+    const dataSize = view.getUint32(0x0c, true);
+    const instanceTableOffset = view.getUint32(0x10, true);
+    const instanceCount = view.getUint32(0x14, true);
+    let skyboxDLOffset = view.getUint32(0x18, true);
+    const dataOffset = view.getUint32(0x1c, true);
+
+    // Fallback: if header has no sky offset, read from track data +0x50.
+    if (skyboxDLOffset === 0 && dataOffset + 0x54 <= view.byteLength) {
+        // Big-endian in track data.
+        const skyPtr = view.getUint32(dataOffset + 0x50, false);
+        if (skyPtr >= pointerBase && skyPtr < pointerBase + dataSize) {
+            skyboxDLOffset = skyPtr - pointerBase;
+        }
+    }
+
+    // TGR2 extended header.
+    let winterPaletteOffset = 0;
+    let winterPaletteCount = 0;
+    if (isTGR2) {
+        winterPaletteOffset = view.getUint32(0x20, true);
+        winterPaletteCount = view.getUint32(0x24, true);
+    }
+
+    // Slice out the raw track data.
+    const dataBuffer = buffer.slice(dataOffset, dataOffset + dataSize);
+    const dataView = dataBuffer.createDataView();
+
+    // Parse instances.
+    const instances: TGRTrackInstance[] = [];
+    const INSTANCE_STRIDE = 0x54;
+
+    for (let i = 0; i < instanceCount; i++) {
+        const instOff = instanceTableOffset + i * INSTANCE_STRIDE;
+        if (instOff + INSTANCE_STRIDE > dataSize) {
+            break;
+        }
+
+        // Read 4x4 float matrix (big-endian in N64 data).
+        const matrix = new Float32Array(16);
+        for (let j = 0; j < 16; j++) {
+            matrix[j] = dataView.getFloat32(instOff + j * 4, false);
+        }
+
+        // Skip zero-matrix instances (sentinels).
+        if (matrix[0] === 0 && matrix[5] === 0 && matrix[10] === 0) {
+            continue;
+        }
+
+        // Read DL pointer and rebase from absolute N64 address.
+        const dlPtr = dataView.getUint32(instOff + 0x44, false);
+        if (dlPtr < pointerBase || dlPtr >= pointerBase + dataSize) {
+            continue;
+        }
+        const dlOffset = dlPtr - pointerBase;
+
+        // Read flags.
+        const flags = dataView.getUint16(instOff + 0x4c, false);
+
+        instances.push({ matrix, dlOffset, flags, rawIndex: i });
+    }
+
+    // Parse winter palette overrides (TGR2 only).
+    const winterOverrides: WinterPaletteOverride[] = [];
+    if (isTGR2 && winterPaletteCount > 0 && winterPaletteOffset > 0) {
+        let off = winterPaletteOffset;
+        for (let i = 0; i < winterPaletteCount; i++) {
+            if (off + 8 > view.byteLength) {
+                break;
+            }
+            const destOffset = view.getUint32(off, true);
+            const size = view.getUint16(off + 4, true);
+            off += 8;
+            if (off + size > view.byteLength) {
+                break;
+            }
+            const data = buffer.createTypedArray(Uint8Array, off, size);
+            winterOverrides.push({ destOffset, size, data });
+            off += size;
+        }
+    }
+
+    // Parse animation entries from track header.
+    const animEntries: TGRAnimEntry[] = [];
+    const ANIM_TABLE_OFFSET = 0x164;
+    const ANIM_COUNT_OFFSET = 0x224;
+    if (ANIM_COUNT_OFFSET + 4 <= dataSize) {
+        const animCount = dataView.getUint32(
+            ANIM_COUNT_OFFSET,
+            false, // Big-endian.
+        );
+        for (let i = 0; i < animCount; i++) {
+            const base = ANIM_TABLE_OFFSET + i * 12;
+            if (base + 12 > dataSize) {
+                break;
+            }
+            const data = dataView.getUint32(base, false);
+            const params = dataView.getUint32(base + 4, false);
+            const type = dataView.getUint8(base + 8);
+            animEntries.push({ type, data, params });
+        }
+    }
+
+    // Parse spline data from animation entries (types 3-5).
+    const splines: TGRSplineData[] = [];
+    {
+        let followerIdx = -1;
+        let leftRailPtr = 0;
+        let rightRailPtr = 0;
+        let nodeCount = 0;
+        for (const anim of animEntries) {
+            if (anim.type === 3) {
+                followerIdx = anim.data;
+            } else if (anim.type === 4) {
+                leftRailPtr = anim.data;
+                nodeCount = anim.params;
+            } else if (anim.type === 5) {
+                rightRailPtr = anim.data;
+            }
+        }
+        if (
+            followerIdx >= 0 &&
+            leftRailPtr >= pointerBase &&
+            rightRailPtr >= pointerBase &&
+            nodeCount > 0
+        ) {
+            const leftOff = leftRailPtr - pointerBase;
+            const rightOff = rightRailPtr - pointerBase;
+            const floatCount = nodeCount * 3;
+            if (leftOff + floatCount * 4 <= dataSize && rightOff + floatCount * 4 <= dataSize) {
+                const leftRail = new Float32Array(floatCount);
+                const rightRail = new Float32Array(floatCount);
+                for (let i = 0; i < floatCount; i++) {
+                    leftRail[i] = dataView.getFloat32(leftOff + i * 4, false);
+                    rightRail[i] = dataView.getFloat32(rightOff + i * 4, false);
+                }
+                splines.push({
+                    followerInstanceIndex: followerIdx,
+                    leftRail,
+                    rightRail,
+                    nodeCount,
+                });
+            }
+        }
+    }
+
+    // Parse animated texture channels (TGR2 only).
+    const animTexChannels: TGRAnimTexChannel[] = [];
+    if (isTGR2) {
+        const animTexOffset = view.getUint32(0x28, true);
+        const animTexCount = view.getUint32(0x2c, true);
+        if (animTexOffset > 0 && animTexCount > 0 && animTexOffset < view.byteLength) {
+            // Skip the count u32 (redundant with header).
+            let aoff = animTexOffset + 4;
+            for (let i = 0; i < animTexCount; i++) {
+                if (aoff + 12 > view.byteLength) {
+                    break;
+                }
+                const destOffset = view.getUint32(aoff, true);
+                const texSize = view.getUint32(aoff + 4, true);
+                const kfCount = view.getUint32(aoff + 8, true);
+                aoff += 12;
+                const keyframes: TGRAnimTexKeyframe[] = [];
+                for (let k = 0; k < kfCount; k++) {
+                    if (aoff + 4 + texSize > view.byteLength) {
+                        break;
+                    }
+                    const time = view.getUint32(aoff, true);
+                    aoff += 4;
+                    const texData = buffer.createTypedArray(Uint8Array, aoff, texSize);
+                    keyframes.push({ time, texData });
+                    aoff += texSize;
+                }
+                if (keyframes.length >= 2) {
+                    animTexChannels.push({ destOffset, texSize, keyframes });
+                }
+            }
+        }
+    }
+
+    return {
+        pointerBase,
+        dataBuffer,
+        instances,
+        skyboxDLOffset,
+        winterOverrides,
+        animEntries,
+        splines,
+        animTexChannels,
+    };
+}

--- a/src/TopGearRally/extract-tgr.py
+++ b/src/TopGearRally/extract-tgr.py
@@ -1,0 +1,1088 @@
+#!/usr/bin/env python
+"""
+Export Top Gear Rally track data for noclip.website.
+
+Extracts and decompresses track geometry from the USA N64 ROM, patches streaming palette/texture
+data, flips the START banner texture, and outputs TGR2 files with dual summer/winter palette
+support.
+
+Output: data/TopGearRally/track_*.bin (TGR2 format)
+
+Usage:
+  export_noclip_tracks.py [ROM_FILE] [OUTPUT_DIR]
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
+import argparse
+import hashlib
+import logging
+import operator
+import struct
+import sys
+import zlib
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
+log = logging.getLogger(__name__)
+ne = operator.ne
+
+
+def _find_git_root() -> Path:
+    # Walk up from the script directory to find the git repository root.
+    d = Path(__file__).resolve().parent
+    for p in d.parents:
+        if (p / '.git').exists():
+            return p
+    msg = 'Could not find .git root.'
+    raise RuntimeError(msg)
+
+
+NOCLIP_ROOT = _find_git_root()
+"""Root directory of the noclip repository. Used to locate the ROM and output directory."""
+DEFAULT_OUTPUT_DIR = NOCLIP_ROOT / 'data' / 'TopGearRally'
+"""Directory where exported track data will be saved (relative to repository root)."""
+DEFAULT_ROM_PATH = NOCLIP_ROOT.parent / 'usa.z64'
+"""Default Path to the Top Gear Rally ROM file."""
+TRACK_ROM_OFFSETS = {
+    0: 0x211C10,  # Desert
+    1: 0x300500,  # Mountain
+    2: 0x3D3050,  # Coastline
+    3: 0x551180,  # Mine
+    4: 0x65C140,  # Amazon
+    10: 0x7D1240,  # Season Winner (gamewin)
+}
+"""
+Track index -> ROM geometry offset (points to compressed chunk list).
+
+Geometry offset points to: [word0=total_comp_size] [decomp_size] [chunk_size, zlib, ...]
+"""
+POINTER_BASE = 0x80025C00
+"""Base address for pointers within track data (DRAM address corresponding to ``td[0]``)."""
+TGR2_MAGIC = 0x32524754
+"""Magic number for TGR2 files ("TGR2" in ASCII)."""
+TGR2_HEADER_SIZE = 0x30  # 48 bytes
+"""Size of TGR2 header before track data starts."""
+IMG_FMT_CI = 2
+"""CI4 image format identifier in the N64 RDP."""
+TRACK_COASTLINE = 2
+"""Coastline track index."""
+BANNER_HALVES = 2
+"""Number of texture halves in a standard START banner."""
+MIN_KEYFRAMES = 2
+"""Minimum keyframe count for an animated channel."""
+WEATHER_SWAP_SENTINEL = 0xFFFFFFFF
+"""Weather-swap sentinel: time_flags[0] value indicating a weather-swap channel."""
+ROM_SHA256 = 'af2ac2550273fa340d84e3674a2d3c60a921a47b5dbf19662fe006c379fafc40'
+"""Expected SHA-256 digest of the Top Gear Rally (USA) ROM."""
+MIN_MIP_DIM = 2
+"""Minimum mipmap dimension before stopping mip chain."""
+
+
+class DLCommand(IntEnum):
+    """N64 F3DEX display list command opcodes."""
+
+    ENDDL = 0xB8
+    """End of display list."""
+    DL_BRANCH = 0x06
+    """Branch to another display list."""
+    SETTIMG = 0xFD
+    """Set texture image source address."""
+    SETTILE = 0xF5
+    """Set tile descriptor."""
+    LOADBLOCK = 0xF3
+    """Load texture block into TMEM."""
+    SETTILESIZE = 0xF2
+    """Set tile size parameters."""
+    TRI1 = 0xBF
+    """Draw one triangle."""
+    TRI2 = 0xB1
+    """Draw two triangles."""
+
+
+class BannerTexEntry(NamedTuple):
+    """A single banner texture entry with address, dimensions, and format."""
+
+    addr: int
+    """Byte offset within track data where the texture is located."""
+    width: int
+    """Width of the texture in pixels."""
+    height: int
+    """Height of the texture in pixels."""
+    fmt: str = 'ci4'
+    """Image format, e.g. 'ci4' or 'ia8'."""
+    row_pitch: int | None = None
+    """Row pitch in bytes for the texture data. If ``None``, defaults to width (no padding)."""
+
+
+def decompress_track(rom: bytes, geom_offset: int) -> tuple[bytes, int]:
+    """
+    Decompress track geometry data from ROM.
+
+    Format at ``geom_offset``:
+      ``+0x00``: u32 BE - total size of first compressed chunk region
+      ``+0x04``: u32 BE - decompressed size
+      ``+0x08``: [u32 BE chunk_comp_size, zlib_data[chunk_comp_size], ...]
+                 (chunks are 2-byte aligned)
+
+    Returns (decompressed_data, stream_end_offset).
+    ``stream_end_offset`` = ``word0`` + ``geom_offset`` (for palette streaming).
+
+    Parameters
+    ----------
+    rom : bytes
+        The full ROM data.
+    geom_offset : int
+        The byte offset within the ROM where the track geometry data starts.
+
+    Returns
+    -------
+    tuple[bytes, int]
+        A tuple containing:
+        - decompressed_data: The full decompressed track data as bytes.
+        - stream_end_offset: The byte offset in the ROM where the compressed chunk region ends
+          (used as the base address for streaming palette/texture data).
+    """
+    word0 = struct.unpack_from('>I', rom, geom_offset)[0]
+    decomp_size = struct.unpack_from('>I', rom, geom_offset + 4)[0]
+    stream_end = word0 + geom_offset
+    log.debug(
+        'Decompressing from ROM 0x%06x, expected %d bytes, stream_end=0x%06x.',
+        geom_offset,
+        decomp_size,
+        stream_end,
+    )
+    result = bytearray()
+    pos = geom_offset + 8
+    n_chunks = 0
+    while len(result) < decomp_size:
+        if pos + 4 > len(rom):
+            break
+        chunk_comp_size = struct.unpack_from('>I', rom, pos)[0]
+        pos += 4
+        if chunk_comp_size == 0:
+            break
+        chunk_data = rom[pos : pos + chunk_comp_size]
+        try:
+            result.extend(zlib.decompress(chunk_data))
+        except zlib.error:
+            log.debug('zlib error at chunk %d (ROM 0x%06x).', n_chunks, pos)
+            break
+        pos += chunk_comp_size
+        n_chunks += 1
+        # Chunks are 2-byte aligned.
+        if pos & 1:
+            pos += 1
+    if len(result) < decomp_size:
+        log.debug(
+            'Partial decompression: got %d/%d bytes (%d chunks).',
+            len(result),
+            decomp_size,
+            n_chunks,
+        )
+    else:
+        log.debug('Decompressed %d chunks.', n_chunks)
+    return bytes(result[:decomp_size]), stream_end
+
+
+def r32(d: bytes | bytearray, o: int) -> int:
+    """Read a big-endian u32 from data at offset."""
+    return cast('int', struct.unpack_from('>I', d, o)[0])
+
+
+def r16(d: bytes | bytearray, o: int) -> int:
+    """Read a big-endian u16 from data at offset."""
+    return cast('int', struct.unpack_from('>H', d, o)[0])
+
+
+def r32s(d: bytes | bytearray, o: int) -> int:
+    """Read a big-endian signed u32 from data at offset."""
+    return cast('int', struct.unpack_from('>i', d, o)[0])
+
+
+def extract_animated_textures(
+    td: bytes | bytearray, pb: int, ds: int, rom: bytes, stream_end: int
+) -> list[dict[str, Any]]:
+    """
+    Extract animated texture channels with multiple keyframes.
+
+    Returns a list of dicts:
+
+    .. code-block:: python
+      {
+          'dest_offset': int,  # byte offset within track data where texture goes
+          'tex_size': int,  # size of each keyframe texture in bytes
+          'keyframes': [  # list of keyframe entries
+              {
+                  'time': int,  # time value (frame-based counter)
+                  'tex_data': bytes,  # raw texture data from ROM
+              },
+              ...,
+          ],
+      }
+
+    Parameters
+    ----------
+    td : bytes | bytearray
+        The track data.
+    pb : int
+        The pointer base address for the track data (DRAM address corresponding to ``td[0]``).
+    ds : int
+        The size of the track data in bytes.
+    rom : bytes
+        The full ROM data, used to read the texture data for each keyframe.
+    stream_end : int
+        The byte offset in the ROM where the compressed chunk region ends (base address for
+        streaming palette/texture data).
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        A list of animated texture channels with their keyframes and texture data.
+    """
+    nch = r32(td, 0x18)
+    ctp = r32(td, 0x1C)
+    ct_off = ctp - pb
+    log.debug('Scanning %d streaming channels for animated textures.', nch)
+    channels = []
+    for ci in range(nch):
+        c = ct_off + ci * 0x24
+        if c + 0x24 > ds:
+            break
+        flags = r32(td, c + 0x20)
+        if not (flags & (1 << 20)):
+            continue
+        dest0 = r32(td, c)
+        kf_ptr = r32(td, c + 8)
+        if kf_ptr < pb or kf_ptr >= pb + ds:
+            continue
+        kf_off = kf_ptr - pb
+        if kf_off + 8 > ds:
+            continue
+        n_kf = r16(td, kf_off + 2)
+        if n_kf < MIN_KEYFRAMES:
+            continue
+        kf0 = kf_off + 8
+        if kf0 + 12 > ds:
+            continue
+        # Skip weather-swap channels.
+        if n_kf == MIN_KEYFRAMES and r32(td, kf0) == WEATHER_SWAP_SENTINEL:
+            continue
+        primary_size = flags & 0x3FFFF
+        if primary_size == 0 or dest0 < pb or dest0 >= pb + ds:
+            continue
+        dest_offset = dest0 - pb
+        if dest_offset + primary_size > ds:
+            continue
+        keyframes = []
+        for ki in range(n_kf):
+            kf = kf_off + 8 + ki * 12
+            if kf + 12 > ds:
+                break
+            time_val = r32(td, kf)
+            tex_rom = r32s(td, kf + 4)
+            if tex_rom < 0:
+                continue
+            src = stream_end + tex_rom
+            if src + primary_size > len(rom):
+                continue
+            keyframes.append({
+                'time': time_val,
+                'tex_data': rom[src : src + primary_size],
+            })
+        if len(keyframes) >= MIN_KEYFRAMES:
+            log.debug(
+                '  Ch%d: %d keyframes, dest=0x%06x, size=0x%x.',
+                ci,
+                len(keyframes),
+                dest_offset,
+                primary_size,
+            )
+            channels.append({
+                'dest_offset': dest_offset,
+                'tex_size': primary_size,
+                'keyframes': keyframes,
+            })
+    log.debug('Found %d animated texture channels.', len(channels))
+    return channels
+
+
+def _patch_static_palettes(
+    td: bytes | bytearray,
+    pb: int,
+    ds: int,
+    rom: bytes,
+    stream_end: int,
+    nch: int,
+    ct_off: int,
+    summer_td: bytearray,
+    winter_td: bytearray,
+) -> int:
+    # Patch static palette channels (bit20=0, type=1) into summer and winter track data.
+    log.debug('Pass 1: Patching static palette channels.')
+    n_static = 0
+    for ci in range(nch):
+        c = ct_off + ci * 0x24
+        if c + 0x24 > len(td):
+            break
+        dest1 = r32(td, c + 4)
+        if dest1 == 0 or dest1 < pb or dest1 >= pb + ds:
+            continue
+        ch2 = r32(td, c + 8)
+        flags = r32(td, c + 0x20)
+        if ne((flags >> 24) & 0xF, 1):
+            continue
+        if flags & (1 << 20):
+            continue
+        src = stream_end + (ch2 & 0xFFF) * 32
+        d = dest1 - pb
+        if src + 32 > len(rom) or d + 32 > ds:
+            continue
+        pal = rom[src : src + 32]
+        summer_td[d : d + 32] = pal
+        winter_td[d : d + 32] = pal
+        n_static += 1
+    log.debug('  Patched %d static palette channels.', n_static)
+    return n_static
+
+
+def _patch_static_textures(
+    td: bytes | bytearray,
+    pb: int,
+    ds: int,
+    rom: bytes,
+    stream_end: int,
+    nch: int,
+    ct_off: int,
+    summer_td: bytearray,
+    winter_td: bytearray,
+) -> int:
+    # Patch static texture channels (bit20=0, type!=1) with non-zero ROM offset.
+    log.debug('Pass 1b: Patching static texture channels.')
+    n_static_tex = 0
+    for ci in range(nch):
+        c = ct_off + ci * 0x24
+        if c + 0x24 > len(td):
+            break
+        flags = r32(td, c + 0x20)
+        if flags & (1 << 20):
+            continue  # skip animated
+        fmt_type = (flags >> 24) & 0xF
+        if fmt_type == 1:
+            continue  # skip palette-only (handled in Pass 1)
+        primary_size = flags & 0x3FFFF
+        if primary_size == 0:
+            continue
+        dest0 = r32(td, c)
+        if dest0 == 0 or dest0 < pb or dest0 >= pb + ds:
+            continue
+        ch2 = r32(td, c + 8)
+        rom_off_unit = ch2 & 0xFFF
+        if rom_off_unit == 0:
+            continue  # no ROM data to load — already correct from decompression.
+        rom_off = rom_off_unit * 32
+        src = stream_end + rom_off
+        d = dest0 - pb
+        if src + primary_size > len(rom) or d + primary_size > ds:
+            continue
+        tex = rom[src : src + primary_size]
+        summer_td[d : d + primary_size] = tex
+        winter_td[d : d + primary_size] = tex
+        log.debug('  Ch%d: static tex 0x%x bytes -> 0x%08x.', ci, primary_size, dest0)
+        n_static_tex += 1
+    log.debug('  Patched %d static texture channels.', n_static_tex)
+    return n_static_tex
+
+
+def _patch_weather_swap_channel(
+    td: bytes | bytearray,
+    pb: int,
+    ds: int,
+    rom: bytes,
+    stream_end: int,
+    dest0: int,
+    dest1: int,
+    kf0: int,
+    primary_size: int,
+    pal_size: int,
+    summer_td: bytearray,
+    winter_td: bytearray,
+) -> None:
+    # Patch a single weather-swap animated channel into summer/winter data.
+    kf1 = kf0 + 12
+    if kf1 + 12 > len(td):
+        return
+    # Summer palette from KF1.
+    summer_pal_rom = r32s(td, kf1 + 8)
+    if dest1 and dest1 >= pb and dest1 < pb + ds and summer_pal_rom >= 0:
+        src = stream_end + summer_pal_rom
+        d = dest1 - pb
+        if src + pal_size <= len(rom) and d + pal_size <= ds:
+            summer_td[d : d + pal_size] = rom[src : src + pal_size]
+    # Winter texture + palette from KF0.
+    winter_tex_rom = r32s(td, kf0 + 4)
+    winter_pal_rom = r32s(td, kf0 + 8)
+    if dest0 and dest0 >= pb and dest0 < pb + ds and winter_tex_rom >= 0:
+        src = stream_end + winter_tex_rom
+        d = dest0 - pb
+        if src + primary_size <= len(rom) and d + primary_size <= ds:
+            winter_td[d : d + primary_size] = rom[src : src + primary_size]
+    if dest1 and dest1 >= pb and dest1 < pb + ds and winter_pal_rom >= 0:
+        src = stream_end + winter_pal_rom
+        d = dest1 - pb
+        if src + pal_size <= len(rom) and d + pal_size <= ds:
+            winter_td[d : d + pal_size] = rom[src : src + pal_size]
+
+
+def _patch_normal_animated_channel(
+    rom: bytes,
+    stream_end: int,
+    pb: int,
+    ds: int,
+    td: bytes | bytearray,
+    dest0: int,
+    dest1: int,
+    kf0: int,
+    primary_size: int,
+    pal_size: int,
+    summer_td: bytearray,
+    winter_td: bytearray,
+) -> tuple[int, int]:
+    # Patch a single non-weather animated channel. Returns (tex_count, pal_count).
+    n_tex = 0
+    n_pal = 0
+    tex_rom = r32s(td, kf0 + 4)
+    pal_rom = r32s(td, kf0 + 8)
+    if dest0 and dest0 >= pb and dest0 < pb + ds and tex_rom >= 0:
+        src = stream_end + tex_rom
+        d = dest0 - pb
+        if src + primary_size <= len(rom) and d + primary_size <= ds:
+            summer_td[d : d + primary_size] = rom[src : src + primary_size]
+            winter_td[d : d + primary_size] = rom[src : src + primary_size]
+            n_tex += 1
+    if dest1 and dest1 >= pb and dest1 < pb + ds and pal_rom >= 0:
+        src = stream_end + pal_rom
+        d = dest1 - pb
+        if src + pal_size <= len(rom) and d + pal_size <= ds:
+            summer_td[d : d + pal_size] = rom[src : src + pal_size]
+            winter_td[d : d + pal_size] = rom[src : src + pal_size]
+            n_pal += 1
+    return n_tex, n_pal
+
+
+def _patch_animated_channels(
+    td: bytes | bytearray,
+    pb: int,
+    ds: int,
+    rom: bytes,
+    stream_end: int,
+    nch: int,
+    ct_off: int,
+    summer_td: bytearray,
+    winter_td: bytearray,
+) -> tuple[int, int, int]:
+    # Patch animated channels (bit20=1), both weather-swap and non-weather.
+    # Returns (n_weather, n_anim_tex, n_anim_pal) counts.
+    log.debug('Pass 2: Patching animated channels.')
+    n_weather = 0
+    n_anim_tex = 0
+    n_anim_pal = 0
+    for ci in range(nch):
+        c = ct_off + ci * 0x24
+        if c + 0x24 > len(td):
+            break
+        dest0 = r32(td, c)
+        dest1 = r32(td, c + 4)
+        kf_ptr = r32(td, c + 8)
+        flags = r32(td, c + 0x20)
+        if not (flags & (1 << 20)):
+            continue
+        if kf_ptr < pb or kf_ptr >= pb + ds:
+            continue
+        kf_off = kf_ptr - pb
+        if kf_off + 8 > len(td):
+            continue
+        n_kf = r16(td, kf_off + 2)
+        if n_kf < 1:
+            continue
+        kf0 = kf_off + 8
+        if kf0 + 12 > len(td):
+            continue
+        primary_size = flags & 0x3FFFF
+        pal_size = 0x200 if ne((flags >> 24) & 0xF, 1) else 0x20
+        is_weather = n_kf == MIN_KEYFRAMES and r32(td, kf0) == WEATHER_SWAP_SENTINEL
+        if is_weather:
+            n_weather += 1
+            _patch_weather_swap_channel(
+                td,
+                pb,
+                ds,
+                rom,
+                stream_end,
+                dest0,
+                dest1,
+                kf0,
+                primary_size,
+                pal_size,
+                summer_td,
+                winter_td,
+            )
+        else:
+            t, p = _patch_normal_animated_channel(
+                rom,
+                stream_end,
+                pb,
+                ds,
+                td,
+                dest0,
+                dest1,
+                kf0,
+                primary_size,
+                pal_size,
+                summer_td,
+                winter_td,
+            )
+            n_anim_tex += t
+            n_anim_pal += p
+    log.debug('  Animated: %d weather, %d tex, %d pal.', n_weather, n_anim_tex, n_anim_pal)
+    return n_weather, n_anim_tex, n_anim_pal
+
+
+def _build_winter_overrides(
+    summer_td: bytearray, winter_td: bytearray, ds: int
+) -> list[tuple[int, int, bytes]]:
+    # Build the winter override diff table (byte-level diff, grouped by 0x20 alignment).
+    seen = {}
+    for off in range(ds):
+        if summer_td[off] != winter_td[off]:
+            base = (off // 0x20) * 0x20
+            if base not in seen and base + 0x20 <= ds:
+                seen[base] = (base, 0x20, bytes(winter_td[base : base + 0x20]))
+    return sorted(seen.values())
+
+
+def patch_palettes(
+    td: bytes | bytearray, pb: int, ds: int, rom: bytes, stream_end: int
+) -> tuple[bytearray, list[tuple[int, int, bytes]]]:
+    """
+    Patch streaming palette/texture data into the track data.
+
+    Returns (summer_td, winter_overrides) where:
+    - ``summer_td``: track data with summer palettes applied.
+    - ``winter_overrides``: list of (dest_off, size, winter_data) tuples.
+
+    Parameters
+    ----------
+    td : bytes | bytearray
+        The track data to patch.
+    pb : int
+        The pointer base address for the track data (DRAM address corresponding to ``td[0]``).
+    ds : int
+        The size of the track data in bytes.
+    rom : bytes
+        The full ROM data, used to read the palette/texture data for patching.
+    stream_end : int
+        The byte offset in the ROM where the compressed chunk region ends (base address for
+        streaming palette/texture data).
+
+    Returns
+    -------
+    tuple[bytearray, list[tuple[int, int, bytes]]]
+        A tuple containing:
+        - ``summer_td``: A bytearray of the track data with summer palettes applied.
+        - ``winter_overrides``: A list of tuples (dest_offset, size, winter_data) for the winter
+          palette/texture overrides.
+    """
+    nch = r32(td, 0x18)
+    ctp = r32(td, 0x1C)
+    ct_off = ctp - pb
+    summer_td = bytearray(td)
+    winter_td = bytearray(td)
+    _patch_static_palettes(td, pb, ds, rom, stream_end, nch, ct_off, summer_td, winter_td)
+    _patch_static_textures(td, pb, ds, rom, stream_end, nch, ct_off, summer_td, winter_td)
+    _patch_animated_channels(td, pb, ds, rom, stream_end, nch, ct_off, summer_td, winter_td)
+    return summer_td, _build_winter_overrides(summer_td, winter_td, ds)
+
+
+def _find_all_ci4_in_dl(
+    td: bytes | bytearray, pb: int, dl_off: int, visited: set[int] | None = None
+) -> Iterator[tuple[int, int, int]]:
+    # Walk DL following branches, yield ALL CI4 LOADBLOCK texture addresses and sizes.
+    if visited is None:
+        visited = set()
+    if dl_off in visited or dl_off < 0 or dl_off + 8 > len(td):
+        return
+    visited.add(dl_off)
+    pc = dl_off
+    last_settimg = None
+    tile_fmt = {}
+    pending_tex = None  # address from most recent LOADBLOCK.
+    for _ in range(2000):
+        if pc + 8 > len(td):
+            break
+        w0 = struct.unpack_from('>I', td, pc)[0]
+        w1 = struct.unpack_from('>I', td, pc + 4)[0]
+        cmd = (w0 >> 24) & 0xFF
+        match cmd:
+            case DLCommand.ENDDL:
+                break
+            case DLCommand.DL_BRANCH if pb <= w1 < pb + len(td):
+                yield from _find_all_ci4_in_dl(td, pb, w1 - pb, visited)
+            case DLCommand.SETTIMG:
+                last_settimg = w1
+            case DLCommand.SETTILE:
+                tile = (w1 >> 24) & 7
+                tile_fmt[tile] = (w0 >> 21) & 7
+            case DLCommand.LOADBLOCK:
+                if last_settimg is not None:
+                    pending_tex = last_settimg
+            case DLCommand.SETTILESIZE:
+                tile = (w1 >> 24) & 7
+                if tile == 0:
+                    cur_w = (((w1 >> 12) & 0xFFF) - ((w0 >> 12) & 0xFFF)) // 4 + 1
+                    cur_h = ((w1 & 0xFFF) - (w0 & 0xFFF)) // 4 + 1
+                    if pending_tex is not None and tile_fmt.get(0) == IMG_FMT_CI:
+                        if pending_tex >= pb and pending_tex < pb + len(td):
+                            yield (pending_tex - pb, cur_w, cur_h)
+                        pending_tex = None
+            # Also catch LOADBLOCK that reuses tile 0 without new SETTILESIZE.
+            case DLCommand.TRI1 | DLCommand.TRI2 if (
+                pending_tex is not None and tile_fmt.get(0) == IMG_FMT_CI and cur_w and cur_h
+            ):
+                if pending_tex >= pb and pending_tex < pb + len(td):
+                    yield (pending_tex - pb, cur_w, cur_h)
+                pending_tex = None
+        pc += 8
+
+
+def flip_ci4_horizontal(data: bytearray, offset: int, width: int, height: int) -> None:
+    """
+    Flip a CI4 texture horizontally (left-right mirror) in place.
+
+    Reverses byte order within each row and swaps nibbles in each byte.
+
+    Parameters
+    ----------
+    data : bytearray
+        The track data containing the texture to modify in place.
+    offset : int
+        The byte offset within `data` where the texture starts.
+    width : int
+        The width of the texture in pixels (must be even since each byte has 2 pixels).
+    height : int
+        The height of the texture in pixels.
+    """
+    row_bytes = width // 2
+    for y in range(height):
+        rs = offset + y * row_bytes
+        row = bytearray(data[rs : rs + row_bytes])
+        row.reverse()
+        for i in range(len(row)):
+            row[i] = ((row[i] & 0x0F) << 4) | ((row[i] & 0xF0) >> 4)
+        data[rs : rs + row_bytes] = row
+
+
+def flip_ia8_horizontal(
+    data: bytearray, offset: int, width: int, height: int, row_pitch: int | None = None
+) -> None:
+    """
+    Flip an IA8 texture horizontally (left-right mirror) in place.
+
+    Each pixel is 1 byte. Handles TMEM interleave (XOR 4 on odd rows) by deinterleaving before
+    flip and re-interleaving after.
+
+    Parameters
+    ----------
+    data : bytearray
+        The track data containing the texture to modify in place.
+    offset : int
+        The byte offset within `data` where the texture starts.
+    width : int
+        The width of the texture in pixels.
+    height : int
+        The height of the texture in pixels.
+    row_pitch : int | None
+        The number of bytes between the start of each row in memory. If ``None``, defaults to width
+        (no padding).
+    """
+    if row_pitch is None:
+        row_pitch = width
+    for y in range(height):
+        rs = offset + y * row_pitch
+        # Deinterleave odd rows (swap 4-byte halves in each 8-byte group).
+        if y & 1:
+            for i in range(0, row_pitch, 8):
+                a = data[rs + i : rs + i + 4]
+                b = data[rs + i + 4 : rs + i + 8]
+                data[rs + i : rs + i + 4] = b
+                data[rs + i + 4 : rs + i + 8] = a
+        # Flip visible pixels.
+        row = bytearray(data[rs : rs + width])
+        row.reverse()
+        data[rs : rs + width] = row
+        # Re-interleave odd rows.
+        if y & 1:
+            for i in range(0, row_pitch, 8):
+                a = data[rs + i : rs + i + 4]
+                b = data[rs + i + 4 : rs + i + 8]
+                data[rs + i : rs + i + 4] = b
+                data[rs + i + 4 : rs + i + 8] = a
+
+
+def fix_coastline_banner_vertices(td: bytearray, pb: int, ds: int) -> None:
+    """
+    Fix Coastline banner by reversing S coordinates on mirrored quads.
+
+    Coastline's banner uses a symmetric mesh where both STA and TRA textures are mapped to
+    overlapping front/back face quads. The axis permutation in noclip swaps left/right, making one
+    set of quads appear mirrored.
+
+    Fix: reverse S coordinates (S = S_max - S) on the quads that appear on the wrong side in noclip
+    (STA Quad1 v16-19, TRA Quad2 v28-31).
+
+    Parameters
+    ----------
+    td : bytearray
+        The track data to modify in place.
+    pb : int
+        The pointer base address for the track data (DRAM address corresponding to td[0]).
+    ds : int
+        The size of the track data in bytes.
+    """
+    # VTX data address from DL at 0x0a6c08: 0x800cc900
+    vtx_addr = 0x800CC900
+    vtx_off = vtx_addr - pb
+    if vtx_off < 0 or vtx_off + 32 * 16 > ds:
+        return
+    s_max = 2048  # 64 pixels * 32 (fixed point 10.5)
+    # Reverse S on STA Quad1 (v16-19) and TRA Quad2 (v28-31)
+    for vi in (16, 17, 18, 19, 28, 29, 30, 31):
+        s_off = vtx_off + vi * 16 + 8  # S is at byte 8 in each 16-byte vertex
+        s_val = struct.unpack_from('>h', td, s_off)[0]
+        s_new = s_max - s_val
+        struct.pack_into('>h', td, s_off, s_new)
+    # Workaround: Cancel the FIRST STA draw (left half) and make the FIRST TRA draw
+    # (left half, normally back-facing/culled) front-facing instead.
+    # Result: left half = TRA (flipped to ART), right half = STA → "ART" + "STA" = START
+    # NOP the first STA TRI2 at 0x0a6c90 (replace with RDPPIPESYNC).
+    if ds >= 0x0A6C90 + 8:
+        struct.pack_into('>I', td, 0x0A6C90, 0xE7000000)  # RDPPIPESYNC
+        struct.pack_into('>I', td, 0x0A6C94, 0x00000000)
+    # Reverse winding of TRA TRI2 #1 at 0x0a6cc8 to make it front-facing.
+    # Original: (24,25,26)(24,26,27) → Reversed: (24,26,25)(24,27,26)
+    if ds >= 0x0A6CC8 + 8:
+        struct.pack_into('>I', td, 0x0A6CC8, 0xB1303432)  # (24,26,25)
+        struct.pack_into('>I', td, 0x0A6CCC, 0x00303634)  # (24,27,26)
+    # Flip TRA texture horizontally so "TRA" reads as "ART".
+    tra_tex_off = 0x800733D8 - pb
+    if tra_tex_off + 1024 <= ds:
+        flip_ci4_horizontal(td, tra_tex_off, 64, 32)
+        # Also flip mipmaps.
+        mip_off = tra_tex_off + 1024
+        for level in range(1, 3):
+            mw, mh = 64 >> level, 32 >> level
+            if mw < MIN_MIP_DIM or mh < 1:
+                break
+            flip_ci4_horizontal(td, mip_off, mw, mh)
+            mip_off += (mw * mh) // 2
+
+
+def zero_out_textures(td: bytearray, pb: int, ds: int, track_idx: int) -> None:
+    """
+    Zero out specific texture data to hide unwanted elements per track.
+
+    Parameters
+    ----------
+    td : bytearray
+        The track data to modify in place.
+    pb : int
+        The pointer base address for the track data (DRAM address corresponding to td[0]).
+    ds : int
+        The size of the track data in bytes.
+    track_idx : int
+        The track index, used to look up the relevant textures to zero out.
+    """
+    # Textures to zero out: (track_idx, DRAM_addr, size_in_bytes)
+    # Season Winner: RALLY Champion banner + camera flash boxes + their palettes
+    zero_textures = {
+        10: (
+            (0x8003ED38, 0x400),  # RALLY Champion banner texture
+            (0x80043650, 0x400),  # Left or right side of banner texture
+            (0x80043830, 0x400),  # Left or right side of banner texture
+            (0x800266D8, 0x20),  # RALLY Champion palette (16 entries RGBA5551)
+            (0x80026778, 0x20),  # Camera flash palette (16 entries RGBA5551)
+        ),
+    }
+    textures = zero_textures.get(track_idx, ())
+    for addr, size in textures:
+        if addr < pb or addr >= pb + ds:
+            continue
+        off = addr - pb
+        sz = min(size, ds - off)
+        td[off : off + sz] = b'\x00' * sz
+        log.debug('  Zeroed 0x%x bytes at 0x%08x.', sz, addr)
+
+
+def _banner_tex_total_size(w: int, h: int, fmt: str = 'ci4') -> int:
+    # Compute total size of a banner texture including mipmaps.
+    if fmt == 'ia8':
+        return w * h  # No mipmaps for IA8 banners.
+    s = (w * h) // 2
+    for lv in range(1, 3):
+        mw, mh = w >> lv, h >> lv
+        if mw < MIN_MIP_DIM or mh < 1:
+            break
+        s += (mw * mh) // 2
+    return s
+
+
+def _swap_banner_halves(
+    td: bytearray, pb: int, ds: int, a: BannerTexEntry, b: BannerTexEntry
+) -> None:
+    # Swap two banner texture halves in track data.
+    a_off = a.addr - pb
+    b_off = b.addr - pb
+    a_size = _banner_tex_total_size(a.width, a.height, a.fmt)
+    b_size = _banner_tex_total_size(b.width, b.height, b.fmt)
+    if a_size == b_size and a_off + a_size <= ds and b_off + b_size <= ds:
+        a_data = bytes(td[a_off : a_off + a_size])
+        b_data = bytes(td[b_off : b_off + b_size])
+        td[a_off : a_off + a_size] = b_data
+        td[b_off : b_off + b_size] = a_data
+
+
+def flip_banner_textures(td: bytearray, pb: int, ds: int, track_idx: int) -> None:
+    """
+    Flip banner CI4 textures horizontally to correct mirrored text.
+
+    The START banner text is composed of two CI4 64x32 textures (e.g. "ART" and "STA" halves). These
+    addresses are known per track from the texture viewer's cache indices.
+
+    Parameters
+    ----------
+    td : bytearray
+        The track data to modify in place.
+    pb : int
+        The pointer base address for the track data (DRAM address corresponding to ``td[0]``).
+    ds : int
+        The size of the track data in bytes.
+    track_idx : int
+        The track index, used to look up the relevant banner texture addresses.
+    """
+    # Known banner texture addresses per track (DRAM addresses).
+    # Format is CI4 by default, or IA8 if specified.
+    banner_textures: dict[int, tuple[BannerTexEntry, ...]] = {
+        0: (BannerTexEntry(0x80082538, 64, 32), BannerTexEntry(0x80082A78, 64, 32)),  # Desert
+        1: (BannerTexEntry(0x800957C0, 64, 32), BannerTexEntry(0x80095D00, 64, 32)),  # Mountain
+        # Coastline (2): symmetric overlapping mesh - both textures cover
+        # full banner with cutout alpha compositing. Needs vertex S-coord
+        # fix, not texture flip.
+        3: (BannerTexEntry(0x800822A0, 126, 32, 'ia8', 128),),  # Strip Mine (IA8)
+        4: (BannerTexEntry(0x80092F90, 64, 32), BannerTexEntry(0x800934D0, 64, 32)),  # Jungle
+        10: (),  # Season Winner: hidden via palette zeroing.
+    }
+    textures = banner_textures.get(track_idx, ())
+    # Step 1: Flip each texture horizontally.
+    for entry in textures:
+        if entry.addr < pb or entry.addr >= pb + ds:
+            continue
+        tex_off = entry.addr - pb
+        if entry.fmt == 'ia8':
+            pitch = entry.row_pitch if entry.row_pitch is not None else entry.width
+            size = pitch * entry.height
+            if tex_off + size > ds:
+                continue
+            flip_ia8_horizontal(td, tex_off, entry.width, entry.height, pitch)
+        else:
+            size = (entry.width * entry.height) // 2
+            if tex_off + size > ds:
+                continue
+            flip_ci4_horizontal(td, tex_off, entry.width, entry.height)
+            # Also flip mipmap levels.
+            mip_off = tex_off + size
+            for level in range(1, 3):
+                mw, mh = entry.width >> level, entry.height >> level
+                if mw < MIN_MIP_DIM or mh < 1:
+                    break
+                flip_ci4_horizontal(td, mip_off, mw, mh)
+                mip_off += (mw * mh) // 2
+    # Step 2: Swap the two texture halves so they appear on the correct
+    # side of the banner.
+    if len(textures) == BANNER_HALVES:
+        _swap_banner_halves(td, pb, ds, textures[0], textures[1])
+
+
+def build_tgr2(
+    td: bytearray,
+    pb: int,
+    ds: int,
+    sky_dl_off: int,
+    inst_off: int,
+    inst_cnt: int,
+    winter_overrides: Sequence[tuple[int, int, bytes]],
+    anim_tex_channels: Sequence[dict[str, Any]] | None = None,
+) -> bytearray:
+    """
+    Build a TGR2 file from track data, winter overrides, and animated textures.
+
+    Parameters
+    ----------
+    td : bytearray
+        The track data with summer palettes applied.
+    pb : int
+        The pointer base address for the track data (DRAM address corresponding to td[0]).
+    ds : int
+        The size of the track data in bytes.
+    sky_dl_off : int
+        The byte offset within track data where the sky DL starts, or 0 if not present.
+    inst_off : int
+        The byte offset within track data where the instance table starts.
+    inst_cnt : int
+        The number of instances in the instance table.
+    winter_overrides : Sequence[tuple[int, int, bytes]]
+        List of (dest_off, size, winter_data) tuples for the winter override table.
+    anim_tex_channels : Sequence[dict] | None
+        List of animated texture channels, where each channel is a dict with keys:``dest_offset``,
+        ``tex_size``, and ``keyframes`` (sequence of dicts with keys ``time`` and ``tex_data``).
+
+    Returns
+    -------
+    bytearray
+        The complete TGR2 file data.
+    """
+    data_offset = TGR2_HEADER_SIZE
+    winter_table_offset = data_offset + ds
+    winter_blob = bytearray()
+    for dest_off, size, data in winter_overrides:
+        winter_blob.extend(struct.pack('<I', dest_off))
+        winter_blob.extend(struct.pack('<H', size))
+        winter_blob.extend(struct.pack('<H', 0))
+        winter_blob.extend(data)
+    # Build animated texture blob. Starts with a channel count word, followed by per-channel headers
+    # (dest offset, texture size, keyframe count) and then each keyframe's time word and raw texture
+    # data.
+    anim_tex_blob = bytearray()
+    anim_channels = anim_tex_channels or ()
+    anim_tex_blob.extend(struct.pack('<I', len(anim_channels)))
+    for ch in anim_channels:
+        anim_tex_blob.extend(struct.pack('<I', ch['dest_offset']))
+        anim_tex_blob.extend(struct.pack('<I', ch['tex_size']))
+        anim_tex_blob.extend(struct.pack('<I', len(ch['keyframes'])))
+        for kf in ch['keyframes']:
+            anim_tex_blob.extend(struct.pack('<I', kf['time']))
+            anim_tex_blob.extend(kf['tex_data'])
+    anim_tex_offset = winter_table_offset + len(winter_blob)
+    header = bytearray(TGR2_HEADER_SIZE)
+    struct.pack_into('<I', header, 0, TGR2_MAGIC)
+    struct.pack_into('<I', header, 4, 1)  # Version.
+    struct.pack_into('<I', header, 8, pb)
+    struct.pack_into('<I', header, 12, ds)
+    struct.pack_into('<I', header, 16, inst_off)
+    struct.pack_into('<I', header, 20, inst_cnt)
+    struct.pack_into('<I', header, 24, sky_dl_off)
+    struct.pack_into('<I', header, 28, data_offset)
+    struct.pack_into('<I', header, 32, winter_table_offset)
+    struct.pack_into('<I', header, 36, len(winter_overrides))
+    # Use reserved fields for animated textures.
+    struct.pack_into('<I', header, 40, anim_tex_offset)
+    struct.pack_into('<I', header, 44, len(anim_channels))
+    return header + bytes(td) + winter_blob + anim_tex_blob
+
+
+def main() -> int:
+    """Export Top Gear Rally track data as TGR2 files."""
+    parser = argparse.ArgumentParser(
+        description='Export Top Gear Rally tracks for noclip.website.',
+    )
+    parser.add_argument(
+        'rom',
+        nargs='?',
+        default=DEFAULT_ROM_PATH,
+        type=Path,
+        help='Path to USA N64 ROM.',
+    )
+    parser.add_argument(
+        'output_dir',
+        nargs='?',
+        default=DEFAULT_OUTPUT_DIR,
+        type=Path,
+        help='Directory to write output TGR2 files.',
+    )
+    parser.add_argument(
+        '-d',
+        '--debug',
+        action='store_true',
+        help='Enable debug log messages.',
+    )
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format='%(levelname)s: %(message)s',
+    )
+    rom_path: Path = args.rom
+    if not rom_path.exists():
+        log.error('ROM not found: %s', rom_path)
+        return 1
+    rom = rom_path.read_bytes()
+    digest = hashlib.sha256(rom).hexdigest()
+    if digest != ROM_SHA256:
+        log.error('ROM SHA-256 mismatch: expected %s, got %s.', ROM_SHA256, digest)
+        return 1
+    log.info('ROM: %d bytes, SHA-256 verified.', len(rom))
+    output_dir: Path = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for track_idx, geom_offset in sorted(TRACK_ROM_OFFSETS.items()):
+        log.info('Track %d (geom @ 0x%06x)', track_idx, geom_offset)
+        # Decompress track data from ROM.
+        td, stream_end = decompress_track(rom, geom_offset)
+        pb = POINTER_BASE
+        ds = len(td)
+        log.info('  Decompressed %d bytes, stream data @ 0x%06x', ds, stream_end)
+        # Read instance table info from track header.
+        inst_ptr = r32(td, 0x60)
+        inst_cnt = r32(td, 0x64)
+        inst_off = inst_ptr - pb
+        sky_ptr = r32(td, 0x50)
+        sky_dl_off = sky_ptr - pb if sky_ptr >= pb and sky_ptr < pb + ds else 0
+        log.debug(
+            '  Instances: %d at offset 0x%06x, sky DL at 0x%06x.', inst_cnt, inst_off, sky_dl_off
+        )
+        # Patch streaming palettes/textures.
+        summer_td, winter_overrides = patch_palettes(td, pb, ds, rom, stream_end)
+        log.info('  Patched palettes: %d winter overrides', len(winter_overrides))
+        # Flip banner CI4 textures horizontally to correct mirrored text caused by the N64->GL
+        # coordinate axis permutation (except Coastline).
+        flip_banner_textures(summer_td, pb, ds, track_idx)
+        log.info('  Banner textures flipped for track %d.', track_idx)
+        # Coastline: fix banner via vertex S coordinate reversal on mirrored quads.
+        if track_idx == TRACK_COASTLINE:
+            fix_coastline_banner_vertices(summer_td, pb, ds)
+            log.info('  Coastline banner vertices fixed.')
+        # Zero out specific textures that should be hidden on certain tracks (e.g., Season Winner's
+        # RALLY Champion banner and related textures).
+        zero_out_textures(summer_td, pb, ds, track_idx)
+        # Extract animated texture channels (waterfalls, torches, bird wings, etc.).
+        if anim_tex := extract_animated_textures(td, pb, ds, rom, stream_end):
+            total_kf = sum(len(ch['keyframes']) for ch in anim_tex)
+            log.info(
+                '  Animated textures: %d channels, %d total keyframes',
+                len(anim_tex),
+                total_kf,
+            )
+        # Build TGR2 output.
+        output = build_tgr2(
+            summer_td, pb, ds, sky_dl_off, inst_off, inst_cnt, winter_overrides, anim_tex
+        )
+        output_path = output_dir / f'track_{track_idx}.bin'
+        Path(output_path).write_bytes(output)
+        log.info('  Output: %d bytes -> %s', len(output), output_path)
+    log.info('Done.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/TopGearRally/f3dex.ts
+++ b/src/TopGearRally/f3dex.ts
@@ -1,0 +1,1103 @@
+import * as RDP from "../Common/N64/RDP.js";
+
+import ArrayBufferSlice from "../ArrayBufferSlice.js";
+import { nArray, assert, hexzero } from "../util.js";
+import {
+    ImageFormat,
+    getImageFormatName,
+    ImageSize,
+    getImageSizeName,
+    getSizBitsPerPixel,
+} from "../Common/N64/Image.js";
+import { GfxCullMode } from "../gfx/platform/GfxPlatform.js";
+import { loadVertexFromView } from "../Common/N64/RSP.js";
+
+// Interpreter for N64 F3DEX microcode.
+
+/**
+ * RSP texture state tracking whether texturing is enabled and
+ * tile parameters.
+ */
+export class TextureState {
+    /** Whether texturing is enabled. */
+    public on = false;
+    /** Active tile index. */
+    public tile = 0;
+    /** Mipmap level. */
+    public level = 0;
+    /** S-axis texture coordinate scale. */
+    public s = 0;
+    /** T-axis texture coordinate scale. */
+    public t = 0;
+
+    /**
+     * Set all texture state fields at once.
+     * @param {boolean} on Whether texturing is enabled.
+     * @param {number} tile Active tile index.
+     * @param {number} level Mipmap level.
+     * @param {number} s S-axis scale.
+     * @param {number} t T-axis scale.
+     */
+    public set(on: boolean, tile: number, level: number, s: number, t: number): void {
+        this.on = on;
+        this.tile = tile;
+        this.level = level;
+        this.s = s;
+        this.t = t;
+    }
+
+    /**
+     * Copy all fields from another TextureState.
+     * @param {TextureState} o Source state.
+     */
+    public copy(o: TextureState): void {
+        this.set(o.on, o.tile, o.level, o.s, o.t);
+    }
+}
+
+/** RDP texture image state set by G_SETTIMG. */
+export class TextureImageState {
+    /** Image format (G_IM_FMT). */
+    public fmt = 0;
+    /** Image size (G_IM_SIZ). */
+    public siz = 0;
+    /** Image width in pixels. */
+    public w = 0;
+    /** DRAM address of the texture image. */
+    public addr = 0;
+
+    /**
+     * Set all texture image state fields at once.
+     * @param {number} fmt Image format.
+     * @param {number} siz Image size.
+     * @param {number} w Width in pixels.
+     * @param {number} addr DRAM address.
+     */
+    public set(fmt: number, siz: number, w: number, addr: number): void {
+        this.fmt = fmt;
+        this.siz = siz;
+        this.w = w;
+        this.addr = addr;
+    }
+}
+
+/**
+ * N64 RSP vertex with position, texture coordinates, colour/normal,
+ * and alpha.
+ */
+export class Vertex {
+    /** X position. */
+    public x = 0;
+    /** Y position. */
+    public y = 0;
+    /** Z position. */
+    public z = 0;
+    /** Texture S coordinate. */
+    public tx = 0;
+    /** Texture T coordinate. */
+    public ty = 0;
+    /** Colour or normal component 0. */
+    public c0 = 0;
+    /** Colour or normal component 1. */
+    public c1 = 0;
+    /** Colour or normal component 2. */
+    public c2 = 0;
+    /** Alpha component. */
+    public a = 0;
+    /** Matrix stack index for vertex transformation. */
+    public matrixIndex = 0;
+
+    /**
+     * Copy all fields from another vertex.
+     * @param {Vertex} v Source vertex.
+     */
+    public copy(v: Vertex): void {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = v.z;
+        this.matrixIndex = v.matrixIndex;
+        this.tx = v.tx;
+        this.ty = v.ty;
+        this.c0 = v.c0;
+        this.c1 = v.c1;
+        this.c2 = v.c2;
+        this.a = v.a;
+    }
+}
+
+/** Vertex used during display list interpretation before output deduplication. */
+export class StagingVertex extends Vertex {
+    /** Index into the shared output vertex array, or -1 if not yet committed. */
+    public outputIndex = -1;
+
+    /**
+     * Loads vertex data from a DataView at the given byte offset.
+     * @param {DataView} view Source data view.
+     * @param {number} offs Byte offset into the view.
+     */
+    public setFromView(view: DataView, offs: number): void {
+        this.outputIndex = -1;
+        loadVertexFromView(this, view, offs);
+    }
+}
+
+/**
+ * Returns a human-readable string combining image format and size names.
+ * @param {ImageFormat} fmt Image format.
+ * @param {ImageSize} siz Image size.
+ * @returns {string} Combined format and size name.
+ */
+export function getImageFormatString(fmt: ImageFormat, siz: ImageSize): string {
+    return `${getImageFormatName(fmt)}${getImageSizeName(siz)}`;
+}
+
+/** Single draw call with a single pipeline state. */
+export class DrawCall {
+    /** RSP geometry mode flags for this draw call. */
+    public SP_GeometryMode = 0;
+    /** Texture state snapshot for this draw call. */
+    public SP_TextureState = new TextureState();
+    /** RDP OtherModeL register value. */
+    public DP_OtherModeL = 0;
+    /** RDP OtherModeH register value. */
+    public DP_OtherModeH = 0;
+    /** RDP colour combiner parameters. */
+    public DP_Combine: RDP.CombineParams;
+
+    /** Indices into the texture cache for this draw call. */
+    public textureIndices: number[] = [];
+
+    /** Starting index in the shared index buffer. */
+    public firstIndex = 0;
+    /** Number of indices in this draw call. */
+    public indexCount = 0;
+}
+
+/** Shared output buffers for vertices, indices, and textures across draw calls. */
+export class RSPSharedOutput {
+    /** Cache of decoded textures referenced by draw calls. */
+    public textureCache = new RDP.TextureCache();
+    /** All output vertices. */
+    public vertices: Vertex[] = [];
+    /** Triangle index buffer referencing vertices. */
+    public indices: number[] = [];
+
+    /**
+     * Loads all vertices from a contiguous vertex data buffer.
+     * @param {DataView} vertexData Source vertex data.
+     */
+    public setVertexBufferFromData(vertexData: DataView): void {
+        const scratchVertex = new StagingVertex();
+
+        // Ensure we don't read past the end (each vertex is 0x10 bytes).
+        const end = vertexData.byteLength - 0x0f;
+        for (let offs = 0; offs < end; offs += 0x10) {
+            scratchVertex.setFromView(vertexData, offs);
+            this.loadVertex(scratchVertex);
+        }
+    }
+
+    /**
+     * Commits a staging vertex to the output array if not already
+     * committed.
+     * @param {StagingVertex} v Staging vertex to commit.
+     */
+    public loadVertex(v: StagingVertex): void {
+        if (v.outputIndex === -1) {
+            const n = new Vertex();
+            n.copy(v);
+            this.vertices.push(n);
+            v.outputIndex = this.vertices.length - 1;
+        }
+    }
+}
+
+/** Collects draw calls produced during display list interpretation. */
+export class RSPOutput {
+    /** All completed draw calls. */
+    public drawCalls: DrawCall[] = [];
+
+    /** The draw call currently being built. */
+    public currentDrawCall = new DrawCall();
+
+    /**
+     * Creates a new draw call starting at the given index offset.
+     * @param {number} firstIndex Starting index in the shared buffer.
+     * @returns {DrawCall} The newly created draw call.
+     */
+    public newDrawCall(firstIndex: number): DrawCall {
+        this.currentDrawCall = new DrawCall();
+        this.currentDrawCall.firstIndex = firstIndex;
+        this.drawCalls.push(this.currentDrawCall);
+        return this.currentDrawCall;
+    }
+}
+
+/** RSP geometry mode bit flags. */
+export enum RSP_Geometry {
+    /** Z-buffer enable. */
+    G_ZBUFFER = 1 << 0,
+    /** Shade enable. */
+    G_SHADE = 1 << 2,
+    /** Smooth (Gouraud) shading. */
+    G_SHADING_SMOOTH = 1 << 9,
+    /** Cull front-facing triangles. */
+    G_CULL_FRONT = 1 << 12,
+    /** Cull back-facing triangles. */
+    G_CULL_BACK = 1 << 13,
+    /** Fog enable. */
+    G_FOG = 1 << 16,
+    /** Lighting enable. */
+    G_LIGHTING = 1 << 17,
+    /** Texture coordinate generation. */
+    G_TEXTURE_GEN = 1 << 18,
+    /** Linear texture coordinate generation. */
+    G_TEXTURE_GEN_LINEAR = 1 << 19,
+    /** Clipping enable. */
+    G_CLIPPING = 1 << 23,
+}
+
+/** Byte offsets within a vertex for G_MODIFYVTX. */
+export enum MODIFYVTX_Locations {
+    /** RGBA colour offset. */
+    G_MWO_POINT_RGBA = 0x10,
+    /** ST texture coordinate offset. */
+    G_MWO_POINT_ST = 0x14,
+    /** XY screen coordinate offset. */
+    G_MWO_POINT_XYSCREEN = 0x18,
+    /** Z screen coordinate offset. */
+    G_MWO_POINT_ZSCREEN = 0x1c,
+}
+
+/**
+ * Translates RSP geometry mode cull flags to a GfxCullMode value.
+ * @param {number} m Geometry mode flags.
+ * @returns {GfxCullMode} Translated cull mode.
+ */
+export function translateCullMode(m: number): GfxCullMode {
+    const cullFront = !!(m & RSP_Geometry.G_CULL_FRONT);
+    const cullBack = !!(m & RSP_Geometry.G_CULL_BACK);
+    if (cullFront && cullBack) {
+        throw new Error("whoops");
+    } else if (cullFront) {
+        return GfxCullMode.Front;
+    } else if (cullBack) {
+        return GfxCullMode.Back;
+    } else {
+        return GfxCullMode.None;
+    }
+}
+
+/** Interface for RSP state machines that can interpret F3DEX display list commands. */
+export interface RSPStateInterface {
+    /** Segment address to buffer mappings. */
+    segmentBuffers: ArrayBufferSlice[];
+
+    /**
+     * Finalizes interpretation and returns the output.
+     * @returns {any} Interpretation output.
+     */
+    finish: () => unknown;
+    /**
+     * Enables the given geometry mode bits.
+     * @param {number} mask Bits to set.
+     */
+    gSPSetGeometryMode: (mask: number) => void;
+    /**
+     * Clears the given geometry mode bits.
+     * @param {number} mask Bits to clear.
+     */
+    gSPClearGeometryMode: (mask: number) => void;
+    /**
+     * Resets the matrix stack depth to the given value.
+     * @param {number} value New stack depth.
+     */
+    gSPResetMatrixStackDepth: (value: number) => void;
+    /**
+     * Sets the texture state for subsequent triangles.
+     * @param {boolean} on Whether texturing is enabled.
+     * @param {number} tile Active tile index.
+     * @param {number} level Mipmap level.
+     * @param {number} s S-axis scale.
+     * @param {number} t T-axis scale.
+     */
+    gSPTexture: (on: boolean, tile: number, level: number, s: number, t: number) => void;
+    /**
+     * Loads vertices from DRAM into the vertex cache.
+     * @param {number} dramAddr DRAM address of vertex data.
+     * @param {number} n Number of vertices to load.
+     * @param {number} v0 Starting vertex cache index.
+     */
+    gSPVertex: (dramAddr: number, n: number, v0: number) => void;
+    /**
+     * Modifies a field of a cached vertex in-place.
+     * @param {number} vtx Vertex cache index.
+     * @param {number} where Field byte offset.
+     * @param {number} val New value.
+     */
+    gSPModifyVertex: (vtx: number, where: number, val: number) => void;
+    /**
+     * Emits a single triangle from three vertex cache indices.
+     * @param {number} i0 First vertex index.
+     * @param {number} i1 Second vertex index.
+     * @param {number} i2 Third vertex index.
+     */
+    gSPTri: (i0: number, i1: number, i2: number) => void;
+    /**
+     * Sets the texture image source for subsequent load commands.
+     * @param {number} fmt Image format.
+     * @param {number} siz Image size.
+     * @param {number} w Width in pixels.
+     * @param {number} addr DRAM address.
+     */
+    gDPSetTextureImage: (fmt: number, siz: number, w: number, addr: number) => void;
+    /**
+     * Configures a tile descriptor in the RDP tile table.
+     * @param {number} fmt Image format.
+     * @param {number} siz Image size.
+     * @param {number} line Words per row.
+     * @param {number} tmem TMEM offset.
+     * @param {number} tile Tile index.
+     * @param {number} palette Palette index.
+     * @param {number} cmt T-axis clamp/mirror/wrap.
+     * @param {number} maskt T-axis mask.
+     * @param {number} shiftt T-axis shift.
+     * @param {number} cms S-axis clamp/mirror/wrap.
+     * @param {number} masks S-axis mask.
+     * @param {number} shifts S-axis shift.
+     */
+    gDPSetTile: (
+        fmt: number,
+        siz: number,
+        line: number,
+        tmem: number,
+        tile: number,
+        palette: number,
+        cmt: number,
+        maskt: number,
+        shiftt: number,
+        cms: number,
+        masks: number,
+        shifts: number,
+    ) => void;
+    /**
+     * Loads a TLUT (palette) into TMEM.
+     * @param {number} tile Tile index.
+     * @param {number} count Number of palette entries.
+     */
+    gDPLoadTLUT: (tile: number, count: number) => void;
+    /**
+     * Loads a contiguous block of texture data into TMEM.
+     * @param {number} tileIndex Tile index.
+     * @param {number} uls Upper-left S coordinate.
+     * @param {number} ult Upper-left T coordinate.
+     * @param {number} lrs Lower-right S coordinate.
+     * @param {number} dxt DXT value.
+     */
+    gDPLoadBlock: (tileIndex: number, uls: number, ult: number, lrs: number, dxt: number) => void;
+    /**
+     * Sets the tile size (texture coordinate clamp/wrap bounds).
+     * @param {number} tile Tile index.
+     * @param {number} uls Upper-left S coordinate.
+     * @param {number} ult Upper-left T coordinate.
+     * @param {number} lrs Lower-right S coordinate.
+     * @param {number} lrt Lower-right T coordinate.
+     */
+    gDPSetTileSize: (tile: number, uls: number, ult: number, lrs: number, lrt: number) => void;
+    /**
+     * Sets bits in the RDP OtherModeL register.
+     * @param {number} sft Bit shift.
+     * @param {number} len Bit length.
+     * @param {number} w1 Value.
+     */
+    gDPSetOtherModeL: (sft: number, len: number, w1: number) => void;
+    /**
+     * Sets bits in the RDP OtherModeH register.
+     * @param {number} sft Bit shift.
+     * @param {number} len Bit length.
+     * @param {number} w1 Value.
+     */
+    gDPSetOtherModeH: (sft: number, len: number, w1: number) => void;
+    /**
+     * Sets the RDP color combiner parameters.
+     * @param {number} w0 High word.
+     * @param {number} w1 Low word.
+     */
+    gDPSetCombine: (w0: number, w1: number) => void;
+    /**
+     * Handles G_MOVEMEM commands (optional).
+     * @param {number} w0 High word.
+     * @param {number} w1 Low word.
+     */
+    gMoveMem?: (w0: number, w1: number) => void;
+}
+
+/** Default RSP state machine that interprets F3DEX commands into draw calls. */
+export class RSPState implements RSPStateInterface {
+    /**
+     * When true, gSPVertex loads vertex data from segment buffers on-demand
+     * instead of assuming vertices are preloaded.
+     */
+    public loadVerticesOnDemand = false;
+
+    private readonly output = new RSPOutput();
+
+    private stateChanged = false;
+    private vertexCache = nArray(64, () => 0);
+
+    private SP_GeometryMode = 0;
+    private readonly SP_TextureState = new TextureState();
+    private SP_MatrixStackDepth = 0;
+
+    private DP_OtherModeL = 0;
+    private DP_OtherModeH = 0;
+    private DP_CombineL = 0;
+    private DP_CombineH = 0;
+    private readonly DP_TextureImageState = new TextureImageState();
+    private readonly DP_TileState = nArray(8, () => new RDP.TileState());
+    private readonly DP_TMemTracker: Map<number, number> = new Map();
+
+    /**
+     * Creates an RSP state with the given segment buffers and
+     * shared output.
+     * @param {ArrayBufferSlice[]} segmentBuffers Segment buffers.
+     * @param {RSPSharedOutput} sharedOutput Shared output state.
+     */
+    public constructor(
+        public segmentBuffers: ArrayBufferSlice[],
+        public sharedOutput: RSPSharedOutput,
+    ) {}
+
+    /**
+     * Finalizes interpretation and returns the RSPOutput, or null
+     * if empty.
+     * @returns {(RSPOutput|null)} Output or null if no draw calls.
+     */
+    public finish(): RSPOutput | null {
+        if (this.output.drawCalls.length === 0) {
+            return null;
+        }
+        return this.output;
+    }
+
+    /** @inheritdoc */
+    public gSPSetGeometryMode(mask: number): void {
+        this._setGeometryMode(this.SP_GeometryMode | mask);
+    }
+
+    /** @inheritdoc */
+    public gSPClearGeometryMode(mask: number): void {
+        this._setGeometryMode(this.SP_GeometryMode & ~mask);
+    }
+
+    /** @inheritdoc */
+    public gSPResetMatrixStackDepth(value: number): void {
+        this.SP_MatrixStackDepth = value;
+    }
+
+    /** @inheritdoc */
+    public gSPTexture(on: boolean, tile: number, level: number, s: number, t: number): void {
+        // This is the texture we're using to rasterize triangles going forward.
+        this.SP_TextureState.set(on, tile, level, s / 0x10000, t / 0x10000);
+        this.stateChanged = true;
+    }
+
+    /** @inheritdoc */
+    public gSPVertex(dramAddr: number, n: number, v0: number): void {
+        const addrIdx = dramAddr & 0x00ffffff;
+        const baseIndex = (addrIdx / 0x10) >>> 0;
+
+        if (this.loadVerticesOnDemand) {
+            // Load vertex data directly from the segment buffer on-demand.
+            // This is needed when the vertex buffer contains mixed
+            // data (DLs, textures, etc.).
+            const segBuffer = this.segmentBuffers[(dramAddr >>> 24) & 0xff];
+            const view = segBuffer.createDataView();
+            const scratchVertex = new StagingVertex();
+            for (let i = 0; i < n; i++) {
+                const offs = addrIdx + i * 0x10;
+                if (offs + 0x10 <= view.byteLength) {
+                    scratchVertex.setFromView(view, offs);
+                    // Ensure vertex slot exists (expand array if needed).
+                    while (this.sharedOutput.vertices.length <= baseIndex + i) {
+                        this.sharedOutput.vertices.push(new Vertex());
+                    }
+                    const vtx = this.sharedOutput.vertices[baseIndex + i];
+                    vtx.copy(scratchVertex);
+                    vtx.matrixIndex = this.SP_MatrixStackDepth;
+                }
+                this.vertexCache[v0 + i] = baseIndex + i;
+            }
+        } else {
+            // Preloaded mode: vertices already in sharedOutput.vertices.
+            for (let i = 0; i < n; i++) {
+                const vertexIndex = baseIndex + i;
+                this.vertexCache[v0 + i] = vertexIndex;
+                this.sharedOutput.vertices[vertexIndex].matrixIndex = this.SP_MatrixStackDepth;
+            }
+        }
+    }
+
+    /** @inheritdoc */
+    // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+    public gSPModifyVertex(_vtx: number, _where: number, _val: number): void {
+        console.error(
+            "gSPModifyVertex() is not supported by this RSPStateInterface implementation",
+        );
+    }
+
+    /** @inheritdoc */
+    public gSPTri(i0: number, i1: number, i2: number): void {
+        this.flushDrawCall();
+
+        this.sharedOutput.indices.push(
+            this.vertexCache[i0],
+            this.vertexCache[i1],
+            this.vertexCache[i2],
+        );
+        this.output.currentDrawCall.indexCount += 3;
+    }
+
+    /** @inheritdoc */
+    public gDPSetTextureImage(fmt: number, siz: number, w: number, addr: number): void {
+        this.DP_TextureImageState.set(fmt, siz, w, addr);
+    }
+
+    /** @inheritdoc */
+    public gDPSetTile(
+        fmt: number,
+        siz: number,
+        line: number,
+        tmem: number,
+        tile: number,
+        palette: number,
+        cmt: number,
+        maskt: number,
+        shiftt: number,
+        cms: number,
+        masks: number,
+        shifts: number,
+    ): void {
+        this.DP_TileState[tile].set(
+            fmt,
+            siz,
+            line,
+            tmem,
+            palette,
+            cmt,
+            maskt,
+            shiftt,
+            cms,
+            masks,
+            shifts,
+        );
+        this.stateChanged = true;
+    }
+
+    /** @inheritdoc */
+    public gDPLoadTLUT(tile: number, _count: number): void {
+        // Track the TMEM destination back to the originating DRAM address.
+        const tmemDst = this.DP_TileState[tile].tmem;
+        this.DP_TMemTracker.set(tmemDst, this.DP_TextureImageState.addr);
+    }
+
+    /** @inheritdoc */
+    public gDPLoadBlock(
+        tileIndex: number,
+        uls: number,
+        ult: number,
+        lrs: number,
+        dxt: number,
+    ): void {
+        // First, verify that we're loading the whole texture.
+        assert(uls === 0 && ult === 0);
+
+        const tile = this.DP_TileState[tileIndex];
+
+        if (dxt !== 0) {
+            // Compute the texture size from lrs/dxt. This is
+            // required for mipmapping to work correctly in B-K
+            // due to hackery.
+            const numWordsTotal = lrs + 1;
+            const numWordsInLine = (1 << 11) / dxt;
+            const numPixelsInLine = (numWordsInLine * 8 * 8) / getSizBitsPerPixel(tile.siz);
+            tile.lrs = (numPixelsInLine - 1) << 2;
+            tile.lrt = (numWordsTotal / numWordsInLine / 4 - 1) << 2;
+        }
+        // When DXT=0, tile dimensions come from SETTILESIZE, not LOADBLOCK.
+
+        // Track the TMEM destination back to the originating DRAM address.
+        this.DP_TMemTracker.set(tile.tmem, this.DP_TextureImageState.addr);
+        this.stateChanged = true;
+    }
+
+    /** @inheritdoc */
+    public gDPSetTileSize(tile: number, uls: number, ult: number, lrs: number, lrt: number): void {
+        this.DP_TileState[tile].setSize(uls, ult, lrs, lrt);
+    }
+
+    /** @inheritdoc */
+    public gDPSetOtherModeL(sft: number, len: number, w1: number): void {
+        const mask = ((1 << len) - 1) << sft;
+        const DP_OtherModeL = (this.DP_OtherModeL & ~mask) | (w1 & mask);
+        if (DP_OtherModeL !== this.DP_OtherModeL) {
+            this.DP_OtherModeL = DP_OtherModeL;
+            this.stateChanged = true;
+        }
+    }
+
+    /** @inheritdoc */
+    public gDPSetOtherModeH(sft: number, len: number, w1: number): void {
+        const mask = ((1 << len) - 1) << sft;
+        const DP_OtherModeH = (this.DP_OtherModeH & ~mask) | (w1 & mask);
+        if (DP_OtherModeH !== this.DP_OtherModeH) {
+            this.DP_OtherModeH = DP_OtherModeH;
+            this.stateChanged = true;
+        }
+    }
+
+    /** @inheritdoc */
+    public gDPSetCombine(w0: number, w1: number): void {
+        if (this.DP_CombineH !== w0 || this.DP_CombineL !== w1) {
+            this.DP_CombineH = w0;
+            this.DP_CombineL = w1;
+            this.stateChanged = true;
+        }
+    }
+
+    private _setGeometryMode(newGeometryMode: number): void {
+        if (this.SP_GeometryMode === newGeometryMode) {
+            return;
+        }
+        this.stateChanged = true;
+        this.SP_GeometryMode = newGeometryMode;
+    }
+
+    private _lookupTMEM(tmem: number): number | undefined {
+        // Exact match first.
+        const exact = this.DP_TMemTracker.get(tmem);
+        if (exact !== undefined) {
+            return exact;
+        }
+
+        // If not found, find the nearest lower TMEM entry.
+        // G_LOADBLOCK loads a contiguous region starting at a base TMEM offset.
+        // Render tiles may reference sub-regions at higher TMEM offsets within
+        // the same loaded block. The DRAM address offset = (tmem_diff * 8) bytes
+        // since each TMEM word is 8 bytes (64 bits).
+        let bestTmem = -1;
+        let bestAddr: number | undefined = undefined;
+        for (const [trackedTmem, addr] of this.DP_TMemTracker) {
+            if (trackedTmem <= tmem && trackedTmem > bestTmem) {
+                bestTmem = trackedTmem;
+                bestAddr = addr;
+            }
+        }
+        if (bestAddr !== undefined && bestTmem >= 0) {
+            return bestAddr + (tmem - bestTmem) * 8;
+        }
+        return bestAddr;
+    }
+
+    private translateTileTexture(tileIndex: number): number {
+        const tile = this.DP_TileState[tileIndex];
+
+        const dramAddr = this._lookupTMEM(tile.tmem);
+        if (dramAddr === undefined) {
+            return -1; // TMEM not loaded for this tile.
+        }
+
+        let dramPalAddr = 0;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+        if (tile.fmt === ImageFormat.G_IM_FMT_CI) {
+            const palTmem = 0x100 + (tile.palette << 4);
+            const palAddr = this._lookupTMEM(palTmem);
+            dramPalAddr = palAddr ?? 0;
+        }
+
+        // TGR texture data requires TMEM deinterleaving for correct decode.
+        return this.sharedOutput.textureCache.translateTileTexture(
+            this.segmentBuffers,
+            dramAddr,
+            dramPalAddr,
+            tile,
+            true,
+        );
+    }
+
+    private flushTextures(dc: DrawCall): void {
+        // If textures are not on, then we have no textures.
+        if (!this.SP_TextureState.on) {
+            return;
+        }
+
+        const lod_en = !!((this.DP_OtherModeH >>> 16) & 0x01);
+        if (lod_en) {
+            // TODO(jstpierre): Support mip-mapping.
+            assert(false);
+        } else {
+            // We're in TILE mode. Now check if we're in two-cycle mode.
+            const cycletype = RDP.getCycleTypeFromOtherModeH(this.DP_OtherModeH);
+            assert(
+                cycletype === RDP.OtherModeH_CycleType.G_CYC_1CYCLE ||
+                    cycletype === RDP.OtherModeH_CycleType.G_CYC_2CYCLE,
+            );
+
+            const tex0 = this.translateTileTexture(this.SP_TextureState.tile);
+            if (tex0 >= 0) {
+                dc.textureIndices.push(tex0);
+            }
+
+            if (this.SP_TextureState.level === 0 && RDP.combineParamsUsesT1(dc.DP_Combine)) {
+                const tex1 = this.translateTileTexture(this.SP_TextureState.tile + 1);
+                if (tex1 >= 0) {
+                    dc.textureIndices.push(tex1);
+                }
+            }
+        }
+    }
+
+    private flushDrawCall(): void {
+        if (this.stateChanged) {
+            this.stateChanged = false;
+
+            const dc = this.output.newDrawCall(this.sharedOutput.indices.length);
+            dc.SP_GeometryMode = this.SP_GeometryMode;
+            dc.SP_TextureState.copy(this.SP_TextureState);
+            dc.DP_Combine = RDP.decodeCombineParams(this.DP_CombineH, this.DP_CombineL);
+            dc.DP_OtherModeH = this.DP_OtherModeH;
+            dc.DP_OtherModeL = this.DP_OtherModeL;
+            this.flushTextures(dc);
+        }
+    }
+}
+
+/**
+ * F3DEX microcode GBI (Graphics Binary Interface) command opcodes.
+ */
+export enum F3DEX_GBI {
+    // DMA commands.
+    /** Load matrix. */
+    G_MTX = 0x01,
+    /** Move memory. */
+    G_MOVEMEM = 0x03,
+    /** Load vertices. */
+    G_VTX = 0x04,
+    /** Branch to display list. */
+    G_DL = 0x06,
+
+    // Immediate commands.
+    /** Single triangle. */
+    G_TRI1 = 0xbf,
+    /** Cull display list. */
+    G_CULLDL = 0xbe,
+    /** Pop matrix stack. */
+    G_POPMTX = 0xbd,
+    /** Move word. */
+    G_MOVEWORD = 0xbc,
+    /** Set texture parameters. */
+    G_TEXTURE = 0xbb,
+    /** Set OtherModeH bits. */
+    G_SETOTHERMODE_H = 0xba,
+    /** Set OtherModeL bits. */
+    G_SETOTHERMODE_L = 0xb9,
+    /** End display list. */
+    G_ENDDL = 0xb8,
+    /** Set geometry mode bits. */
+    G_SETGEOMETRYMODE = 0xb7,
+    /** Clear geometry mode bits. */
+    G_CLEARGEOMETRYMODE = 0xb6,
+    /** Draw 3D line. */
+    G_LINE3D = 0xb5,
+    /** RDP half word 1. */
+    G_RDPHALF_1 = 0xb4,
+    /** RDP half word 2. */
+    G_RDPHALF_2 = 0xb3,
+    /** Modify vertex. */
+    G_MODIFYVTX = 0xb2,
+    /** Two triangles. */
+    G_TRI2 = 0xb1,
+    /** Branch on Z. */
+    G_BRANCH_Z = 0xb0,
+    /** Load microcode. */
+    G_LOAD_UCODE = 0xaf,
+
+    // RDP commands.
+    /** Set colour image. */
+    G_SETCIMG = 0xff,
+    /** Set Z image. */
+    G_SETZIMG = 0xfe,
+    /** Set texture image. */
+    G_SETTIMG = 0xfd,
+    /** Set colour combiner. */
+    G_SETCOMBINE = 0xfc,
+    /** Set environment colour. */
+    G_SETENVCOLOR = 0xfb,
+    /** Set primitive colour. */
+    G_SETPRIMCOLOR = 0xfa,
+    /** Set blend colour. */
+    G_SETBLENDCOLOR = 0xf9,
+    /** Set fog colour. */
+    G_SETFOGCOLOR = 0xf8,
+    /** Set fill colour. */
+    G_SETFILLCOLOR = 0xf7,
+    /** Fill rectangle. */
+    G_FILLRECT = 0xf6,
+    /** Set tile descriptor. */
+    G_SETTILE = 0xf5,
+    /** Load tile. */
+    G_LOADTILE = 0xf4,
+    /** Load block. */
+    G_LOADBLOCK = 0xf3,
+    /** Set tile size. */
+    G_SETTILESIZE = 0xf2,
+    /** Load TLUT (palette). */
+    G_LOADTLUT = 0xf0,
+    /** Set RDP other mode. */
+    G_RDPSETOTHERMODE = 0xef,
+    /** Set primitive depth. */
+    G_SETPRIMDEPTH = 0xee,
+    /** Set scissor rectangle. */
+    G_SETSCISSOR = 0xed,
+    /** Set colour convert. */
+    G_SETCONVERT = 0xec,
+    /** Set chroma key R. */
+    G_SETKEYR = 0xeb,
+    /** Set chroma key GB. */
+    G_SETKEYFB = 0xea,
+    /** RDP full sync. */
+    G_RDPFULLSYNC = 0xe9,
+    /** RDP tile sync. */
+    G_RDPTILESYNC = 0xe8,
+    /** RDP pipe sync. */
+    G_RDPPIPESYNC = 0xe7,
+    /** RDP load sync. */
+    G_RDPLOADSYNC = 0xe6,
+    /** Texture rectangle flipped. */
+    G_TEXRECTFLIP = 0xe5,
+    /** Texture rectangle. */
+    G_TEXRECT = 0xe4,
+}
+
+/**
+ * Interprets an F3DEX display list starting at the given
+ * segmented address.
+ * @param {RSPStateInterface} state RSP state machine.
+ * @param {number} addr Segmented address of the display list.
+ */
+export function runDL_F3DEX(state: RSPStateInterface, addr: number): void {
+    const segmentBuffer = state.segmentBuffers[(addr >>> 24) & 0xff];
+    const view = segmentBuffer.createDataView();
+
+    for (let i = addr & 0x00ffffff; i < segmentBuffer.byteLength; i += 0x08) {
+        const w0 = view.getUint32(i + 0x00);
+        const w1 = view.getUint32(i + 0x04);
+
+        const cmd: F3DEX_GBI = w0 >>> 24;
+        if (window.debug) {
+            console.debug(hexzero(i, 8), F3DEX_GBI[cmd], hexzero(w0, 8), hexzero(w1, 8));
+        }
+
+        switch (cmd) {
+            case F3DEX_GBI.G_ENDDL:
+                return;
+
+            case F3DEX_GBI.G_CLEARGEOMETRYMODE:
+                state.gSPClearGeometryMode(w1);
+                break;
+
+            case F3DEX_GBI.G_SETGEOMETRYMODE:
+                state.gSPSetGeometryMode(w1);
+                break;
+
+            case F3DEX_GBI.G_TEXTURE:
+                {
+                    const level = (w0 >>> 11) & 0x07;
+                    const tile = (w0 >>> 8) & 0x07;
+                    const on = !!((w0 >>> 0) & 0x7f);
+                    const s = (w1 >>> 16) & 0xffff;
+                    const t = (w1 >>> 0) & 0xffff;
+                    state.gSPTexture(on, tile, level, s, t);
+                }
+                break;
+
+            case F3DEX_GBI.G_SETTIMG:
+                {
+                    const fmt = (w0 >>> 21) & 0x07;
+                    const siz = (w0 >>> 19) & 0x03;
+                    const w = (w0 & 0x0fff) + 1;
+                    state.gDPSetTextureImage(fmt, siz, w, w1);
+                }
+                break;
+
+            case F3DEX_GBI.G_SETTILE:
+                {
+                    const fmt = (w0 >>> 21) & 0x07;
+                    const siz = (w0 >>> 19) & 0x03;
+                    const line = (w0 >>> 9) & 0x1ff;
+                    const tmem = (w0 >>> 0) & 0x1ff;
+                    const tile = (w1 >>> 24) & 0x07;
+                    const palette = (w1 >>> 20) & 0x0f;
+                    const cmt = (w1 >>> 18) & 0x03;
+                    const maskt = (w1 >>> 14) & 0x0f;
+                    const shiftt = (w1 >>> 10) & 0x0f;
+                    const cms = (w1 >>> 8) & 0x03;
+                    const masks = (w1 >>> 4) & 0x0f;
+                    const shifts = (w1 >>> 0) & 0x0f;
+                    state.gDPSetTile(
+                        fmt,
+                        siz,
+                        line,
+                        tmem,
+                        tile,
+                        palette,
+                        cmt,
+                        maskt,
+                        shiftt,
+                        cms,
+                        masks,
+                        shifts,
+                    );
+                }
+                break;
+
+            case F3DEX_GBI.G_LOADTLUT:
+                {
+                    const tile = (w1 >>> 24) & 0x07;
+                    const count = (w1 >>> 14) & 0x3ff;
+                    state.gDPLoadTLUT(tile, count);
+                }
+                break;
+
+            case F3DEX_GBI.G_LOADBLOCK:
+                {
+                    const uls = (w0 >>> 12) & 0x0fff;
+                    const ult = (w0 >>> 0) & 0x0fff;
+                    const tile = (w1 >>> 24) & 0x07;
+                    const lrs = (w1 >>> 12) & 0x0fff;
+                    const dxt = (w1 >>> 0) & 0x0fff;
+                    state.gDPLoadBlock(tile, uls, ult, lrs, dxt);
+                }
+                break;
+
+            case F3DEX_GBI.G_VTX:
+                {
+                    const v0 = ((w0 >>> 16) & 0xff) / 2;
+                    const n = (w0 >>> 10) & 0x3f;
+                    state.gSPVertex(w1, n, v0);
+                }
+                break;
+
+            case F3DEX_GBI.G_TRI1:
+                {
+                    const i0 = ((w1 >>> 16) & 0xff) / 2;
+                    const i1 = ((w1 >>> 8) & 0xff) / 2;
+                    const i2 = ((w1 >>> 0) & 0xff) / 2;
+                    state.gSPTri(i0, i1, i2);
+                }
+                break;
+
+            case F3DEX_GBI.G_TRI2:
+                {
+                    {
+                        const i0 = ((w0 >>> 16) & 0xff) / 2;
+                        const i1 = ((w0 >>> 8) & 0xff) / 2;
+                        const i2 = ((w0 >>> 0) & 0xff) / 2;
+                        state.gSPTri(i0, i1, i2);
+                    }
+                    {
+                        const i0 = ((w1 >>> 16) & 0xff) / 2;
+                        const i1 = ((w1 >>> 8) & 0xff) / 2;
+                        const i2 = ((w1 >>> 0) & 0xff) / 2;
+                        state.gSPTri(i0, i1, i2);
+                    }
+                }
+                break;
+
+            case F3DEX_GBI.G_DL:
+                {
+                    runDL_F3DEX(state, w1);
+                }
+                break;
+
+            case F3DEX_GBI.G_SETOTHERMODE_H:
+                {
+                    const len = (w0 >>> 0) & 0xff;
+                    const sft = (w0 >>> 8) & 0xff;
+                    state.gDPSetOtherModeH(sft, len, w1);
+                }
+                break;
+
+            case F3DEX_GBI.G_SETOTHERMODE_L:
+                {
+                    const len = (w0 >>> 0) & 0xff;
+                    const sft = (w0 >>> 8) & 0xff;
+                    state.gDPSetOtherModeL(sft, len, w1);
+                }
+                break;
+
+            case F3DEX_GBI.G_SETCOMBINE:
+                {
+                    state.gDPSetCombine(w0 & 0x00ffffff, w1);
+                }
+                break;
+
+            case F3DEX_GBI.G_SETTILESIZE:
+                {
+                    const uls = (w0 >>> 12) & 0x0fff;
+                    const ult = (w0 >>> 0) & 0x0fff;
+                    const tile = (w1 >>> 24) & 0x07;
+                    const lrs = (w1 >>> 12) & 0x0fff;
+                    const lrt = (w1 >>> 0) & 0x0fff;
+                    state.gDPSetTileSize(tile, uls, ult, lrs, lrt);
+                }
+                break;
+
+            case F3DEX_GBI.G_POPMTX:
+                {
+                    // state.gSPPopMatrix();
+                }
+                break;
+
+            case F3DEX_GBI.G_MODIFYVTX:
+                {
+                    const where = (w0 >>> 16) & 0x00ff;
+                    const vtx = ((w0 >>> 0) & 0xffff) / 2;
+                    const val = (w1 >>> 0) & 0xffffffff;
+                    state.gSPModifyVertex(vtx, where, val);
+                }
+                break;
+
+            case F3DEX_GBI.G_MOVEMEM:
+                {
+                    state.gMoveMem?.(w0, w1);
+                }
+                break;
+
+            case F3DEX_GBI.G_CULLDL:
+            case F3DEX_GBI.G_RDPFULLSYNC:
+            case F3DEX_GBI.G_RDPTILESYNC:
+            case F3DEX_GBI.G_RDPPIPESYNC:
+            case F3DEX_GBI.G_RDPLOADSYNC:
+                // Implementation not necessary.
+                break;
+
+            case F3DEX_GBI.G_SETPRIMCOLOR:
+            case F3DEX_GBI.G_SETENVCOLOR:
+            case F3DEX_GBI.G_SETBLENDCOLOR:
+            case F3DEX_GBI.G_SETFOGCOLOR:
+            case F3DEX_GBI.G_SETFILLCOLOR:
+            case F3DEX_GBI.G_FILLRECT:
+            case F3DEX_GBI.G_SETPRIMDEPTH:
+            case F3DEX_GBI.G_SETSCISSOR:
+            case F3DEX_GBI.G_RDPSETOTHERMODE:
+            case F3DEX_GBI.G_SETCIMG:
+            case F3DEX_GBI.G_SETZIMG:
+                // Not yet implemented but should not be treated as errors.
+                break;
+
+            default:
+                console.error(`Unknown DL opcode: ${cmd.toString(16)}`);
+        }
+    }
+}

--- a/src/TopGearRally/f3dex.ts
+++ b/src/TopGearRally/f3dex.ts
@@ -1,3 +1,4 @@
+import { vec4 } from "gl-matrix";
 import * as RDP from "../Common/N64/RDP.js";
 
 import ArrayBufferSlice from "../ArrayBufferSlice.js";
@@ -163,6 +164,10 @@ export class DrawCall {
     public DP_OtherModeH = 0;
     /** RDP colour combiner parameters. */
     public DP_Combine: RDP.CombineParams;
+    /** Primitive colour set by G_SETPRIMCOLOR. */
+    public DP_PrimColor = vec4.fromValues(1, 1, 1, 1);
+    /** Environment colour set by G_SETENVCOLOR. */
+    public DP_EnvColor = vec4.fromValues(1, 1, 1, 1);
 
     /** Indices into the texture cache for this draw call. */
     public textureIndices: number[] = [];
@@ -430,6 +435,23 @@ export interface RSPStateInterface {
      * @param {number} w1 Low word.
      */
     gMoveMem?: (w0: number, w1: number) => void;
+    /**
+     * Sets the primitive colour (optional).
+     * @param {number} lod LOD fraction.
+     * @param {number} r Red (0-255).
+     * @param {number} g Green (0-255).
+     * @param {number} b Blue (0-255).
+     * @param {number} a Alpha (0-255).
+     */
+    gSPSetPrimColor?: (lod: number, r: number, g: number, b: number, a: number) => void;
+    /**
+     * Sets the environment colour (optional).
+     * @param {number} r Red (0-255).
+     * @param {number} g Green (0-255).
+     * @param {number} b Blue (0-255).
+     * @param {number} a Alpha (0-255).
+     */
+    gSPSetEnvColor?: (r: number, g: number, b: number, a: number) => void;
 }
 
 /** Default RSP state machine that interprets F3DEX commands into draw calls. */
@@ -456,6 +478,8 @@ export class RSPState implements RSPStateInterface {
     private readonly DP_TextureImageState = new TextureImageState();
     private readonly DP_TileState = nArray(8, () => new RDP.TileState());
     private readonly DP_TMemTracker: Map<number, number> = new Map();
+    private readonly DP_PrimColor = vec4.fromValues(1, 1, 1, 1);
+    private readonly DP_EnvColor = vec4.fromValues(1, 1, 1, 1);
 
     /**
      * Creates an RSP state with the given segment buffers and
@@ -665,6 +689,18 @@ export class RSPState implements RSPStateInterface {
         }
     }
 
+    /** @inheritdoc */
+    public gSPSetPrimColor(lod: number, r: number, g: number, b: number, a: number): void {
+        vec4.set(this.DP_PrimColor, r / 0xff, g / 0xff, b / 0xff, a / 0xff);
+        this.stateChanged = true;
+    }
+
+    /** @inheritdoc */
+    public gSPSetEnvColor(r: number, g: number, b: number, a: number): void {
+        vec4.set(this.DP_EnvColor, r / 0xff, g / 0xff, b / 0xff, a / 0xff);
+        this.stateChanged = true;
+    }
+
     private _setGeometryMode(newGeometryMode: number): void {
         if (this.SP_GeometryMode === newGeometryMode) {
             return;
@@ -767,6 +803,8 @@ export class RSPState implements RSPStateInterface {
             dc.DP_Combine = RDP.decodeCombineParams(this.DP_CombineH, this.DP_CombineL);
             dc.DP_OtherModeH = this.DP_OtherModeH;
             dc.DP_OtherModeL = this.DP_OtherModeL;
+            vec4.copy(dc.DP_PrimColor, this.DP_PrimColor);
+            vec4.copy(dc.DP_EnvColor, this.DP_EnvColor);
             this.flushTextures(dc);
         }
     }
@@ -1083,7 +1121,26 @@ export function runDL_F3DEX(state: RSPStateInterface, addr: number): void {
                 break;
 
             case F3DEX_GBI.G_SETPRIMCOLOR:
+                {
+                    const lod = (w0 >>> 0) & 0xff;
+                    const r = (w1 >>> 24) & 0xff;
+                    const g = (w1 >>> 16) & 0xff;
+                    const b = (w1 >>> 8) & 0xff;
+                    const a = (w1 >>> 0) & 0xff;
+                    state.gSPSetPrimColor?.(lod, r, g, b, a);
+                }
+                break;
+
             case F3DEX_GBI.G_SETENVCOLOR:
+                {
+                    const r = (w1 >>> 24) & 0xff;
+                    const g = (w1 >>> 16) & 0xff;
+                    const b = (w1 >>> 8) & 0xff;
+                    const a = (w1 >>> 0) & 0xff;
+                    state.gSPSetEnvColor?.(r, g, b, a);
+                }
+                break;
+
             case F3DEX_GBI.G_SETBLENDCOLOR:
             case F3DEX_GBI.G_SETFOGCOLOR:
             case F3DEX_GBI.G_SETFILLCOLOR:

--- a/src/TopGearRally/render.ts
+++ b/src/TopGearRally/render.ts
@@ -58,113 +58,6 @@ const TRACK_RAM_LOW24 = 0x025c00;
 
 const bindingLayouts = [{ numUniformBuffers: 3, numSamplers: 2 }];
 
-// -- Per-draw-call color extracted from raw DL scanning. --
-interface DLColorState {
-    primColor: vec4;
-    envColor: vec4;
-}
-
-/**
- * Scan raw DL bytes to extract G_SETPRIMCOLOR / G_SETENVCOLOR
- * state indexed by cumulative triangle output position. Records
- * the running prim/env colour at each triangle index so that
- * DrawCallInstances can look up colours by firstIndex.
- */
-function scanDLColors(
-    segmentBuffers: ArrayBufferSlice[],
-    dlAddresses: number[],
-): Map<number, DLColorState> {
-    // Map from triangle start index (in terms of index buffer entries) to color state.
-    const colorByIndex: Map<number, DLColorState> = new Map();
-    let primColor = vec4.fromValues(1, 1, 1, 1);
-    let envColor = vec4.fromValues(1, 1, 1, 1);
-    // Cumulative index buffer position (each tri = 3 indices).
-    let triIndex = 0;
-    // Record at first triangle.
-    let colorDirty = true;
-
-    function resolveAddr(addr: number): DataView {
-        const seg = (addr >>> 24) & 0xff;
-        const buf = segmentBuffers[seg];
-        return buf.createDataView();
-    }
-
-    function walkDL(addr: number, depth: number): void {
-        if (depth > 16) {
-            return;
-        }
-        const view = resolveAddr(addr);
-        const offs0 = addr & 0x00ffffff;
-
-        for (let pc = offs0; ; pc += 8) {
-            if (pc + 8 > view.byteLength) {
-                break;
-            }
-            const w0 = view.getUint32(pc, false);
-            const w1 = view.getUint32(pc + 4, false);
-            const cmd = (w0 >>> 24) & 0xff;
-
-            switch (cmd) {
-                case 0xb8: // G_ENDDL
-                    return;
-
-                case 0x06: // G_DL (branch)
-                    walkDL(w1, depth + 1);
-                    break;
-
-                case 0xfa: {
-                    // G_SETPRIMCOLOR
-                    const r = (w1 >>> 24) & 0xff;
-                    const g = (w1 >>> 16) & 0xff;
-                    const b = (w1 >>> 8) & 0xff;
-                    const a = (w1 >>> 0) & 0xff;
-                    primColor = vec4.fromValues(r / 0xff, g / 0xff, b / 0xff, a / 0xff);
-                    colorDirty = true;
-                    break;
-                }
-                case 0xfb: {
-                    // G_SETENVCOLOR
-                    const r = (w1 >>> 24) & 0xff;
-                    const g = (w1 >>> 16) & 0xff;
-                    const b = (w1 >>> 8) & 0xff;
-                    const a = (w1 >>> 0) & 0xff;
-                    envColor = vec4.fromValues(r / 0xff, g / 0xff, b / 0xff, a / 0xff);
-                    colorDirty = true;
-                    break;
-                }
-
-                case 0xbf: // G_TRI1
-                    if (colorDirty) {
-                        colorByIndex.set(triIndex, {
-                            primColor: vec4.clone(primColor),
-                            envColor: vec4.clone(envColor),
-                        });
-                        colorDirty = false;
-                    }
-                    triIndex += 3;
-                    break;
-
-                case 0xb1: // G_TRI2
-                    if (colorDirty) {
-                        colorByIndex.set(triIndex, {
-                            primColor: vec4.clone(primColor),
-                            envColor: vec4.clone(envColor),
-                        });
-                        colorDirty = false;
-                    }
-                    triIndex += 6;
-                    break;
-            }
-        }
-    }
-
-    for (const addr of dlAddresses) {
-        walkDL(addr, 0);
-    }
-
-    return colorByIndex;
-}
-
 // -- TGR-specific DrawCallInstance with prim/env color support. --
 
 const viewMatrixScratch = mat4.create();
@@ -181,19 +74,13 @@ class TGRDrawCallInstance {
     private program!: DeviceProgram;
     private gfxProgram: GfxProgram | null = null;
     private readonly textureMappings = nArray(2, () => new TextureMapping());
-    private readonly primColor: vec4;
-    private readonly envColor: vec4;
     private usesLighting = false;
 
     public constructor(
         geometryData: RenderData,
         private readonly drawMatrix: mat4[],
         private readonly drawCall: DrawCall,
-        primColor: vec4,
-        envColor: vec4,
     ) {
-        this.primColor = vec4.clone(primColor);
-        this.envColor = vec4.clone(envColor);
 
         for (let i = 0; i < this.textureMappings.length; i++) {
             if (i < this.drawCall.textureIndices.length) {
@@ -344,22 +231,10 @@ class TGRDrawCallInstance {
 
         offs = renderInst.allocateUniformBuffer(F3DEX_Program.ub_CombineParams, 8);
         const comb = renderInst.mapUniformBufferF32(F3DEX_Program.ub_CombineParams);
-        offs += fillVec4(
-            comb,
-            offs,
-            this.primColor[0],
-            this.primColor[1],
-            this.primColor[2],
-            this.primColor[3],
-        );
-        fillVec4(
-            comb,
-            offs,
-            this.envColor[0],
-            this.envColor[1],
-            this.envColor[2],
-            this.envColor[3],
-        );
+        const prim = this.drawCall.DP_PrimColor;
+        const env = this.drawCall.DP_EnvColor;
+        offs += fillVec4(comb, offs, prim[0], prim[1], prim[2], prim[3]);
+        fillVec4(comb, offs, env[0], env[1], env[2], env[3]);
         renderInstManager.submitRenderInst(renderInst);
     }
 
@@ -938,13 +813,11 @@ export class TGRRenderer implements SceneGfx, Destroyable {
         // Walk all unique instance DLs and record draw call ranges.
         let dlErrorCount = 0;
         const dlToDrawCallRange: Map<number, { start: number; end: number }> = new Map();
-        const dlAddressesInOrder: number[] = [];
 
         for (const dlOff of uniqueDLOffsets) {
             const out = rspState.finish();
             const startDC = out ? out.drawCalls.length : 0;
             const dlAddr = track.pointerBase + dlOff;
-            dlAddressesInOrder.push(dlAddr);
 
             // Reset render state to defaults before each DL.
             // The game's RenderTrackGeometry sets these once
@@ -999,7 +872,6 @@ export class TGRRenderer implements SceneGfx, Destroyable {
             const out = rspState.finish();
             const startDC = out ? out.drawCalls.length : 0;
             const skyAddr = track.pointerBase + track.skyboxDLOffset;
-            dlAddressesInOrder.push(skyAddr);
 
             // The sky DL sets its own RSP/RDP state, but we
             // reset to clean defaults to avoid inheriting state
@@ -1041,11 +913,6 @@ export class TGRRenderer implements SceneGfx, Destroyable {
             return;
         }
 
-        // Scan raw DL bytes to extract prim/env colors indexed
-        // by triangle position. This avoids needing to match
-        // BK's exact draw-call boundary detection.
-        const colorByIndex = scanDLColors(segmentBuffers, dlAddressesInOrder);
-
         console.debug(
             `TGR: ${rspOutput.drawCalls.length} draw calls, ` +
                 `${sharedOutput.textureCache.textures.length} textures, ` +
@@ -1082,31 +949,6 @@ export class TGRRenderer implements SceneGfx, Destroyable {
             0,
             1,
         );
-
-        // Default colors for draw calls where no
-        // SETPRIMCOLOR/SETENVCOLOR was found.
-        const defaultPrim = vec4.fromValues(1, 1, 1, 1);
-        const defaultEnv = vec4.fromValues(1, 1, 1, 1);
-
-        // Build a function to look up the most recent color state
-        // at or before a given index.
-        const colorIndices = Array.from(colorByIndex.keys()).sort((a, b) => a - b);
-        function lookupColor(firstIndex: number): DLColorState | null {
-            // Binary search for the largest index <= firstIndex.
-            let lo = 0,
-                hi = colorIndices.length - 1;
-            let best = -1;
-            while (lo <= hi) {
-                const mid = (lo + hi) >>> 1;
-                if (colorIndices[mid] <= firstIndex) {
-                    best = mid;
-                    lo = mid + 1;
-                } else {
-                    hi = mid - 1;
-                }
-            }
-            return best >= 0 ? colorByIndex.get(colorIndices[best])! : null;
-        }
 
         // Build per-instance draw call groups with transform
         // matrices.
@@ -1156,19 +998,13 @@ export class TGRRenderer implements SceneGfx, Destroyable {
                     continue;
                 }
 
-                // Look up the most recent prim/env color at this
-                // draw call's firstIndex.
-                const colorState = lookupColor(dc.firstIndex);
-                const prim = colorState ? colorState.primColor : defaultPrim;
-                const env = colorState ? colorState.envColor : defaultEnv;
-
                 // On Season Winner, hide the banner texture but
                 // keep the poles.
                 if (isBanner && isSeasonWinner && dc.textureIndices.length > 0) {
                     continue;
                 }
 
-                const dci = new TGRDrawCallInstance(this.renderData, drawMatrices, dc, prim, env);
+                const dci = new TGRDrawCallInstance(this.renderData, drawMatrices, dc);
                 dci.isTransparent = isTransparent;
                 group.drawCallInstances.push(dci);
             }
@@ -1213,16 +1049,10 @@ export class TGRRenderer implements SceneGfx, Destroyable {
                     continue;
                 }
 
-                const colorState = lookupColor(dc.firstIndex);
-                const prim = colorState ? colorState.primColor : defaultPrim;
-                const env = colorState ? colorState.envColor : defaultEnv;
-
                 const dci = new TGRDrawCallInstance(
                     this.renderData,
                     skyDrawMatrices,
                     dc,
-                    prim,
-                    env,
                 );
                 dci.isSky = true;
                 dci.disableDepthWrite();

--- a/src/TopGearRally/render.ts
+++ b/src/TopGearRally/render.ts
@@ -1,0 +1,1654 @@
+import { mat4, vec3, vec4 } from "gl-matrix";
+import * as RDP from "../Common/N64/RDP.js";
+import * as F3DEX from "./f3dex.js";
+import { RenderData, F3DEX_Program } from "../BanjoKazooie/render.js";
+import { RSP_Geometry, DrawCall, translateCullMode, getImageFormatString } from "./f3dex.js";
+import { CameraController, computeViewMatrix } from "../Camera.js";
+import { calcTextureMatrixFromRSPState } from "../Common/N64/RSP.js";
+import {
+    makeBackbufferDescSimple,
+    makeAttachmentClearDescriptor,
+} from "../gfx/helpers/RenderGraphHelpers.js";
+import {
+    fillMatrix4x2,
+    fillMatrix4x3,
+    fillMatrix4x4,
+    fillVec4,
+} from "../gfx/helpers/UniformBufferHelpers.js";
+import {
+    GfxDevice,
+    GfxBlendFactor,
+    GfxBlendMode,
+    GfxMegaStateDescriptor,
+    GfxProgram,
+    GfxTexture,
+} from "../gfx/platform/GfxPlatform.js";
+import { setAttachmentStateSimple } from "../gfx/helpers/GfxMegaStateDescriptorHelpers.js";
+import { GfxrAttachmentClearDescriptor, GfxrAttachmentSlot } from "../gfx/render/GfxRenderGraph.js";
+import { GfxRenderHelper } from "../gfx/render/GfxRenderHelper.js";
+import {
+    GfxRenderInstList,
+    GfxRenderInstManager,
+    makeSortKey,
+    GfxRendererLayer,
+} from "../gfx/render/GfxRenderInstManager.js";
+import { TextureMapping } from "../TextureHolder.js";
+import { DeviceProgram } from "../Program.js";
+import { SceneGfx, ViewerRenderInput, Texture as ViewerTexture } from "../viewer.js";
+import * as UI from "../ui.js";
+import { Destroyable } from "../SceneBase.js";
+import ArrayBufferSlice from "../ArrayBufferSlice.js";
+import { TGRTrack } from "./data.js";
+import { nArray } from "../util.js";
+
+/**
+ * Top Gear Rally track renderer.
+ *
+ * Walks N64 display lists from decompressed track data using the
+ * BanjoKazooie F3DEX interpreter. Each track instance has a 4x4
+ * matrix that transforms local DL geometry to world space.
+ *
+ * Uses its own DrawCallInstance to support G_SETPRIMCOLOR,
+ * G_SETENVCOLOR, parameterised lighting, and per-vertex fog
+ * without modifying BK's shared code.
+ */
+
+/** Low 24 bits of the N64 DRAM base address 0x80025c00. */
+const TRACK_RAM_LOW24 = 0x025c00;
+
+const bindingLayouts = [{ numUniformBuffers: 3, numSamplers: 2 }];
+
+// -- Per-draw-call color extracted from raw DL scanning. --
+interface DLColorState {
+    primColor: vec4;
+    envColor: vec4;
+}
+
+/**
+ * Scan raw DL bytes to extract G_SETPRIMCOLOR / G_SETENVCOLOR
+ * state indexed by cumulative triangle output position. Records
+ * the running prim/env colour at each triangle index so that
+ * DrawCallInstances can look up colours by firstIndex.
+ */
+function scanDLColors(
+    segmentBuffers: ArrayBufferSlice[],
+    dlAddresses: number[],
+): Map<number, DLColorState> {
+    // Map from triangle start index (in terms of index buffer entries) to color state.
+    const colorByIndex: Map<number, DLColorState> = new Map();
+    let primColor = vec4.fromValues(1, 1, 1, 1);
+    let envColor = vec4.fromValues(1, 1, 1, 1);
+    // Cumulative index buffer position (each tri = 3 indices).
+    let triIndex = 0;
+    // Record at first triangle.
+    let colorDirty = true;
+
+    function resolveAddr(addr: number): DataView {
+        const seg = (addr >>> 24) & 0xff;
+        const buf = segmentBuffers[seg];
+        return buf.createDataView();
+    }
+
+    function walkDL(addr: number, depth: number): void {
+        if (depth > 16) {
+            return;
+        }
+        const view = resolveAddr(addr);
+        const offs0 = addr & 0x00ffffff;
+
+        for (let pc = offs0; ; pc += 8) {
+            if (pc + 8 > view.byteLength) {
+                break;
+            }
+            const w0 = view.getUint32(pc, false);
+            const w1 = view.getUint32(pc + 4, false);
+            const cmd = (w0 >>> 24) & 0xff;
+
+            switch (cmd) {
+                case 0xb8: // G_ENDDL
+                    return;
+
+                case 0x06: // G_DL (branch)
+                    walkDL(w1, depth + 1);
+                    break;
+
+                case 0xfa: {
+                    // G_SETPRIMCOLOR
+                    const r = (w1 >>> 24) & 0xff;
+                    const g = (w1 >>> 16) & 0xff;
+                    const b = (w1 >>> 8) & 0xff;
+                    const a = (w1 >>> 0) & 0xff;
+                    primColor = vec4.fromValues(r / 0xff, g / 0xff, b / 0xff, a / 0xff);
+                    colorDirty = true;
+                    break;
+                }
+                case 0xfb: {
+                    // G_SETENVCOLOR
+                    const r = (w1 >>> 24) & 0xff;
+                    const g = (w1 >>> 16) & 0xff;
+                    const b = (w1 >>> 8) & 0xff;
+                    const a = (w1 >>> 0) & 0xff;
+                    envColor = vec4.fromValues(r / 0xff, g / 0xff, b / 0xff, a / 0xff);
+                    colorDirty = true;
+                    break;
+                }
+
+                case 0xbf: // G_TRI1
+                    if (colorDirty) {
+                        colorByIndex.set(triIndex, {
+                            primColor: vec4.clone(primColor),
+                            envColor: vec4.clone(envColor),
+                        });
+                        colorDirty = false;
+                    }
+                    triIndex += 3;
+                    break;
+
+                case 0xb1: // G_TRI2
+                    if (colorDirty) {
+                        colorByIndex.set(triIndex, {
+                            primColor: vec4.clone(primColor),
+                            envColor: vec4.clone(envColor),
+                        });
+                        colorDirty = false;
+                    }
+                    triIndex += 6;
+                    break;
+            }
+        }
+    }
+
+    for (const addr of dlAddresses) {
+        walkDL(addr, 0);
+    }
+
+    return colorByIndex;
+}
+
+// -- TGR-specific DrawCallInstance with prim/env color support. --
+
+const viewMatrixScratch = mat4.create();
+const modelViewScratch = mat4.create();
+const texMatrixScratch = mat4.create();
+
+class TGRDrawCallInstance {
+    public isSky = false;
+    public flipTexS = false;
+    public isTransparent = false;
+
+    private readonly textureEntry: RDP.Texture[] = [];
+    private readonly megaStateFlags: Partial<GfxMegaStateDescriptor>;
+    private program!: DeviceProgram;
+    private gfxProgram: GfxProgram | null = null;
+    private readonly textureMappings = nArray(2, () => new TextureMapping());
+    private readonly primColor: vec4;
+    private readonly envColor: vec4;
+    private usesLighting = false;
+
+    public constructor(
+        geometryData: RenderData,
+        private readonly drawMatrix: mat4[],
+        private readonly drawCall: DrawCall,
+        primColor: vec4,
+        envColor: vec4,
+    ) {
+        this.primColor = vec4.clone(primColor);
+        this.envColor = vec4.clone(envColor);
+
+        for (let i = 0; i < this.textureMappings.length; i++) {
+            if (i < this.drawCall.textureIndices.length) {
+                const idx = this.drawCall.textureIndices[i];
+                this.textureEntry[i] = geometryData.sharedOutput.textureCache.textures[idx];
+                this.textureMappings[i].gfxTexture = geometryData.textures[idx];
+                this.textureMappings[i].gfxSampler = geometryData.samplers[idx];
+            }
+        }
+
+        this.megaStateFlags = RDP.translateRenderMode(this.drawCall.DP_OtherModeL);
+        // The BK translateRenderMode only enables blending when the
+        // blend destination is CLR_MEM. The N64 mode 0x0c1848f8 uses
+        // coverage-based transparency that WebGL cannot replicate
+        // directly. Apply standard alpha blending for this specific
+        // mode so transparent pixels (e.g. camera flash backgrounds)
+        // show through correctly.
+        if (this.drawCall.DP_OtherModeL === 0x0c1848f8) {
+            setAttachmentStateSimple(this.megaStateFlags, {
+                blendMode: GfxBlendMode.Add,
+                blendSrcFactor: GfxBlendFactor.SrcAlpha,
+                blendDstFactor: GfxBlendFactor.OneMinusSrcAlpha,
+            });
+            this.megaStateFlags.depthWrite = false;
+        }
+        const cullMode = translateCullMode(this.drawCall.SP_GeometryMode);
+        this.megaStateFlags.cullMode = cullMode;
+
+        this.createProgram();
+    }
+
+    public disableDepthWrite(): void {
+        this.megaStateFlags.depthWrite = false;
+    }
+
+    public getDrawMatrix(): mat4 {
+        return this.drawMatrix[0];
+    }
+
+    public setDrawMatrix(m: mat4): void {
+        mat4.copy(this.drawMatrix[0], m);
+        mat4.copy(this.drawMatrix[1], m);
+    }
+
+    public getTextureIndex(slot: number): number {
+        if (slot < this.drawCall.textureIndices.length) {
+            return this.drawCall.textureIndices[slot];
+        }
+        return -1;
+    }
+
+    public setGfxTexture(slot: number, tex: GfxTexture): void {
+        if (slot < this.textureMappings.length) {
+            this.textureMappings[slot].gfxTexture = tex;
+        }
+    }
+
+    public prepareToRender(
+        device: GfxDevice,
+        renderInstManager: GfxRenderInstManager,
+        viewerInput: ViewerRenderInput,
+        skyMatrix?: mat4,
+        fogParams?: WeatherParams,
+    ): void {
+        this.gfxProgram ??= renderInstManager.gfxRenderCache.createProgram(this.program);
+
+        const renderInst = renderInstManager.newRenderInst();
+        renderInst.setGfxProgram(this.gfxProgram);
+        renderInst.setSamplerBindingsFromTextureMappings(this.textureMappings);
+        renderInst.setMegaStateFlags(this.megaStateFlags);
+        renderInst.setDrawCount(this.drawCall.indexCount, this.drawCall.firstIndex);
+
+        if (this.isSky) {
+            renderInst.sortKey = makeSortKey(GfxRendererLayer.BACKGROUND);
+        } else if (this.isTransparent) {
+            renderInst.sortKey = makeSortKey(GfxRendererLayer.TRANSLUCENT);
+        }
+
+        // DrawParams layout: bone matrices + tex matrices +
+        // [lighting] + fog. Lighting adds 3 vec4s
+        // (DiffuseColor, DiffuseDirection, AmbientColor) for
+        // 1 light.
+        const lightingSize = this.usesLighting ? 4 + 4 + 4 : 0;
+        let offs = renderInst.allocateUniformBuffer(
+            F3DEX_Program.ub_DrawParams,
+            12 * 2 + 8 * 2 + lightingSize + 4 + 4,
+        );
+        const mappedF32 = renderInst.mapUniformBufferF32(F3DEX_Program.ub_DrawParams);
+
+        computeViewMatrix(viewMatrixScratch, viewerInput.camera);
+
+        // For sky draw calls, use the sky matrix (which follows
+        // the camera).
+        const drawMat0 = this.isSky && skyMatrix ? skyMatrix : this.drawMatrix[0];
+        const drawMat1 = this.isSky && skyMatrix ? skyMatrix : this.drawMatrix[1];
+
+        mat4.mul(modelViewScratch, viewMatrixScratch, drawMat0);
+        offs += fillMatrix4x3(mappedF32, offs, modelViewScratch);
+
+        mat4.mul(modelViewScratch, viewMatrixScratch, drawMat1);
+        offs += fillMatrix4x3(mappedF32, offs, modelViewScratch);
+
+        this.computeTextureMatrix(texMatrixScratch, 0);
+        offs += fillMatrix4x2(mappedF32, offs, texMatrixScratch);
+
+        this.computeTextureMatrix(texMatrixScratch, 1);
+        offs += fillMatrix4x2(mappedF32, offs, texMatrixScratch);
+
+        // Lighting uniforms: u_DiffuseColor[0],
+        // u_DiffuseDirection[0], u_AmbientColor.
+        if (this.usesLighting) {
+            // Game's summer lighting:
+            //   directional=(0xFF,0xFF,0xCC),
+            //   ambient=(0x66,0x66,0x77).
+            // Light direction: (15, 10, 20) normalized in N64
+            // space. In view space we need to transform by the
+            // view matrix, but for simplicity use a fixed
+            // direction that approximates top-front lighting.
+
+            // u_DiffuseColor[0].
+            offs += fillVec4(mappedF32, offs, 1.0, 1.0, 0.8, 0.0);
+            // u_DiffuseDirection[0] (view-space approx:
+            // slightly above+forward).
+            offs += fillVec4(mappedF32, offs, 0.0, 0.57, 0.82, 0.0);
+            // u_AmbientColor (0x66/0xFF, 0x66/0xFF,
+            // 0x77/0xFF).
+            offs += fillVec4(mappedF32, offs, 0.4, 0.4, 0.47, 1.0);
+        }
+
+        // Fog params: u_FogParam = (near, far, 0, 0),
+        // u_FogColor = (r, g, b, 1).
+        if (fogParams) {
+            offs += fillVec4(mappedF32, offs, fogParams.fogNear, fogParams.fogFar, 0, 0);
+            fillVec4(
+                mappedF32,
+                offs,
+                fogParams.fogR / 255.0,
+                fogParams.fogG / 255.0,
+                fogParams.fogB / 255.0,
+                1.0,
+            );
+        } else {
+            // No fog: set near/far to extreme values so
+            // fogFactor is always 0.
+            offs += fillVec4(mappedF32, offs, 1000000, 1000001, 0, 0);
+            fillVec4(mappedF32, offs, 0, 0, 0, 0);
+        }
+
+        offs = renderInst.allocateUniformBuffer(F3DEX_Program.ub_CombineParams, 8);
+        const comb = renderInst.mapUniformBufferF32(F3DEX_Program.ub_CombineParams);
+        offs += fillVec4(
+            comb,
+            offs,
+            this.primColor[0],
+            this.primColor[1],
+            this.primColor[2],
+            this.primColor[3],
+        );
+        fillVec4(
+            comb,
+            offs,
+            this.envColor[0],
+            this.envColor[1],
+            this.envColor[2],
+            this.envColor[3],
+        );
+        renderInstManager.submitRenderInst(renderInst);
+    }
+
+    private createProgram(): void {
+        this.usesLighting = (this.drawCall.SP_GeometryMode & RSP_Geometry.G_LIGHTING) !== 0;
+
+        // When lighting is enabled, pass G_MW_NUMLIGHT=1 to the
+        // F3DEX_Program so the shader knows how many directional
+        // lights to process.
+        const numLights = this.usesLighting ? 1 : 0;
+        const program = new F3DEX_Program(
+            this.drawCall.DP_OtherModeH,
+            this.drawCall.DP_OtherModeL,
+            this.drawCall.DP_Combine,
+            0.5,
+            [],
+            numLights,
+        );
+        program.defines.set("BONE_MATRIX_COUNT", "2");
+
+        if (this.drawCall.textureIndices.length) {
+            program.defines.set("USE_TEXTURE", "1");
+        }
+
+        const shade = (this.drawCall.SP_GeometryMode & RSP_Geometry.G_SHADE) !== 0;
+        if (shade) {
+            program.defines.set("USE_VERTEX_COLOR", "1");
+        }
+
+        if (this.usesLighting) {
+            program.defines.set("LIGHTING", "1");
+            program.defines.set("PARAMETERIZED_LIGHTING", "1");
+        }
+
+        if (this.drawCall.SP_GeometryMode & RSP_Geometry.G_TEXTURE_GEN) {
+            program.defines.set("TEXTURE_GEN", "1");
+        }
+
+        if (this.drawCall.SP_GeometryMode & RSP_Geometry.G_TEXTURE_GEN_LINEAR) {
+            program.defines.set("TEXTURE_GEN_LINEAR", "1");
+        }
+
+        // Always enable fog support. Fog params control whether
+        // it is visible.
+        program.defines.set("USE_FOG", "1");
+
+        this.program = program;
+        this.gfxProgram = null;
+    }
+
+    private computeTextureMatrix(m: mat4, textureEntryIndex: number): void {
+        const entry = this.textureEntry[textureEntryIndex] as RDP.Texture | undefined;
+        if (entry === undefined) {
+            mat4.identity(m);
+            return;
+        }
+        calcTextureMatrixFromRSPState(
+            m,
+            this.drawCall.SP_TextureState.s,
+            this.drawCall.SP_TextureState.t,
+            entry.width,
+            entry.height,
+            entry.tile.shifts,
+            entry.tile.shiftt,
+        );
+        // Flip the S (horizontal) texture coordinate for mirrored
+        // banners. Negating the S components causes UV to go
+        // negative. With GL REPEAT, negative UVs sample texels in
+        // reverse order within each tile:
+        //   frac(-0.25) = 0.75, frac(-0.5) = 0.5,
+        //   frac(-0.75) = 0.25.
+        if (this.flipTexS) {
+            m[0] = -m[0];
+            m[4] = -m[4];
+            m[8] = -m[8];
+            m[12] = -m[12];
+        }
+    }
+}
+
+// -- Main renderer. --
+
+interface TGRDrawCallGroup {
+    drawCallInstances: TGRDrawCallInstance[];
+    isTransparent: boolean; // Instance flag 0x0008.
+}
+
+class TGRTextureHolder implements UI.TextureListHolder {
+    public textureNames: string[] = [];
+    public onnewtextures: (() => void) | null = null;
+
+    public constructor(
+        private readonly renderData: RenderData,
+        sharedOutput: F3DEX.RSPSharedOutput,
+    ) {
+        for (let i = 0; i < sharedOutput.textureCache.textures.length; i++) {
+            const tex = sharedOutput.textureCache.textures[i];
+            const fmtStr = getImageFormatString(tex.tile.fmt, tex.tile.siz);
+            this.textureNames.push(`${i}: ${fmtStr} ${tex.width}x${tex.height}`);
+        }
+    }
+
+    public getViewerTexture(i: number): Promise<ViewerTexture> {
+        return Promise.resolve({ gfxTexture: this.renderData.textures[i] });
+    }
+}
+
+// Fog colour, clear colour, and near/far distances per weather mode.
+interface WeatherParams {
+    fogR: number;
+    fogG: number;
+    fogB: number;
+    clearR: number;
+    clearG: number;
+    clearB: number;
+    fogNear: number;
+    fogFar: number;
+}
+
+// Fog near/far in GL view-space units (N64 units times WORLD_SCALE).
+const WEATHER_PARAMS: WeatherParams[] = [
+    // Sunny (effectively no fog).
+    {
+        fogR: 128,
+        fogG: 179,
+        fogB: 230,
+        clearR: 0.5,
+        clearG: 0.7,
+        clearB: 0.9,
+        fogNear: 99000,
+        fogFar: 100000,
+    },
+    // Rain (mild fog, darker sky).
+    {
+        fogR: 100,
+        fogG: 110,
+        fogB: 120,
+        clearR: 0.35,
+        clearG: 0.4,
+        clearB: 0.5,
+        fogNear: 30000,
+        fogFar: 60000,
+    },
+    // Snow (grey fog, moderate visibility).
+    {
+        fogR: 96,
+        fogG: 104,
+        fogB: 112,
+        clearR: 0.38,
+        clearG: 0.41,
+        clearB: 0.44,
+        fogNear: 25000,
+        fogFar: 55000,
+    },
+    // Night (blue-tinted fog, dark sky).
+    {
+        fogR: 30,
+        fogG: 30,
+        fogB: 55,
+        clearR: 0.02,
+        clearG: 0.02,
+        clearB: 0.08,
+        fogNear: 20000,
+        fogFar: 50000,
+    },
+    // Fog / blizzard (dense black fog, very low visibility).
+    {
+        fogR: 0,
+        fogG: 0,
+        fogB: 0,
+        clearR: 0.0,
+        clearG: 0.0,
+        clearB: 0.0,
+        fogNear: 5000,
+        fogFar: 15000,
+    },
+];
+
+// Per-instance rotation animation state (types 0 through 2).
+interface RotationAnimState {
+    instanceRawIndex: number;
+    /** Rotation axis in N64 space (unit vector). */
+    axis: vec3;
+    /** Rotation speed in degrees per frame at 30 fps. */
+    speed: number;
+    /** Accumulated angle in degrees. */
+    angle: number;
+    /** Original N64 matrix before n64ToGL transform. */
+    baseMatrixRaw: mat4;
+}
+
+// Per-spline follower animation state (type 3).
+interface SplineAnimState {
+    instanceRawIndex: number;
+    leftRail: Float32Array;
+    rightRail: Float32Array;
+    nodeCount: number;
+    currentNode: number;
+    accumDist: number;
+    segmentLen: number;
+    /** Speed in N64 distance units per second. */
+    speed: number;
+    active: boolean;
+}
+
+// Per-channel animated texture state.
+interface AnimTexState {
+    /** Texture cache index for the base (KF0) texture. */
+    texCacheIndex: number;
+    /** Millisecond timestamps for each keyframe. */
+    keyframeTimes: number[];
+    /** GPU textures for each keyframe (index 0 = base). */
+    keyframeGfxTextures: GfxTexture[];
+    currentKeyframe: number;
+    timeAccum: number;
+    /** Duration of one full cycle in milliseconds. */
+    totalCycleTime: number;
+    /** Draw call instances that reference this texture. */
+    affectedDrawCalls: TGRDrawCallInstance[];
+}
+
+/** Main scene renderer for Top Gear Rally tracks. */
+export class TGRRenderer implements SceneGfx, Destroyable {
+    /** Texture list holder for the debug texture viewer panel. */
+    public textureHolder?: UI.TextureListHolder;
+
+    private readonly renderHelper: GfxRenderHelper;
+    private readonly renderInstListMain = new GfxRenderInstList();
+    private clearDescriptor: GfxrAttachmentClearDescriptor;
+    private renderData: RenderData | null = null;
+    private readonly drawCallGroups: TGRDrawCallGroup[] = [];
+    private readonly skyDrawCallInstances: TGRDrawCallInstance[] = [];
+    private readonly skyN64ToGL = mat4.create();
+    private readonly n64ToGL = mat4.create();
+    private readonly trackCenter = vec3.create();
+    private weatherMode = 0;
+    private readonly rotationAnims: RotationAnimState[] = [];
+    private readonly splineAnims: SplineAnimState[] = [];
+    private readonly animTexStates: AnimTexState[] = [];
+    // Map from raw instance index to the draw call group index for animation updates.
+    private readonly rawIndexToGroupIdx: Map<number, number> = new Map();
+    private animTexElapsedMs = 0;
+
+    /**
+     * Constructor.
+     * @param {GfxDevice} device GPU device handle.
+     * @param {TGRTrack} track Track data to render.
+     * @param {boolean} mirrored Whether to mirror the track geometry (used for mirrored banners).
+     * @param {number} trackIndex Index of the track (used for animation state).
+     */
+    public constructor(
+        device: GfxDevice,
+        private readonly track: TGRTrack,
+        private readonly mirrored = false,
+        private readonly trackIndex = 0,
+    ) {
+        this.renderHelper = new GfxRenderHelper(device);
+        this.clearDescriptor = makeAttachmentClearDescriptor({ r: 0.5, g: 0.7, b: 0.9, a: 1.0 });
+
+        try {
+            this.parseAndBuild(device);
+        } catch (e) {
+            console.error("TGR: Failed to parse track data:", e);
+        }
+    }
+
+    private static computeSegmentLen(s: SplineAnimState): void {
+        const i = s.currentNode;
+        if (i + 1 >= s.nodeCount) {
+            s.segmentLen = 1;
+            return;
+        }
+        // Midpoint of left/right rails at current and next
+        // node.
+        const lx0 = s.leftRail[i * 3];
+        const ly0 = s.leftRail[i * 3 + 1];
+        const lz0 = s.leftRail[i * 3 + 2];
+        const rx0 = s.rightRail[i * 3];
+        const ry0 = s.rightRail[i * 3 + 1];
+        const rz0 = s.rightRail[i * 3 + 2];
+        const lx1 = s.leftRail[(i + 1) * 3];
+        const ly1 = s.leftRail[(i + 1) * 3 + 1];
+        const lz1 = s.leftRail[(i + 1) * 3 + 2];
+        const rx1 = s.rightRail[(i + 1) * 3];
+        const ry1 = s.rightRail[(i + 1) * 3 + 1];
+        const rz1 = s.rightRail[(i + 1) * 3 + 2];
+        const mx0 = (lx0 + rx0) * 0.5;
+        const my0 = (ly0 + ry0) * 0.5;
+        const mz0 = (lz0 + rz0) * 0.5;
+        const mx1 = (lx1 + rx1) * 0.5;
+        const my1 = (ly1 + ry1) * 0.5;
+        const mz1 = (lz1 + rz1) * 0.5;
+        const dx = mx1 - mx0;
+        const dy = my1 - my0;
+        const dz = mz1 - mz0;
+        s.segmentLen = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        if (s.segmentLen < 0.001) {
+            s.segmentLen = 0.001;
+        }
+    }
+
+    /**
+     * Update animations and submit all render instances for
+     * the current frame.
+     *
+     * @param {GfxDevice} device GPU device handle.
+     * @param {ViewerRenderInput} viewerInput Per-frame viewer
+     *     state.
+     */
+    public prepareToRender(device: GfxDevice, viewerInput: ViewerRenderInput): void {
+        if (
+            this.renderData === null ||
+            (this.drawCallGroups.length === 0 && this.skyDrawCallInstances.length === 0)
+        ) {
+            return;
+        }
+
+        // Update animations.
+        const dtSec = viewerInput.deltaTime / 1000.0;
+        this.updateAnimations(viewerInput.deltaTime);
+        this.updateSplines(dtSec);
+        // deltaTime is in ms.
+        this.updateAnimatedTextures(viewerInput.deltaTime);
+
+        const { renderInstManager } = this.renderHelper;
+        renderInstManager.setCurrentList(this.renderInstListMain);
+
+        const template = this.renderHelper.pushTemplateRenderInst();
+        template.setBindingLayouts(bindingLayouts);
+        template.setVertexInput(
+            this.renderData.inputLayout,
+            this.renderData.vertexBufferDescriptors,
+            this.renderData.indexBufferDescriptor,
+        );
+
+        // Set scene params (projection matrix).
+        const offs = template.allocateUniformBuffer(F3DEX_Program.ub_SceneParams, 16);
+        const mappedF32 = template.mapUniformBufferF32(F3DEX_Program.ub_SceneParams);
+        fillMatrix4x4(mappedF32, offs, viewerInput.camera.projectionMatrix);
+
+        // Compute sky matrix: translate the sky dome to the
+        // camera position. The sky dome follows the viewer so
+        // it always appears at infinity.
+        let skyMatrix: mat4 | undefined = undefined;
+        if (this.skyDrawCallInstances.length > 0) {
+            skyMatrix = mat4.create();
+            // Extract camera world position from the view
+            // matrix inverse.
+            // camera.worldMatrix is the camera-to-world
+            // transform; translation is in column 3.
+            const { worldMatrix } = viewerInput.camera;
+            const [, , , , , , , , , , , , camX, camY, camZ] = worldMatrix;
+
+            // Build the sky model matrix: n64ToGL coordinate
+            // transform, then translate to camera.
+            mat4.copy(skyMatrix, this.skyN64ToGL);
+            skyMatrix[12] = camX;
+            skyMatrix[13] = camY;
+            skyMatrix[14] = camZ;
+        }
+
+        // Weather fog parameters.
+        const fogParams = this.weatherMode > 0 ? WEATHER_PARAMS[this.weatherMode] : undefined;
+
+        // Sky weather tint: the game tints the skybox via
+        // combiner (env color blending) not via fog. We pass a
+        // sky-specific fog that covers the full sky to simulate
+        // this. The game uses env alpha = 0x40 (25%) blend
+        // toward fog color in weather modes.
+        let skyFog: WeatherParams | undefined = undefined;
+        if (fogParams) {
+            // Sky vertices are at moderate view-space Z. Use
+            // range that creates ~60% blend.
+            skyFog = {
+                ...fogParams,
+                fogNear: 0,
+                fogFar: 25000,
+            };
+        }
+
+        // Render sky first (BACKGROUND sort key ensures it
+        // draws behind everything).
+        for (const dci of this.skyDrawCallInstances) {
+            dci.prepareToRender(device, renderInstManager, viewerInput, skyMatrix, skyFog);
+        }
+
+        // Render track geometry with weather fog.
+        for (const group of this.drawCallGroups) {
+            for (const dci of group.drawCallInstances) {
+                dci.prepareToRender(device, renderInstManager, viewerInput, undefined, fogParams);
+            }
+        }
+
+        renderInstManager.popTemplate();
+
+        this.renderHelper.prepareToRender();
+    }
+
+    /**
+     * Build the render graph, execute all passes, and present.
+     *
+     * @param {GfxDevice} device GPU device handle.
+     * @param {ViewerRenderInput} viewerInput Per-frame viewer
+     *     state.
+     */
+    public render(device: GfxDevice, viewerInput: ViewerRenderInput) {
+        const wp = WEATHER_PARAMS[this.weatherMode];
+        this.clearDescriptor = makeAttachmentClearDescriptor({
+            r: wp.clearR,
+            g: wp.clearG,
+            b: wp.clearB,
+            a: 1.0,
+        });
+
+        const builder = this.renderHelper.renderGraph.newGraphBuilder();
+
+        const mainColorDesc = makeBackbufferDescSimple(
+            GfxrAttachmentSlot.Color0,
+            viewerInput,
+            this.clearDescriptor,
+        );
+        const mainDepthDesc = makeBackbufferDescSimple(
+            GfxrAttachmentSlot.DepthStencil,
+            viewerInput,
+            this.clearDescriptor,
+        );
+
+        const mainColorTargetID = builder.createRenderTargetID(mainColorDesc, "Main Color");
+        const mainDepthTargetID = builder.createRenderTargetID(mainDepthDesc, "Main Depth");
+        builder.pushPass((pass) => {
+            pass.setDebugName("Main");
+            pass.attachRenderTargetID(GfxrAttachmentSlot.Color0, mainColorTargetID);
+            pass.attachRenderTargetID(GfxrAttachmentSlot.DepthStencil, mainDepthTargetID);
+            pass.exec((passRenderer) => {
+                this.renderInstListMain.drawOnPassRenderer(
+                    this.renderHelper.renderCache,
+                    passRenderer,
+                );
+            });
+        });
+        this.renderHelper.antialiasingSupport.pushPasses(builder, viewerInput, mainColorTargetID);
+        builder.resolveRenderTargetToExternalTexture(
+            mainColorTargetID,
+            viewerInput.onscreenTexture,
+        );
+
+        this.prepareToRender(device, viewerInput);
+        builder.execute();
+        this.renderInstListMain.reset();
+    }
+
+    /**
+     * Create the weather selection UI panel.
+     *
+     * @returns {UI.Panel[]} Array of UI panels.
+     */
+    public createPanels(): UI.Panel[] {
+        const panels: UI.Panel[] = [];
+
+        // Weather / Time of Day panel.
+        const weatherPanel = new UI.Panel();
+        weatherPanel.customHeaderBackgroundColor = UI.COOL_BLUE_COLOR;
+        weatherPanel.setTitle(UI.TIME_OF_DAY_ICON, "Weather");
+
+        const weatherSelect = new UI.SingleSelect();
+        weatherSelect.setStrings(["Sunny", "Rain", "Snow", "Night", "Fog"]);
+        weatherSelect.onselectionchange = (index: number) => {
+            this.weatherMode = index;
+        };
+        weatherSelect.selectItem(0);
+        weatherPanel.contents.appendChild(weatherSelect.elem);
+        panels.push(weatherPanel);
+
+        return panels;
+    }
+
+    /**
+     * Configure the camera controller speed for this scene.
+     *
+     * @param {CameraController} c Camera controller instance.
+     */
+    // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+    public adjustCameraController(c: CameraController): void {
+        c.setSceneMoveSpeedMult(1.0);
+    }
+
+    /**
+     * Release all GPU resources.
+     *
+     * @param {GfxDevice} device GPU device handle.
+     */
+    public destroy(device: GfxDevice): void {
+        if (this.renderData) {
+            this.renderData.destroy(device);
+        }
+        this.renderHelper.destroy();
+    }
+
+    private parseAndBuild(device: GfxDevice): void {
+        const { track } = this;
+        const dataSize = track.dataBuffer.byteLength;
+
+        // Create padded buffer so N64 absolute addresses resolve
+        // correctly. 0x80025c00 -> segment 0, offset 0x025c00.
+        const paddedSize = TRACK_RAM_LOW24 + dataSize;
+        const paddedArrayBuffer = new ArrayBuffer(paddedSize);
+        new Uint8Array(paddedArrayBuffer).set(
+            track.dataBuffer.createTypedArray(Uint8Array),
+            TRACK_RAM_LOW24,
+        );
+        const paddedBuffer = new ArrayBufferSlice(paddedArrayBuffer);
+
+        // BK's F3DEX uses (addr >>> 24) & 0xFF for segment
+        // lookup. TGR addresses are 0x80XXXXXX -> segment index
+        // 0x80 = 128. Create 256-entry segment buffer array with
+        // index 0x80 mapped.
+        const segmentBuffers: ArrayBufferSlice[] = nArray(256, () => paddedBuffer);
+
+        const sharedOutput = new F3DEX.RSPSharedOutput();
+
+        // Collect unique DLs and build DL->DrawCall range mapping.
+        const uniqueDLOffsets: number[] = [];
+        const dlOffsetSet: Set<number> = new Set();
+        for (const inst of track.instances) {
+            if (!dlOffsetSet.has(inst.dlOffset)) {
+                dlOffsetSet.add(inst.dlOffset);
+                uniqueDLOffsets.push(inst.dlOffset);
+            }
+        }
+
+        // Walk all DLs through a single RSP state (persistent
+        // texture state).
+        const rspState = new F3DEX.RSPState(segmentBuffers, sharedOutput);
+        rspState.loadVerticesOnDemand = true;
+
+        // Set default RSP/RDP state to match what the game's
+        // RenderTrackGeometry sets up before iterating track
+        // instances. Instance DLs that don't set their own state
+        // will inherit these defaults.
+        //
+        // Replicate the RSP/RDP state that RenderTrackGeometry
+        // sets up before iterating track instances. Instance DLs
+        // rely on this inherited state.
+        //
+        // CRITICAL: Tile 6 must have tmem=496 (palette TMEM
+        // area) and tile 7 must have tmem=0 (load tile area).
+        // Without this, LOADTLUT and LOADBLOCK both target
+        // tmem=0 in the DP_TMemTracker, causing the palette
+        // load to overwrite the texture DRAM address. This
+        // corrupts ALL CI4/CI8 textures.
+
+        // Tile 7: load tile at tmem=0.
+        rspState.gDPSetTile(0, 1, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0);
+        // Tile 6: palette at tmem=496.
+        rspState.gDPSetTile(0, 0, 0, 496, 6, 0, 0, 0, 0, 0, 0, 0);
+        // Tile 5: secondary at tmem=256.
+        rspState.gDPSetTile(0, 0, 0, 256, 5, 0, 0, 0, 0, 0, 0, 0);
+        // Enable textures, 2 LOD levels.
+        rspState.gSPTexture(true, 0, 1, 0xffff, 0xffff);
+        // G_PM_1PRIMITIVE (pipeline mode).
+        rspState.gDPSetOtherModeH(19, 1, 0x80000);
+        // G_TT_RGBA16 (texture LUT mode).
+        rspState.gDPSetOtherModeH(9, 3, 0xc00);
+        // G_TF_BILERP (texture filter).
+        rspState.gDPSetOtherModeH(12, 2, 0x2000);
+        // G_TP_NONE (texture persp correction).
+        rspState.gDPSetOtherModeH(8, 1, 0x0);
+        // G_RM_AA_ZB_OPA_SURF (default opaque).
+        rspState.gDPSetOtherModeL(3, 29, 0x0c192038);
+        // G_SHADE | G_SHADING_SMOOTH | G_ZBUFFER |
+        // G_CULL_BACK.
+        rspState.gSPSetGeometryMode(0x20205);
+        // Default combine: (TEX1-TEX0)*LOD+TEX0.
+        rspState.gDPSetCombine(0x26a004, 0x1ffc93f8);
+
+        // Walk all unique instance DLs and record draw call ranges.
+        let dlErrorCount = 0;
+        const dlToDrawCallRange: Map<number, { start: number; end: number }> = new Map();
+        const dlAddressesInOrder: number[] = [];
+
+        for (const dlOff of uniqueDLOffsets) {
+            const out = rspState.finish();
+            const startDC = out ? out.drawCalls.length : 0;
+            const dlAddr = track.pointerBase + dlOff;
+            dlAddressesInOrder.push(dlAddr);
+
+            // Reset render state to defaults before each DL.
+            // The game's RenderTrackGeometry sets these once
+            // before the instance loop; DLs that don't set their
+            // own state expect these defaults. Texture/TMEM state
+            // persists intentionally across DLs.
+            rspState.gSPTexture(true, 0, 1, 0xffff, 0xffff);
+            rspState.gDPSetOtherModeH(19, 1, 0x80000);
+            rspState.gDPSetOtherModeH(9, 3, 0xc00);
+            rspState.gDPSetOtherModeH(12, 2, 0x2000);
+            rspState.gDPSetOtherModeH(8, 1, 0x0);
+            // Default render mode (opaque).
+            rspState.gDPSetOtherModeL(3, 29, 0x0c192038);
+            rspState.gSPClearGeometryMode(0xffffff);
+            rspState.gSPSetGeometryMode(0x20205);
+            rspState.gDPSetCombine(0x26a004, 0x1ffc93f8);
+
+            try {
+                F3DEX.runDL_F3DEX(rspState, dlAddr);
+            } catch (e) {
+                if (dlErrorCount < 5) {
+                    console.warn(`TGR: DL at 0x${dlOff.toString(16)} failed:`, e);
+                }
+                dlErrorCount++;
+            }
+
+            const out2 = rspState.finish();
+            const endDC = out2 ? out2.drawCalls.length : 0;
+            if (endDC > startDC) {
+                dlToDrawCallRange.set(dlOff, {
+                    start: startDC,
+                    end: endDC,
+                });
+            }
+        }
+
+        if (dlErrorCount > 0) {
+            console.warn(
+                `TGR: ${dlErrorCount} DLs failed to parse` + ` (out of ${uniqueDLOffsets.length})`,
+            );
+        }
+
+        // Process sky DL if present.
+        let skyDCRange: { start: number; end: number } | null = null;
+        const skyOffHex = track.skyboxDLOffset.toString(16);
+        const dataSizeHex = dataSize.toString(16);
+        const skyValid = track.skyboxDLOffset > 0 && track.skyboxDLOffset < dataSize;
+        console.debug(
+            `TGR: skyboxDLOffset=0x${skyOffHex}, dataSize=0x${dataSizeHex}, valid=${skyValid}`,
+        );
+        if (skyValid) {
+            const out = rspState.finish();
+            const startDC = out ? out.drawCalls.length : 0;
+            const skyAddr = track.pointerBase + track.skyboxDLOffset;
+            dlAddressesInOrder.push(skyAddr);
+
+            // The sky DL sets its own RSP/RDP state, but we
+            // reset to clean defaults to avoid inheriting state
+            // from the last instance DL.
+            rspState.gSPClearGeometryMode(0xffffff);
+            // SHADE | SMOOTH | ZBUFFER | CULL_BACK.
+            rspState.gSPSetGeometryMode(0x20205);
+            // Textures on, no LOD.
+            rspState.gSPTexture(true, 0, 0, 0xffff, 0xffff);
+            // Pipeline.
+            rspState.gDPSetOtherModeH(19, 1, 0x80000);
+            // No texture LUT (RGBA16 sky textures).
+            rspState.gDPSetOtherModeH(9, 3, 0x0);
+            // Bilinear filter.
+            rspState.gDPSetOtherModeH(12, 2, 0x2000);
+            // No persp correction.
+            rspState.gDPSetOtherModeH(8, 1, 0x0);
+            // Opaque render mode.
+            rspState.gDPSetOtherModeL(3, 29, 0x0c192038);
+            rspState.gDPSetCombine(0x26a004, 0x1ffc93f8);
+
+            try {
+                F3DEX.runDL_F3DEX(rspState, skyAddr);
+            } catch (e) {
+                console.warn(`TGR: Sky DL at 0x${skyOffHex} failed:`, e);
+            }
+
+            const out2 = rspState.finish();
+            const endDC = out2 ? out2.drawCalls.length : 0;
+            if (endDC > startDC) {
+                skyDCRange = { start: startDC, end: endDC };
+                console.debug(`TGR: Sky DL generated ${endDC - startDC} draw calls.`);
+            }
+        }
+
+        const rspOutput = rspState.finish();
+        if (rspOutput === null) {
+            console.warn("TGR: No draw calls generated");
+            return;
+        }
+
+        // Scan raw DL bytes to extract prim/env colors indexed
+        // by triangle position. This avoids needing to match
+        // BK's exact draw-call boundary detection.
+        const colorByIndex = scanDLColors(segmentBuffers, dlAddressesInOrder);
+
+        console.debug(
+            `TGR: ${rspOutput.drawCalls.length} draw calls, ` +
+                `${sharedOutput.textureCache.textures.length} textures, ` +
+                `${sharedOutput.vertices.length} vertices`,
+        );
+
+        // Create GPU resources.
+        const cache = this.renderHelper.renderCache;
+        this.renderData = new RenderData(device, cache, sharedOutput);
+
+        // Set up texture holder for the debug texture viewer
+        // panel.
+        this.textureHolder = new TGRTextureHolder(this.renderData, sharedOutput);
+
+        // N64 uses Z-up coordinate system, noclip/OpenGL uses
+        // Y-up.
+        const WORLD_SCALE = 100;
+        const zSign = this.mirrored ? -WORLD_SCALE : WORLD_SCALE;
+        const n64ToGL = mat4.fromValues(
+            0,
+            0,
+            zSign,
+            0,
+            WORLD_SCALE,
+            0,
+            0,
+            0,
+            0,
+            WORLD_SCALE,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+        );
+
+        // Default colors for draw calls where no
+        // SETPRIMCOLOR/SETENVCOLOR was found.
+        const defaultPrim = vec4.fromValues(1, 1, 1, 1);
+        const defaultEnv = vec4.fromValues(1, 1, 1, 1);
+
+        // Build a function to look up the most recent color state
+        // at or before a given index.
+        const colorIndices = Array.from(colorByIndex.keys()).sort((a, b) => a - b);
+        function lookupColor(firstIndex: number): DLColorState | null {
+            // Binary search for the largest index <= firstIndex.
+            let lo = 0,
+                hi = colorIndices.length - 1;
+            let best = -1;
+            while (lo <= hi) {
+                const mid = (lo + hi) >>> 1;
+                if (colorIndices[mid] <= firstIndex) {
+                    best = mid;
+                    lo = mid + 1;
+                } else {
+                    hi = mid - 1;
+                }
+            }
+            return best >= 0 ? colorByIndex.get(colorIndices[best])! : null;
+        }
+
+        // Build per-instance draw call groups with transform
+        // matrices.
+        const isSeasonWinner = this.trackIndex === 10;
+
+        // Find the banner DL offset: raw instance 1 is always
+        // the banner. All instances sharing this DL offset are
+        // banner copies placed around the track.
+        let bannerDLOffset = -1;
+        for (const inst of track.instances) {
+            if (inst.rawIndex === 1) {
+                bannerDLOffset = inst.dlOffset;
+                break;
+            }
+        }
+
+        for (const inst of track.instances) {
+            const range = dlToDrawCallRange.get(inst.dlOffset);
+            if (!range) {
+                continue;
+            }
+
+            const isBanner = bannerDLOffset >= 0 && inst.dlOffset === bannerDLOffset;
+
+            // Direct copy of N64 row-major -> gl-matrix
+            // column-major.
+            const mRaw = mat4.create();
+            const s = inst.matrix;
+            for (let j = 0; j < 16; j++) {
+                mRaw[j] = s[j];
+            }
+
+            // Apply coordinate system rotation.
+            const m = mat4.create();
+            mat4.mul(m, n64ToGL, mRaw);
+
+            const drawMatrices = [m, m];
+            const isTransparent = (inst.flags & 0x0008) !== 0;
+            const group: TGRDrawCallGroup = {
+                drawCallInstances: [],
+                isTransparent,
+            };
+
+            for (let i = range.start; i < range.end; i++) {
+                const dc = rspOutput.drawCalls[i];
+                if (dc.indexCount === 0) {
+                    continue;
+                }
+
+                // Look up the most recent prim/env color at this
+                // draw call's firstIndex.
+                const colorState = lookupColor(dc.firstIndex);
+                const prim = colorState ? colorState.primColor : defaultPrim;
+                const env = colorState ? colorState.envColor : defaultEnv;
+
+                // On Season Winner, hide the banner texture but
+                // keep the poles.
+                if (isBanner && isSeasonWinner && dc.textureIndices.length > 0) {
+                    continue;
+                }
+
+                const dci = new TGRDrawCallInstance(this.renderData, drawMatrices, dc, prim, env);
+                dci.isTransparent = isTransparent;
+                group.drawCallInstances.push(dci);
+            }
+
+            if (group.drawCallInstances.length > 0) {
+                this.rawIndexToGroupIdx.set(inst.rawIndex, this.drawCallGroups.length);
+                this.drawCallGroups.push(group);
+            }
+        }
+
+        // Store n64ToGL for animation use.
+        mat4.copy(this.n64ToGL, n64ToGL);
+
+        // Initialize rotation animations from track animation
+        // table.
+        this.initAnimations(track, n64ToGL);
+
+        // Initialize spline animations.
+        this.initSplines(track);
+
+        // Initialize animated texture channels (waterfalls,
+        // bird wings, etc.).
+        this.initAnimatedTextures(device, track, segmentBuffers, sharedOutput, paddedArrayBuffer);
+
+        // Build sky draw call instances.
+        if (skyDCRange) {
+            // The sky dome is rendered at the camera position
+            // with the N64->GL coordinate transform. We store
+            // n64ToGL so prepareToRender can build a per-frame
+            // matrix that tracks the camera.
+            mat4.copy(this.skyN64ToGL, n64ToGL);
+
+            // Use identity as placeholder draw matrix; the
+            // actual matrix is computed per-frame in
+            // prepareToRender using the camera position.
+            const skyIdentity = mat4.create();
+            const skyDrawMatrices = [skyIdentity, skyIdentity];
+
+            for (let i = skyDCRange.start; i < skyDCRange.end; i++) {
+                const dc = rspOutput.drawCalls[i];
+                if (dc.indexCount === 0) {
+                    continue;
+                }
+
+                const colorState = lookupColor(dc.firstIndex);
+                const prim = colorState ? colorState.primColor : defaultPrim;
+                const env = colorState ? colorState.envColor : defaultEnv;
+
+                const dci = new TGRDrawCallInstance(
+                    this.renderData,
+                    skyDrawMatrices,
+                    dc,
+                    prim,
+                    env,
+                );
+                dci.isSky = true;
+                dci.disableDepthWrite();
+                this.skyDrawCallInstances.push(dci);
+            }
+
+            console.debug(`TGR: ${this.skyDrawCallInstances.length} sky draw call instances`);
+        }
+
+        // Compute track center from the first instance's
+        // translation.
+        if (track.instances.length > 0) {
+            const s = track.instances[0].matrix;
+            if (this.mirrored) {
+                vec3.set(
+                    this.trackCenter,
+                    s[13] * WORLD_SCALE,
+                    s[14] * WORLD_SCALE,
+                    -s[12] * WORLD_SCALE,
+                );
+            } else {
+                vec3.set(
+                    this.trackCenter,
+                    s[13] * WORLD_SCALE,
+                    s[14] * WORLD_SCALE,
+                    s[12] * WORLD_SCALE,
+                );
+            }
+        }
+
+        const cx = this.trackCenter[0].toFixed(0);
+        const cy = this.trackCenter[1].toFixed(0);
+        const cz = this.trackCenter[2].toFixed(0);
+        console.debug(
+            `TGR: ${this.drawCallGroups.length} instance groups, center: (${cx}, ${cy}, ${cz})`,
+        );
+    }
+
+    private initAnimations(track: TGRTrack, _n64ToGL: mat4): void {
+        for (const anim of track.animEntries) {
+            // Only rotation types for now.
+            if (anim.type > 2) {
+                continue;
+            }
+
+            const instRawIdx = anim.data;
+            const groupIdx = this.rawIndexToGroupIdx.get(instRawIdx);
+            if (groupIdx === undefined) {
+                continue;
+            }
+
+            // Find the matching raw instance to get the original
+            // N64 matrix.
+            const inst = track.instances.find((i) => i.rawIndex === instRawIdx);
+            if (!inst) {
+                continue;
+            }
+
+            // Decode rotation speed from float bits.
+            const buf = new ArrayBuffer(4);
+            new DataView(buf).setUint32(0, anim.params, false);
+            const speed = new DataView(buf).getFloat32(0, false);
+
+            // Axis in N64 space: type 0=Z, 1=X, 2=Y.
+            const axis =
+                anim.type === 0
+                    ? vec3.fromValues(0, 0, 1)
+                    : anim.type === 1
+                      ? vec3.fromValues(1, 0, 0)
+                      : vec3.fromValues(0, 1, 0);
+
+            // Store the raw N64 matrix (before n64ToGL transform).
+            // This is stored as gl-matrix column-major =
+            // transpose of N64 row-major.
+            const baseMatrixRaw = mat4.create();
+            for (let j = 0; j < 16; j++) {
+                baseMatrixRaw[j] = inst.matrix[j];
+            }
+
+            this.rotationAnims.push({
+                instanceRawIndex: instRawIdx,
+                axis,
+                speed,
+                angle: 0,
+                baseMatrixRaw,
+            });
+        }
+        if (this.rotationAnims.length > 0) {
+            console.debug(`TGR: ${this.rotationAnims.length} rotation animations initialized`);
+        }
+    }
+
+    private updateAnimations(deltaTimeMs: number): void {
+        if (this.rotationAnims.length === 0) {
+            return;
+        }
+
+        // The game applies speed (in degrees) per frame at
+        // ~30fps. Convert to frames:
+        // deltaTimeMs / (1000/30) = deltaTimeMs * 30 / 1000.
+        const dtFrames = (deltaTimeMs * 30.0) / 1000.0;
+        const rotMat = mat4.create();
+        const n64Result = mat4.create();
+        const glResult = mat4.create();
+
+        for (const anim of this.rotationAnims) {
+            // Accumulate angle in degrees (game uses degrees per
+            // frame).
+            anim.angle += anim.speed * dtFrames;
+
+            const groupIdx = this.rawIndexToGroupIdx.get(anim.instanceRawIndex);
+            if (groupIdx === undefined) {
+                continue;
+            }
+            const group = this.drawCallGroups[groupIdx];
+
+            // Convert accumulated angle to radians for
+            // mat4.fromRotation.
+            const angleRad = (anim.angle * Math.PI) / 180.0;
+
+            // RIGHT-multiply the raw N64 matrix by the rotation.
+            mat4.fromRotation(rotMat, angleRad, anim.axis);
+            mat4.copy(n64Result, anim.baseMatrixRaw);
+            mat4.mul(n64Result, n64Result, rotMat);
+
+            // Transform to GL space.
+            mat4.mul(glResult, this.n64ToGL, n64Result);
+
+            // Update all draw call instances in this group.
+            for (const dci of group.drawCallInstances) {
+                dci.setDrawMatrix(glResult);
+            }
+        }
+    }
+
+    private initSplines(track: TGRTrack): void {
+        // Speed: 50 units/sec for most tracks, 18 for Mountain
+        // (track 1) and track 6.
+        const speed = this.trackIndex === 1 || this.trackIndex === 6 ? 18.0 : 50.0;
+
+        for (const spline of track.splines) {
+            const groupIdx = this.rawIndexToGroupIdx.get(spline.followerInstanceIndex);
+            if (groupIdx === undefined) {
+                continue;
+            }
+
+            const state: SplineAnimState = {
+                instanceRawIndex: spline.followerInstanceIndex,
+                leftRail: spline.leftRail,
+                rightRail: spline.rightRail,
+                nodeCount: spline.nodeCount,
+                currentNode: 0,
+                accumDist: 0,
+                segmentLen: 1,
+                speed,
+                active: true,
+            };
+
+            // Compute initial segment length.
+            TGRRenderer.computeSegmentLen(state);
+            this.splineAnims.push(state);
+        }
+        if (this.splineAnims.length > 0) {
+            console.debug(`TGR: ${this.splineAnims.length} spline animations initialized`);
+        }
+    }
+
+    private updateSplines(dt: number): void {
+        const tmpFwd = vec3.create();
+        // N64 Z-up; we transform later.
+        const tmpUp = vec3.fromValues(0, 0, 1);
+        const tmpRight = vec3.create();
+
+        for (const s of this.splineAnims) {
+            if (!s.active) {
+                continue;
+            }
+
+            s.accumDist += s.speed * dt;
+
+            // Advance segments.
+            while (s.accumDist >= s.segmentLen && s.currentNode + 1 < s.nodeCount - 1) {
+                s.accumDist -= s.segmentLen;
+                s.currentNode++;
+                TGRRenderer.computeSegmentLen(s);
+            }
+
+            // Loop back to start.
+            if (s.currentNode + 1 >= s.nodeCount - 1) {
+                s.currentNode = 0;
+                s.accumDist = 0;
+                TGRRenderer.computeSegmentLen(s);
+            }
+
+            const i = s.currentNode;
+            const t = s.segmentLen > 0 ? s.accumDist / s.segmentLen : 0;
+
+            // Interpolate midpoints between left/right rails.
+            const lx0 = s.leftRail[i * 3];
+            const ly0 = s.leftRail[i * 3 + 1];
+            const lz0 = s.leftRail[i * 3 + 2];
+            const rx0 = s.rightRail[i * 3];
+            const ry0 = s.rightRail[i * 3 + 1];
+            const rz0 = s.rightRail[i * 3 + 2];
+            const lx1 = s.leftRail[(i + 1) * 3];
+            const ly1 = s.leftRail[(i + 1) * 3 + 1];
+            const lz1 = s.leftRail[(i + 1) * 3 + 2];
+            const rx1 = s.rightRail[(i + 1) * 3];
+            const ry1 = s.rightRail[(i + 1) * 3 + 1];
+            const rz1 = s.rightRail[(i + 1) * 3 + 2];
+
+            const mx0 = (lx0 + rx0) * 0.5;
+            const my0 = (ly0 + ry0) * 0.5;
+            const mz0 = (lz0 + rz0) * 0.5;
+            const mx1 = (lx1 + rx1) * 0.5;
+            const my1 = (ly1 + ry1) * 0.5;
+            const mz1 = (lz1 + rz1) * 0.5;
+
+            // Position: lerp between midpoints (N64 space).
+            const px = mx0 + (mx1 - mx0) * t;
+            const py = my0 + (my1 - my0) * t;
+            const pz = mz0 + (mz1 - mz0) * t;
+
+            // Forward direction (N64 space).
+            tmpFwd[0] = mx1 - mx0;
+            tmpFwd[1] = my1 - my0;
+            tmpFwd[2] = mz1 - mz0;
+            vec3.normalize(tmpFwd, tmpFwd);
+
+            // Build N64-space 4x4 matrix with position and
+            // orientation. Use forward as X, compute
+            // right = fwd x up, then recompute up.
+            vec3.set(tmpUp, 0, 0, 1); // N64 Z is up.
+            vec3.cross(tmpRight, tmpFwd, tmpUp);
+            vec3.normalize(tmpRight, tmpRight);
+            vec3.cross(tmpUp, tmpRight, tmpFwd);
+            vec3.normalize(tmpUp, tmpUp);
+
+            // N64 row-major matrix stored column-major in our
+            // Float32Array: Row 0 = forward (X),
+            // Row 1 = right (Y), Row 2 = up (Z),
+            // Row 3 = position.
+            const mRaw = mat4.fromValues(
+                tmpFwd[0],
+                tmpRight[0],
+                tmpUp[0],
+                0,
+                tmpFwd[1],
+                tmpRight[1],
+                tmpUp[1],
+                0,
+                tmpFwd[2],
+                tmpRight[2],
+                tmpUp[2],
+                0,
+                px,
+                py,
+                pz,
+                1,
+            );
+
+            // Transform to GL space.
+            const mGL = mat4.create();
+            mat4.mul(mGL, this.n64ToGL, mRaw);
+
+            // Update draw call group.
+            const groupIdx = this.rawIndexToGroupIdx.get(s.instanceRawIndex);
+            if (groupIdx === undefined) {
+                continue;
+            }
+            const group = this.drawCallGroups[groupIdx];
+            for (const dci of group.drawCallInstances) {
+                dci.setDrawMatrix(mGL);
+            }
+        }
+    }
+
+    private initAnimatedTextures(
+        device: GfxDevice,
+        track: TGRTrack,
+        segmentBuffers: ArrayBufferSlice[],
+        sharedOutput: F3DEX.RSPSharedOutput,
+        paddedArrayBuffer: ArrayBuffer,
+    ): void {
+        if (track.animTexChannels.length === 0 || !this.renderData) {
+            return;
+        }
+
+        const texCache = sharedOutput.textureCache.textures;
+        const paddedU8 = new Uint8Array(paddedArrayBuffer);
+
+        for (const ch of track.animTexChannels) {
+            const dramAddr = track.pointerBase + ch.destOffset;
+            const bufOffset = TRACK_RAM_LOW24 + ch.destOffset;
+
+            // Find the base texture cache entry that matches
+            // this channel's DRAM address.
+            let baseCacheIdx = -1;
+            for (let i = 0; i < texCache.length; i++) {
+                if (texCache[i].dramAddr === dramAddr) {
+                    baseCacheIdx = i;
+                    break;
+                }
+            }
+            if (baseCacheIdx < 0) {
+                console.warn(
+                    `TGR: Animated tex channel dest=0x${dramAddr.toString(16)} not found in texture cache.`,
+                );
+                continue;
+            }
+
+            const baseTex = texCache[baseCacheIdx];
+
+            // Save the original texture data (KF0).
+            const origData = paddedU8.slice(bufOffset, bufOffset + ch.texSize);
+
+            // Build GPU textures for each keyframe.
+            const keyframeGfxTextures: GfxTexture[] = [];
+            const keyframeTimes: number[] = [];
+
+            // KF0 is already the base texture in renderData.
+            keyframeGfxTextures.push(this.renderData.textures[baseCacheIdx]);
+            keyframeTimes.push(ch.keyframes[0].time);
+
+            for (let ki = 1; ki < ch.keyframes.length; ki++) {
+                const kf = ch.keyframes[ki];
+                keyframeTimes.push(kf.time);
+
+                // Copy this keyframe's texture data into the
+                // padded buffer.
+                paddedU8.set(kf.texData, bufOffset);
+
+                // Re-translate the texture using the same tile
+                // state.
+                const newTex = RDP.translateTileTexture(
+                    segmentBuffers,
+                    dramAddr,
+                    baseTex.dramPalAddr,
+                    baseTex.tile,
+                    true,
+                );
+                keyframeGfxTextures.push(RDP.translateToGfxTexture(device, newTex));
+            }
+
+            // Restore original KF0 data.
+            paddedU8.set(origData, bufOffset);
+
+            // Find all draw call instances that reference this
+            // texture.
+            const affected: TGRDrawCallInstance[] = [];
+            for (const group of this.drawCallGroups) {
+                for (const dci of group.drawCallInstances) {
+                    for (let slot = 0; slot < 2; slot++) {
+                        if (dci.getTextureIndex(slot) === baseCacheIdx) {
+                            affected.push(dci);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Total cycle time = lastKF.time - firstKF.time (the
+            // game uses modulo of this).
+            const [firstTime] = keyframeTimes;
+            const lastTime = keyframeTimes[keyframeTimes.length - 1];
+            const totalCycleTime = lastTime - firstTime;
+            // If cycle is 0 (shouldn't happen), use a default.
+            const safeCycleTime = totalCycleTime > 0 ? totalCycleTime : 1000;
+
+            this.animTexStates.push({
+                texCacheIndex: baseCacheIdx,
+                keyframeTimes,
+                keyframeGfxTextures,
+                currentKeyframe: 0,
+                timeAccum: 0,
+                totalCycleTime: safeCycleTime,
+                affectedDrawCalls: affected,
+            });
+        }
+
+        if (this.animTexStates.length > 0) {
+            const totalKF = this.animTexStates.reduce(
+                (s, a) => s + a.keyframeGfxTextures.length,
+                0,
+            );
+            console.debug(
+                `TGR: ${this.animTexStates.length} animated texture channels ` +
+                    `(${totalKF} total GPU textures)`,
+            );
+        }
+    }
+
+    private updateAnimatedTextures(dtMs: number): void {
+        // All animated texture channels share a single global
+        // elapsed time (milliseconds). The game uses:
+        // elapsedMs % totalCycleDuration to select keyframes.
+        this.animTexElapsedMs += dtMs;
+
+        for (const at of this.animTexStates) {
+            // Wrap time within the cycle:
+            // totalCycleTime = lastKF.time - firstKF.time.
+            const wrappedTime =
+                at.totalCycleTime > 0 ? this.animTexElapsedMs % at.totalCycleTime : 0;
+
+            // Find active keyframe: walk forward, find last KF
+            // whose time <= wrappedTime.
+            let kfIdx = 0;
+            for (let i = 1; i < at.keyframeTimes.length; i++) {
+                const kfDelta = at.keyframeTimes[i] - at.keyframeTimes[0];
+                if (wrappedTime < kfDelta) {
+                    break;
+                }
+                kfIdx = i;
+            }
+
+            if (kfIdx !== at.currentKeyframe) {
+                at.currentKeyframe = kfIdx;
+                const tex = at.keyframeGfxTextures[kfIdx];
+                for (const dci of at.affectedDrawCalls) {
+                    for (let slot = 0; slot < 2; slot++) {
+                        if (dci.getTextureIndex(slot) === at.texCacheIndex) {
+                            dci.setGfxTexture(slot, tex);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/TopGearRally/scenes.ts
+++ b/src/TopGearRally/scenes.ts
@@ -1,0 +1,47 @@
+import { GfxDevice } from "../gfx/platform/GfxPlatform.js";
+import { SceneContext, SceneDesc, SceneGroup } from "../SceneBase.js";
+import { SceneGfx } from "../viewer.js";
+import { TGRRenderer } from "./render.js";
+import { parseTGRTrack } from "./data.js";
+
+const pathBase = "TopGearRally";
+
+class TopGearRallySceneDesc implements SceneDesc {
+    public constructor(
+        public id: string,
+        public name: string,
+        private readonly trackIndex: number,
+        private readonly mirrored = false,
+    ) {}
+
+    public async createScene(device: GfxDevice, context: SceneContext): Promise<SceneGfx> {
+        const { dataFetcher } = context;
+        const trackData = await dataFetcher.fetchData(`${pathBase}/track_${this.trackIndex}.bin`);
+        const track = parseTGRTrack(trackData);
+        return new TGRRenderer(device, track, this.mirrored, this.trackIndex);
+    }
+}
+
+const sceneDescs = [
+    "Tracks",
+    new TopGearRallySceneDesc("coastline", "Coastline", 2),
+    new TopGearRallySceneDesc("jungle", "Jungle", 4),
+    new TopGearRallySceneDesc("desert", "Desert", 0),
+    new TopGearRallySceneDesc("mountain", "Mountain", 1),
+    new TopGearRallySceneDesc("stripmine", "Strip Mine", 3),
+    "Mirrored",
+    new TopGearRallySceneDesc("coastline_m", "Coastline", 2, true),
+    new TopGearRallySceneDesc("jungle_m", "Jungle", 4, true),
+    new TopGearRallySceneDesc("desert_m", "Desert", 0, true),
+    new TopGearRallySceneDesc("mountain_m", "Mountain", 1, true),
+    new TopGearRallySceneDesc("stripmine_m", "Strip Mine", 3, true),
+    "Other",
+    new TopGearRallySceneDesc("season_winner", "Season Winner", 10),
+];
+
+/** Unique identifier for the Top Gear Rally scene group. */
+export const id = "TopGearRally";
+/** Display name for the Top Gear Rally scene group. */
+export const name = "Top Gear Rally";
+/** Scene group definition containing all Top Gear Rally track scenes. */
+export const sceneGroup: SceneGroup = { id, name, sceneDescs };

--- a/src/main.ts
+++ b/src/main.ts
@@ -102,6 +102,7 @@ import * as Scenes_OuterWilds from './OuterWilds/Scenes.js';
 import * as Scenes_CrashWarped from './CrashWarped/scenes.js';
 import * as Scenes_PlusForXP from './PlusForXP/scenes.js';
 import * as Scenes_MarioKart64 from './MarioKart64/scenes.js';
+import * as Scenes_TopGearRally from './TopGearRally/scenes.js';
 import * as Scenes_KirbyAirRide from './KirbyAirRide/scenes.js';
 import * as Scenes_Descent1 from './Descent1_2/Scenes_Descent1.js';
 import * as Scenes_Descent2 from './Descent1_2/Scenes_Descent2.js';
@@ -260,6 +261,7 @@ const sceneGroups: (string | SceneGroup)[] = [
     Scenes_Descent2.sceneGroup,
     Scenes_Descent2Vertigo.sceneGroup,
     Scenes_TokyoMirageSessionsSharpFE.sceneGroup,
+    Scenes_TopGearRally.sceneGroup,
 ];
 
 enum SaveStatesAction {


### PR DESCRIPTION
I am getting bored of it over the last 3 days so here is most of the job done. It is placed in the Experimental section because of the following issues.

## Affecting all tracks

- Billboard spline-animated models usually have a 'best' viewing angle, and when not viewed at that angle, the skybox is often in the transparent section of the texture.
- Weather is not properly implemented (commented out). This affects some signage in most tracks.
- Reflection is probably implemented incorrectly.

## Coastline

- Missing lighthouse light and its animation.
- Windmill blades clipped at bottom.

## Jungle

- Missing fire above the heads in the tunnel.
- Some directional signs are just solid colours (yellow ones in this track).
- Road texture is shown incorrect in some places (shortcut and towards end of track).
- Second to last waterfall not animated; part of water body missing.

## Desert

- Light textures on the ceiling do not appear correctly in the second and last long tunnel.
- 'FISH N CHIPS' sign is probably supposed to be mirrored when the backside is shown to camera or it is supposed to be a billboard (as stored in the ROM, it rotates).

## Mountain

- Some signs show a different than expected texture (might be directional signs).
- Most of the checkmark banner textures are mirrored.

## Strip Mine

- Animation splines are traced backwards.
- START banner is cut off on the right.
- Most of the checkmark banner textures are mirrored.

## Season Winner

- Camera flashes are not implemented correctly (original code is not designed for free camera).
