### PR TITLE
Add Day of Defeat: Source (PC)

### DIFF
--- a/src/SourceEngine/Scenes_DayOfDefeatSource.ts
+++ b/src/SourceEngine/Scenes_DayOfDefeatSource.ts
@@ -1,0 +1,43 @@
+
+import { GfxDevice } from "../gfx/platform/GfxPlatform.js";
+import { SceneContext, SceneDesc, SceneGroup } from "../SceneBase.js";
+import { SourceFileSystem, SourceLoadContext } from "./Main.js";
+import { createScene } from "./Scenes.js";
+
+class DayOfDefeatSourceSceneDesc implements SceneDesc {
+    constructor(public id: string, public name: string = id) {
+    }
+
+    public async createScene(device: GfxDevice, context: SceneContext) {
+        const filesystem = await context.dataShare.ensureObject(`${pathBase}/SourceFileSystem`, async () => {
+            const filesystem = new SourceFileSystem(context.dataFetcher);
+            await Promise.all([
+                filesystem.createVPKMount(`${pathBase}/dod_pak`),
+                filesystem.createVPKMount(`HalfLife2/hl2_textures`),
+                filesystem.createVPKMount(`HalfLife2/hl2_misc`),
+            ]);
+            return filesystem;
+        });
+
+        const loadContext = new SourceLoadContext(filesystem);
+        return createScene(context, loadContext, this.id, `${pathBase}/maps/${this.id}.bsp`);
+    }
+}
+
+const pathBase = `DayOfDefeatSource`;
+
+const id = 'DayOfDefeatSource';
+const name = 'Day of Defeat: Source';
+const sceneDescs = [
+    new DayOfDefeatSourceSceneDesc('dod_anzio'),
+    new DayOfDefeatSourceSceneDesc('dod_argentan'),
+    new DayOfDefeatSourceSceneDesc('dod_avalanche'),
+    new DayOfDefeatSourceSceneDesc('dod_colmar'),
+    new DayOfDefeatSourceSceneDesc('dod_donner'),
+    new DayOfDefeatSourceSceneDesc('dod_flash'),
+    new DayOfDefeatSourceSceneDesc('dod_jagd'),
+    new DayOfDefeatSourceSceneDesc('dod_kalt'),
+    new DayOfDefeatSourceSceneDesc('dod_palermo'),
+];
+
+export const sceneGroup: SceneGroup = { id, name, sceneDescs };

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,6 +64,7 @@ import * as Scenes_BanjoTooie from './BanjoTooie/scenes.js';
 import * as Scenes_SunshineWater from './InteractiveExamples/SunshineWater.js';
 import * as Scenes_CounterStrikeSource from './SourceEngine/Scenes_CounterStrikeSource.js';
 import * as Scenes_CounterStrikeGO from './SourceEngine/Scenes_CounterStrikeGO.js';
+import * as Scenes_DayOfDefeatSource from './SourceEngine/Scenes_DayOfDefeatSource.js';
 import * as Scenes_HalfLife2 from './SourceEngine/Scenes_HalfLife2.js';
 import * as Scenes_HalfLife2DM from './SourceEngine/Scenes_HalfLife2DM.js';
 import * as Scenes_HalfLife2LostCoast from './SourceEngine/Scenes_HalfLife2LostCoast.js';
