### PR TITLE
TextureViewer: Corrected off-by-1 value in the texture rendering y coordinate

### DIFF
--- a/src/TextureViewer.ts
+++ b/src/TextureViewer.ts
@@ -12,7 +12,7 @@ uniform sampler2D u_Texture;
 void main() {
     ivec2 t_FragCoord = ivec2(gl_FragCoord.xy);
 #if !GFX_VIEWPORT_ORIGIN_TL()
-    t_FragCoord.y = ${Math.max(height >>> mipLevel, 1)} - t_FragCoord.y;
+    t_FragCoord.y = ${Math.max(height >>> mipLevel, 1)} - 1 - t_FragCoord.y;
 #endif
     gl_FragColor = texelFetch(TEXTURE(u_Texture), t_FragCoord.xy, ${mipLevel});
 }`;


### PR DESCRIPTION
For example, this texture from **Half-Life** that once was cut off above and had a black line beneath:
<img width="64" height="64" alt="image" src="https://github.com/user-attachments/assets/b38d85ba-b2e4-4aef-9f29-6bc4c2c736c8" />
...will now display properly, as:
 <img width="64" height="64" alt="image" src="https://github.com/user-attachments/assets/9f6ba0b8-73e0-40df-bbd8-0ab56906c59c" />