### PR TITLE
Wind Waker: disable glare when facing away from the sun

### DIFF
--- a/src/ZeldaWindWaker/d_kankyo_wether.ts
+++ b/src/ZeldaWindWaker/d_kankyo_wether.ts
@@ -1609,6 +1609,16 @@ function dKyr_sun_move(globals: dGlobals): void {
         // Sun should not glare during strange hours of night.
         sunCanGlare = false;
     }
+    else {
+        const sunForward = scratchVec3;
+        vec3.subtract(sunForward, pkt.sunPos, globals.camera.cameraPos);
+        vec3.normalize(sunForward, sunForward);
+
+        const facingAway = vec3.dot(globals.camera.cameraFwd, sunForward) > 1.0;
+        if (facingAway) {
+            sunCanGlare = false;
+        }
+    }
 
     let numCenterPointsVisible = 0, numPointsVisible = 0, numCulledPoints = 0;
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/af1fbb65-0888-4493-829c-8adc402af66d

https://github.com/user-attachments/assets/9557c82b-641c-4ece-8e0a-221bbe8ee10a

Z peeking (`numPointsVisible`) doesn't seem to consider the sun direction and darkens the environment when looking in the opposite direction.

I preemptively check the angle instead.

Do you find it a reasonable hack ? (I take it you've tried to match the decompiled code)

(Disclaimer: couldn't set up the dev env so I patched the production script for testing, it shouldn't make a difference though)