@@ -200,6 +201,7 @@ const sceneGroups: (string | SceneGroup)[] = [
     Scenes_DarkSoulsCollision.sceneGroup,
     Scenes_Fez.sceneGroup,
     Scenes_CounterStrikeSource.sceneGroup,
+    Scenes_DayOfDefeatSource.sceneGroup,
     Scenes_HalfLife2.sceneGroup,
     Scenes_HalfLife2DM.sceneGroup,
     Scenes_Halo1.sceneGroup,


### PR DESCRIPTION
Quite straightforward PR. **Adds support for "Day of Defeat: Source", based on Valve's source engine.** This works and might turn the user's computer into a toaster (so let's call it a win/win ;).

It needs the following **Day of Defeat: Source files** (inside /data/DayOfDefeatSource):
```
dod_pak_000.vpk 100.4 MB
dod_pak_001.vpk 100.3 MB
dod_pak_002.vpk 100.4 MB
dod_pak_003.vpk 97.3 MB
dod_pak_004.vpk 134.5 MB
dod_pak_005.vpk 132.5 MB
dod_pak_006.vpk 132.4 MB
dod_pak_dir.vpk 340.2 KB
maps/dod_anzio.bsp 37.0 MB
maps/dod_argentan.bsp 34.3 MB
maps/dod_avalanche.bsp 32.5 MB
maps/dod_colmar.bsp 18.0 MB
maps/dod_donner.bsp 28.3 MB
maps/dod_flash.bsp 27.8 MB
maps/dod_jagd.bsp 42.0 MB
maps/dod_kalt.bsp 32.2 MB
maps/dod_palermo.bsp 33.2 MB
```

As well as the following **Half-Life 2 files** (inside /data/HalfLife2; these files might already exist because of HL2 and Counter Strike: Source support; I can adapt the path as needed):
```
hl2_misc_000.vpk 111.6 MB
hl2_misc_001.vpk 111.8 MB
hl2_misc_002.vpk 111.5 MB
hl2_misc_003.vpk 125.8 MB
hl2_misc_dir.vpk 692.4 KB
hl2_textures_000.vpk 100.8 MB
hl2_textures_001.vpk 102.3 MB
hl2_textures_002.vpk 100.7 MB
hl2_textures_003.vpk 100.7 MB
hl2_textures_004.vpk 100.8 MB
hl2_textures_005.vpk 100.8 MB
hl2_textures_006.vpk 100.7 MB
hl2_textures_007.vpk 101.3 MB
hl2_textures_008.vpk 101.7 MB
hl2_textures_009.vpk 101.4 MB
hl2_textures_010.vpk 101.5 MB
hl2_textures_011.vpk 113.7 MB
hl2_textures_dir.vpk 209.4 KB
```

I can provide them if needed.

Here are the **default savestates** for all the maps:
```
{
    "SaveState_DayOfDefeatSource/dod_jagd/1": "ShareData=AHb3IUOs}+9F}:ZUfy5UV]:loQr/[gUmp2KUNj/r+[$!S91{n68,)c(UEe}pV[",
    "SaveState_DayOfDefeatSource/dod_argentan/1": "ShareData=AY+7FT{632UD4EC9nUPI+$:Du50p*4UWtrMUFpC$Vz14{Um/hj8_pOsUL4[4+^",
    "SaveState_DayOfDefeatSource/dod_flash/1": "ShareData=AE$m_9jZ}rSm*rhTZWCRVv==(P|xZTUmn6w83zcVV,Ixs8w1ce8717A94a(/VS",
    "SaveState_DayOfDefeatSource/dod_kalt/1": "ShareData=AV0CcT*VZd8;v0=UjHfB=j;i;5ea/[Ul{t(T!GaCVo@WV98RMx87@~&UK[@[+^",
    "SaveState_DayOfDefeatSource/dod_colmar/1": "ShareData=AU;XG8aFs49v~l78}4L]+/}GwQ)]zu9D8DwUe0?LWF0GW98FKpTB+H+Swia^+d",
    "SaveState_DayOfDefeatSource/dod_anzio/1": "ShareData=AOX}L93_eg8{k-/9rT6j=Q}m)Q0_12UnL7o9O=)}+=,2zUh}-m9YXp39tF?RVt",
    "SaveState_DayOfDefeatSource/dod_donner/1": "ShareData=AA3zWUjYV8Tr7^r9riB2WN(=i4MwkHUdo9~T_1bNU)H@MUjS|i85iBbUlFKV+d",
    "SaveState_DayOfDefeatSource/dod_avalanche/1": "ShareData=AF=5*UL[JoUUYUMUf_bQWB|!IQyVlrUi$ta9O{tq+?v)Z9wQ-;T7?G}UC2pDVt",
    "SaveState_DayOfDefeatSource/dod_palermo/1": "ShareData=AH:zSUoli/8gNy_UM2z5=DLCZ5*iTlUZR/;TsC?e+}1]K9OF=G8k;:0UdKqMV["
}
```

Fun tidbit, dod_palermo has a "map within a map within a map within a map", all at different scales.
<img width="1440" height="900" alt="DayOfDefeatSource_palermo" src="https://github.com/user-attachments/assets/03ebf528-d79d-43a1-8530-6790eaa4c3f9" />