### PR TITLE
Add Day of Defeat (PC/Experimental)

### DIFF
--- a/src/Common/IdTech2/BSPFile.ts
+++ b/src/Common/IdTech2/BSPFile.ts
@@ -217,7 +217,7 @@ export class BSPFile {
         const vertexData = new Float32Array(numVertexData * 7);
         let dstOffsVertex = 0;
 
-        const indexData = new Uint16Array(numIndexData);
+        const indexData = new Uint32Array(numIndexData);
         let dstOffsIndex = 0;
         let dstIndexBase = 0;
 

--- a/src/Common/IdTech2/Render.ts
+++ b/src/Common/IdTech2/Render.ts
@@ -548,7 +548,7 @@ export class BSPRenderer {
         const vertexBufferDescriptors: GfxInputLayoutBufferDescriptor[] = [
             { byteStride: (3+4)*0x04, frequency: GfxVertexBufferFrequency.PerVertex, },
         ];
-        const indexBufferFormat = GfxFormat.U16_R;
+        const indexBufferFormat = GfxFormat.U32_R;
         this.inputLayout = cache.createInputLayout({ vertexAttributeDescriptors, vertexBufferDescriptors, indexBufferFormat });
 
         this.vertexBuffer = createBufferFromData(device, GfxBufferUsage.Vertex, GfxBufferFrequencyHint.Static, this.bsp.vertexData);
@@ -584,6 +584,13 @@ export class BSPRenderer {
             const classname = entity.classname || '';
 
             if (classname.startsWith('trigger_'))
+                continue;
+
+            const rendermode = parseInt(entity.rendermode || '0', 10);
+            const renderamt = parseInt(entity.renderamt || '0', 10);
+
+            // rendermode 1 (Color) / 2 (Texture) / 5 (Additive) with renderamt 0 = fully transparent
+            if (rendermode !== 0 && rendermode !== 4 && renderamt === 0)
                 continue;
 
             if (this.context.isQuake) {

--- a/src/GoldSrc/Scenes_DayOfDefeat.ts
+++ b/src/GoldSrc/Scenes_DayOfDefeat.ts
@@ -36,6 +36,8 @@ export class DayOfDefeatSceneDesc implements SceneDesc {
 
         renderer.textureCache.addBSP(bspFile);
 
+        // Day of Defeat maps frequently reference WADs from other maps, and mappers
+        // often included every WAD on their system, so expect some 404s.
         await Promise.all(bspFile.getWadList().map(async (v) => {
             const wadPath = normalizeWadPath(v);
             let wadData = await sceneContext.dataFetcher.fetchData(`${pathBase}/${wadPath}`, { allow404: true });
@@ -48,6 +50,15 @@ export class DayOfDefeatSceneDesc implements SceneDesc {
             if (wadData.byteLength > 0) {
                 const wad = parseWAD(wadData);
                 renderer.textureCache.addWAD(wad);
+                return;
+            }
+
+            // WAD not found - check if it matches a map name and load that BSP's textures
+            const wadName = wadPath.split('/').pop()!.replace(/\.wad$/, '');
+            const siblingBspData = await sceneContext.dataFetcher.fetchData(`${pathBase}/dod/maps/${wadName}.bsp`, { allow404: true });
+            if (siblingBspData.byteLength > 0) {
+                const siblingBsp = new BSPFile(siblingBspData);
+                renderer.textureCache.addBSP(siblingBsp);
             }
         }));
 

--- a/src/GoldSrc/Scenes_DayOfDefeat.ts
+++ b/src/GoldSrc/Scenes_DayOfDefeat.ts
@@ -1,0 +1,88 @@
+import { GfxDevice } from "../gfx/platform/GfxPlatform.js";
+import { SceneContext, SceneDesc, SceneGroup } from "../SceneBase.js";
+import { SceneGfx } from "../viewer.js";
+import { BSPFile } from "../Common/IdTech2/BSPFile.js";
+import { BSPRenderer, IdTech2Context, IdTech2Renderer } from "../Common/IdTech2/Render.js";
+import { parseWAD } from "../Common/IdTech2/WAD.js";
+
+const pathBase = `HalfLife`;
+
+function normalizeWadPath(v: string): string {
+    const filename = v.split('/').pop()!;
+
+    // Half-Life WADs always come from valve/
+    if (filename === 'halflife.wad')
+        return `valve/${filename}`;
+
+    if (v.includes('/valve/'))
+        return `valve/${filename}`;
+    if (v.includes('/dod/'))
+        return `dod/${filename}`;
+
+    // Default to dod for unknown paths
+    return `dod/${filename}`;
+}
+
+export class DayOfDefeatSceneDesc implements SceneDesc {
+    constructor(public id: string, public name: string = id) {
+    }
+
+    public async createScene(device: GfxDevice, sceneContext: SceneContext): Promise<SceneGfx> {
+        const bspData = await sceneContext.dataFetcher.fetchData(`${pathBase}/dod/maps/${this.id}.bsp`);
+        const bspFile = new BSPFile(bspData);
+
+        const context = new IdTech2Context(bspFile.version);
+        const renderer = new IdTech2Renderer(device, context);
+
+        renderer.textureCache.addBSP(bspFile);
+
+        await Promise.all(bspFile.getWadList().map(async (v) => {
+            const wadPath = normalizeWadPath(v);
+            let wadData = await sceneContext.dataFetcher.fetchData(`${pathBase}/${wadPath}`, { allow404: true });
+
+            if (wadData.byteLength === 0 && wadPath.startsWith('valve/')) {
+                const dodPath = wadPath.replace(/^valve\//, 'dod/');
+                wadData = await sceneContext.dataFetcher.fetchData(`${pathBase}/${dodPath}`, { allow404: true });
+            }
+
+            if (wadData.byteLength > 0) {
+                const wad = parseWAD(wadData);
+                renderer.textureCache.addWAD(wad);
+            }
+        }));
+
+        const bspRenderer = new BSPRenderer(context, renderer.renderHelper.renderCache, renderer.textureCache, bspFile);
+        renderer.bspRenderers.push(bspRenderer);
+
+        return renderer;
+    }
+}
+
+const sceneDescs = [
+    new DayOfDefeatSceneDesc('dod_anzio'),
+    new DayOfDefeatSceneDesc('dod_avalanche'),
+    new DayOfDefeatSceneDesc('dod_caen'),
+    new DayOfDefeatSceneDesc('dod_charlie'),
+    new DayOfDefeatSceneDesc('dod_chemille'),
+    new DayOfDefeatSceneDesc('dod_donner'),
+    new DayOfDefeatSceneDesc('dod_escape'),
+    new DayOfDefeatSceneDesc('dod_falaise'),
+    new DayOfDefeatSceneDesc('dod_flash'),
+    new DayOfDefeatSceneDesc('dod_flugplatz'),
+    new DayOfDefeatSceneDesc('dod_forest'),
+    new DayOfDefeatSceneDesc('dod_glider'),
+    new DayOfDefeatSceneDesc('dod_jagd'),
+    new DayOfDefeatSceneDesc('dod_kalt'),
+    new DayOfDefeatSceneDesc('dod_kraftstoff'),
+    new DayOfDefeatSceneDesc('dod_merderet'),
+    new DayOfDefeatSceneDesc('dod_northbound'),
+    new DayOfDefeatSceneDesc('dod_saints'),
+    new DayOfDefeatSceneDesc('dod_sturm'),
+    new DayOfDefeatSceneDesc('dod_switch'),
+    new DayOfDefeatSceneDesc('dod_vicenza'),
+    new DayOfDefeatSceneDesc('dod_zalec'),
+];
+
+const id = 'DayOfDefeat';
+const name = "Day of Defeat";
+export const sceneGroup: SceneGroup = { id, name, sceneDescs };

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,6 +91,7 @@ import * as Scenes_Glover from './Glover/scenes.js';
 import * as Scenes_HalfLife from './GoldSrc/Scenes_HalfLife.js';
 import * as Scenes_CounterStrike from './GoldSrc/Scenes_CounterStrike.js';
 import * as Scenes_TeamFortressClassic from './GoldSrc/Scenes_TeamFortressClassic.js';
+import * as Scenes_DayOfDefeat from './GoldSrc/Scenes_DayOfDefeat.js';
 import * as Scenes_Quake from './Quake/Scenes_Quake.js';
 import * as Scenes_SuperMonkeyBall from './SuperMonkeyBall/Scenes_SuperMonkeyBall.js';
 import * as Scenes_DragonQuest8 from './DragonQuest8/scenes.js';
@@ -248,6 +249,7 @@ const sceneGroups: (string | SceneGroup)[] = [
     Scenes_HalfLife.sceneGroup,
     Scenes_CounterStrike.sceneGroup,
     Scenes_TeamFortressClassic.sceneGroup,
+    Scenes_DayOfDefeat.sceneGroup,
     Scenes_Quake.sceneGroup,
     Scenes_Left4Dead2.sceneGroup,
     Scenes_NeoTokyo.sceneGroup,


### PR DESCRIPTION
This PR adds support for Day of Defeat, a mod (and then stand-alone game) for Half-Life (GoldSrc engine).

In order to get rid of some issues, the following changes also had to be implemented (see commit 3be6a3c2846efb6abeb920c28abab3e7c4ca75a8) :
1. Due to an overflow which created some strange virtual artifacts (vertices spanning all across the map), this PR also changes the type of index buffers from Uint16 to Uint32.
2. Brush entities with non-zero rendermode and zero renderamt are not rendered anymore, since they were supposed to be transparent in GoldSrc.
These changes affect other GoldSrc games, but I couldn't find any regressions.

It needs the following **Day of Defeat files** (inside /data/HalfLife/dod; taken from the stand-alone release):
```
decals.wad 942.6 KB
dod_anzio.wad 4.5 MB
dod_avalanche.wad 3.6 MB
dod_caen.wad 6.4 MB
dod_charlie.wad 2.5 MB
dod_chemille.wad 4.3 MB
dod_donner.wad 5.0 MB
dod_escape.wad 6.1 MB
dod_falaise.wad 1.8 MB
dod_flash.wad 3.1 MB
dod_flugplatz.wad 3.9 MB
dod_forest.wad 3.7 MB
dod_glider.wad 4.0 MB
dod_jagd.wad 5.1 MB
dod_kalt.wad 4.9 MB
dod_kraftstoff.wad 3.9 MB
dod_merderet.wad 3.7 MB
dod_narby.wad 5.1 MB
dod_northbound.wad 3.7 MB
dod_saints.wad 5.4 MB
dod_sturm.wad 2.7 MB
dod_vicenza.wad 4.4 MB
dod_zalec.wad 4.6 MB
gfx.wad 84.6 KB
hlbasics.wad 55.5 KB
maps/dod_anzio.bsp 4.3 MB
maps/dod_avalanche.bsp 3.6 MB
maps/dod_caen.bsp 5.2 MB
maps/dod_charlie.bsp 3.8 MB
maps/dod_chemille.bsp 3.7 MB
maps/dod_donner.bsp 3.3 MB
maps/dod_escape.bsp 3.8 MB
maps/dod_falaise.bsp 3.5 MB
maps/dod_flash.bsp 3.1 MB
maps/dod_flugplatz.bsp 3.7 MB
maps/dod_forest.bsp 3.9 MB
maps/dod_glider.bsp 3.7 MB
maps/dod_jagd.bsp 4.8 MB
maps/dod_kalt.bsp 3.5 MB
maps/dod_kraftstoff.bsp 3.4 MB
maps/dod_merderet.bsp 3.5 MB
maps/dod_northbound.bsp 3.9 MB
maps/dod_saints.bsp 3.5 MB
maps/dod_sturm.bsp 3.7 MB
maps/dod_switch.bsp 4.7 MB
maps/dod_vicenza.bsp 4.5 MB
maps/dod_zalec.bsp 5.6 MB
```
I can provide them if needed.

Here are the **default savestates** for all the maps:
```
{
    "SaveState_DayOfDefeat/dod_chemille/1": "ShareData=ACI},UYGB)T2Zi$Us^PXWFHu35yYiqUitj59Ej68+rrVP90ey8TeO5qUoB$!V[",
    "SaveState_DayOfDefeat/dod_donner/1": "ShareData=ANBz(Uc}Pq7XR+OTS){RWN?SkQ1AfTUe!7=TZR=]Vr4yd8Z$_B8o2(PUXhwY+5",
    "SaveState_DayOfDefeat/dod_caen/1": "ShareData=AY^JaUn9A?8$-S[UwVk/V(eF1Q$rx6UbYLbT1JLJVlLPn9r51s8;2T9Uld*0V[",
    "SaveState_DayOfDefeat/dod_sturm/1": "ShareData=AVmh|Ut[E5UEwYH9u8QS=QSV_5gguLUWsrEUJGjW=x[uAUst0w9PoJ2Ue?66Vt",
    "SaveState_DayOfDefeat/dod_saints/1": "ShareData=ADQw4Uu4T1Sn:S,8x5*]VS,2+Q0$ZSUijDLTg}=h++S)zTc;zB88yxQUVkh&+5",
    "SaveState_DayOfDefeat/dod_flash/1": "ShareData=AFH~JUfJFl8)/zhUeAvmWEMRN5E$BhUV2n&T&a+mVhN9N95cqQ9D;^mUhx4gWP",
    "SaveState_DayOfDefeat/dod_zalec/1": "ShareData=AD=VHT+l:e8m;CGUt:a[WOO}v5lP06Uf2Q/TvYb6+,]h*9z,:u7~jlOT-JpR=a",
    "SaveState_DayOfDefeat/dod_northbound/1": "ShareData=AQ8!+Trtz98tl(39h+JI=L=!p5-~)+UpLs!8vkJ6+]9luUc$iQS2L0qTZ]hTV[",
    "SaveState_DayOfDefeat/dod_escape/1": "ShareData=AbREX96KMfUI]?g91EN@=aW[nQzHyIUj2h?T)^1rVWlMaUrGn/UC_VO9uhtJ+^",
    "SaveState_DayOfDefeat/dod_kalt/1": "ShareData=AUU)9UZAat8R0j,UC;8EWIe_$6Y{z1Unp]/Tx~C4Vg:4G9fN&083_T_Uo~ETV[",
    "SaveState_DayOfDefeat/dod_vicenza/1": "ShareData=AYQ@lUtRg(7:5&cT3/vm=P|E}6EoIhUgQ38Tt,Aq+icB?9D|ti8yS*nUc=DUVt",
    "SaveState_DayOfDefeat/dod_kraftstoff/1": "ShareData=AOk~^TUR@J9AUU6UnZEkWMlcFQIy+)UduhrT:/OnVmkpr9x[=@7YqLzTJXT8+^",
    "SaveState_DayOfDefeat/dod_glider/1": "ShareData=AV|u&94w$sS^W^=7E1!{V=LZb5IzTiTDAc]Uv--?WLLq|S|sffUnMJF8L|-7+^",
    "SaveState_DayOfDefeat/dod_merderet/1": "ShareData=AN*AB9dE_X9I_]PUaOSuWQE|05(paQUsmE$UShYy=e~&k9jRpUT*T]j9TK@f+^",
    "SaveState_DayOfDefeat/dod_anzio/1": "ShareData=AU~$&93/L88u/Pr9IJF@=Ilr=6D&:6Uo2G^9Dw(H+!}}GUT^[d8|=5i9w-R[Vt",
    "SaveState_DayOfDefeat/dod_forest/1": "ShareData=AZ(4)92KZu8|E){UT*g2=q4f16HVq,UhsfVT|oxOVuM8Y9Ot:aULegQ95,zB+^",
    "SaveState_DayOfDefeat/dod_charlie/1": "ShareData=AH{~19J::OTN-MKUcCSiV|H^QQc5awUaXyl8TNcU+WofD9o5ed7)h$f9IlyL+^",
    "SaveState_DayOfDefeat/dod_switch/1": "ShareData=AB^?r9sQ6z8pTV|UT/?cV*-&pQ9(W@UrL:gT[@+o=XGUk9Q3YiTzym~9r4/k+^",
    "SaveState_DayOfDefeat/dod_flugplatz/1": "ShareData=AV@^d8Mp/99B9XtUs@~f=KW]Y6d+&tUv5=_T=qF-+nDy_96ACdSx!uj8j5b&V[",
    "SaveState_DayOfDefeat/dod_jagd/1": "ShareData=AK6DhUj+)VTz|J?Um1l2WZZ*l5d8@)Us5Tj8*9Ux+61ab9u9{}T3}bEUkYhy+^",
    "SaveState_DayOfDefeat/dod_falaise/1": "ShareData=AWi:*UlQMh73Cc*TKjr-+;0,45@pEfUWCj6T!t&AVh6&38N*k09Clw!UY4byV[",
    "SaveState_DayOfDefeat/dod_avalanche/1": "ShareData=AW=Q+UNt4dT;xcUUqKpDV64}m5/p56UhLLw8@D:S+3/kO9hVOWT+oQxUBKJ)Vt"
}
```

Some **known issues**
1. Some maps have "flying door compositions". These are probably placeholder for other entities. <img width="1440" height="900" alt="DayOfDefeat_donner" src="https://github.com/user-attachments/assets/6cf49a5b-071b-4a60-8789-2b1b5705b0c5" />
2. dod_flugplatz has some gigantic upside-down tripod add-on to the "flying door composition". <img width="1440" height="900" alt="DayOfDefeat_flugplatz" src="https://github.com/user-attachments/assets/6c41797c-d2b0-4347-9277-93a96f8b64dc" />
