### PR TITLE
Fixup error handling

### DIFF
--- a/src/BanjoKazooie/f3dex.ts
+++ b/src/BanjoKazooie/f3dex.ts
@@ -146,7 +146,7 @@ export function translateCullMode(m: number): GfxCullMode {
     const cullFront = !!(m & RSP_Geometry.G_CULL_FRONT);
     const cullBack = !!(m & RSP_Geometry.G_CULL_BACK);
     if (cullFront && cullBack)
-        throw "whoops";
+        throw new Error("whoops");
     else if (cullFront)
         return GfxCullMode.Front;
     else if (cullBack)

--- a/src/BanjoKazooie/render.ts
+++ b/src/BanjoKazooie/render.ts
@@ -229,7 +229,7 @@ void main() {
         else if (textFilt === TextFilt.G_TF_BILERP)
             texFiltStr = 'Bilerp';
         else
-            throw "whoops";
+            throw new Error("whoops");
 
         const colorInputs: string[] = [
             't_CombColor.rgb', 't_Tex0.rgb', 't_Tex1.rgb', 'u_PrimColor.rgb',

--- a/src/BeetleAdventureRacing/MaterialRenderer.ts
+++ b/src/BeetleAdventureRacing/MaterialRenderer.ts
@@ -292,7 +292,7 @@ export class MaterialRenderer {
         const cullBack = !!(renderOpts & RenderOptionsFlags.ENABLE_BACKFACE_CULLING);
         const cullFront = !!(renderOpts & RenderOptionsFlags.ENABLE_FRONTFACE_CULLING);
         if (cullBack && cullFront) {
-            throw "whoops";
+            throw new Error("whoops");
         } else if (cullBack) {
             stateFlags.cullMode = GfxCullMode.Back;
         } else if (cullFront) {

--- a/src/Common/CTR_H3D/H3D.ts
+++ b/src/Common/CTR_H3D/H3D.ts
@@ -95,7 +95,7 @@ function toSection(relocationType: RelocationType): FileSectionType {
     case RelocationType.RAW_EXT_VERTEX: return FileSectionType.RAW_EXT;
     case RelocationType.RAW_EXT_INDEX: return FileSectionType.RAW_EXT;
     case RelocationType.RAW_EXT_INDEX_U8: return FileSectionType.RAW_EXT;
-    default: throw "whoops";
+    default: throw new Error("whoops");
     }
 }
 

--- a/src/Common/Compression/LZO.ts
+++ b/src/Common/Compression/LZO.ts
@@ -16,7 +16,7 @@ export function decompress(srcBuffer: ArrayBufferSlice, maxDstSize: number): Arr
     const srcView = srcBuffer.createDataView();
 
     if (srcView.byteLength < 3)
-        throw "Input Overrun";
+        throw new Error("Input Overrun");
 
     let inp = 0;
     let outp = 0;
@@ -29,12 +29,12 @@ export function decompress(srcBuffer: ArrayBufferSlice, maxDstSize: number): Arr
 
     function needsIn(count: number): void {
         if (inp + count > srcView.byteLength)
-            throw "Input overrun";
+            throw new Error("Input overrun");
     }
 
     function needsOut(count: number): void {
         if (outp + count > maxDstSize)
-            throw "Output overrun";
+            throw new Error("Output overrun");
     }
 
     function consumeZeroByteLength(): number {
@@ -201,7 +201,7 @@ export function decompress(srcBuffer: ArrayBufferSlice, maxDstSize: number): Arr
             }
         }
         if (lbcur < 0)
-            throw "Lookbehind overrun";
+            throw new Error("Lookbehind overrun");
         needsIn(nstate);
         needsOut(lblen + nstate);
         /* Copy lookbehind */
@@ -214,7 +214,7 @@ export function decompress(srcBuffer: ArrayBufferSlice, maxDstSize: number): Arr
     }
 
     if (lblen !== 3) /* Ensure terminating M4 was encountered */
-        throw "LZO terminator not reached";
+        throw new Error("LZO terminator not reached");
 
     return new ArrayBufferSlice(outBuffer.buffer, 0, outp);
 }

--- a/src/Common/Compression/LZX.ts
+++ b/src/Common/Compression/LZX.ts
@@ -121,7 +121,7 @@ export class LZXState {
         else if (windowBits === 21)
             this.positionSlots = 50;
         else
-            throw "whoops";
+            throw new Error("whoops");
 
         this.maintreeHuffTable = new HuffmanTable(256 + (this.positionSlots << 3));
 
@@ -291,7 +291,7 @@ export function decompressLZX(state: LZXState, dst: Uint8Array, dstOffs: number,
 
         windowOffs &= windowMask;
         if (windowOffs + blockRemaining > windowSize)
-            throw "whoops";
+            throw new Error("whoops");
 
         while (blockRemaining > 0) {
             if (state.blockType === BlockType.Verbatim || state.blockType === BlockType.Aligned) {
@@ -342,7 +342,7 @@ export function decompressLZX(state: LZXState, dst: Uint8Array, dstOffs: number,
                         R2 = R1; R1 = R0; R0 = offs;
                     } else {
                         // TypeScript is too dumb to figure out that this never happens...
-                        throw "whoops";
+                        throw new Error("whoops");
                     }
 
                     let src = (windowOffs - offs);
@@ -364,7 +364,7 @@ export function decompressLZX(state: LZXState, dst: Uint8Array, dstOffs: number,
                 }
                 bs.reset();
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         }
     }

--- a/src/Common/JSYSTEM/J3D/J3DGraphBase.ts
+++ b/src/Common/JSYSTEM/J3D/J3DGraphBase.ts
@@ -565,7 +565,7 @@ export class MaterialInstance {
             break;
 
         default:
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 

--- a/src/Common/JSYSTEM/J3D/J3DGraphSimple.ts
+++ b/src/Common/JSYSTEM/J3D/J3DGraphSimple.ts
@@ -268,7 +268,7 @@ export class J3DModelInstanceSimple extends J3DModelInstance {
         for (let i = 0; i < joints.length; i++)
             if (joints[i].name === jointName)
                 return this.shapeInstanceState.jointToWorldMatrixArray[i];
-        throw "could not find joint";
+        throw new Error("could not find joint");
     }
 
     private calcSkybox(camera: Camera): void {

--- a/src/Common/JSYSTEM/JKRArchive.ts
+++ b/src/Common/JSYSTEM/JKRArchive.ts
@@ -101,7 +101,7 @@ function decompress(src: ArrayBufferSlice, type: JKRCompressionType): ArrayBuffe
     else if (type === JKRCompressionType.Yay0)
         return Yay0.decompress(src);
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 export function parse(buffer: ArrayBufferSlice, name: string = ''): JKRArchive {

--- a/src/Common/JSYSTEM/JPA.ts
+++ b/src/Common/JSYSTEM/JPA.ts
@@ -1426,7 +1426,7 @@ function calcTexIdx(workData: JPAEmitterWorkData, tick: number, time: number, ra
     } else if (bsp1.texCalcIdxType === CalcIdxType.Random) {
         anmIdx = randomPhase % texIdxAnimData.length;
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     return texIdxAnimData[anmIdx];
@@ -1447,7 +1447,7 @@ function calcColor(dstPrm: Color, dstEnv: Color, workData: JPAEmitterWorkData, t
     } else if (bsp1.colorCalcIdxType === CalcIdxType.Random) {
         anmIdx = randomPhase % (bsp1.colorAnimMaxFrm + 1);
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     if (bsp1.colorPrmAnimData !== null)
@@ -1603,7 +1603,7 @@ ${super.generateIndTexStages()}`;
         } else if (index === 3) {
             return `texture(SAMPLER_2D(u_Texture14), ${coord}, TextureLODBias(${index}))`;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 }
@@ -1853,7 +1853,7 @@ export class JPABaseEmitter {
             else if (kfa1.keyType === JPAKeyType.Scale)
                 this.scaleOut = v;
             else
-                throw "whoops";
+                throw new Error("whoops");
         }
     }
 
@@ -2012,7 +2012,7 @@ export class JPABaseEmitter {
         else if (bem1.volumeType === VolumeType.Line)
             this.calcVolumeLine(workData);
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     public createParticle(): JPABaseParticle | null {
@@ -3147,7 +3147,7 @@ export class JPABaseParticle {
             else if (field.type === FieldType.Spin)
                 this.calcFieldSpin(field, workData);
             else
-                throw "whoops";
+                throw new Error("whoops");
         }
     }
 
@@ -3191,7 +3191,7 @@ export class JPABaseParticle {
         else if (type === CalcScaleAnmType.Reverse)
             return 1.0 - this.time;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     private calcScaleFade(scaleAnm: number, esp1: JPAExtraShapeBlock, base: number, increase: number, decrease: number): number {
@@ -3758,7 +3758,7 @@ export class JPABaseParticle {
             this.applyPivot(dst, workData);
             this.loadTexMtx(materialParams.u_TexMtx[0], materialParams.m_TextureMapping[0], workData, dst);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         colorMult(materialParams.u_Color[ColorKind.C0], this.colorPrm, workData.baseEmitter.globalColorPrm);
@@ -4314,7 +4314,7 @@ function parseResource_JEFFjpa1(res: JPAResourceRaw): JPAResource {
         } else if (fourcc === 'TEX1') {
             // Textures were parsed beforehand; skip.
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         tableIdx += blockSize;
@@ -4767,7 +4767,7 @@ function parseResource_JPAC1_00(res: JPAResourceRaw): JPAResource {
             // to JPAC texture indices -- I assume this is "Texture Database".
             tdb1 = buffer.subarray(dataBegin + 0x00).createTypedArray(Uint16Array, 0, tdb1Count, Endianness.BIG_ENDIAN);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         tableIdx += blockSize;
@@ -4927,7 +4927,7 @@ function parseResource_JPAC2(res: JPAResourceRaw, version: JPACVersion): JPAReso
                 isNoDrawParent       = !!((flags >>> 29) & 0x01);
                 isNoDrawChild        = !!((flags >>> 30) & 0x01);
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
 
             if (shapeType === ShapeType.DirectionCross || shapeType === ShapeType.RotationCross)
@@ -5276,7 +5276,7 @@ function parseResource_JPAC2(res: JPAResourceRaw, version: JPACVersion): JPAReso
             // to JPAC texture indices -- I assume this is "Texture Database".
             tdb1 = buffer.subarray(tableIdx + 0x08).createTypedArray(Uint16Array, 0, tdb1Count, Endianness.BIG_ENDIAN);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         tableIdx += blockSize;
@@ -5305,7 +5305,7 @@ function parseResource(version: JPACVersion, resRaw: JPAResourceRaw): JPAResourc
     else if (version === JPACVersion.JPAC2_10 || version === JPACVersion.JPAC2_11)
         return parseResource_JPAC2(resRaw, version);
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function parseJEFFjpa1(buffer: ArrayBufferSlice): JPAC {
@@ -5439,6 +5439,6 @@ export function parse(buffer: ArrayBufferSlice): JPAC {
     else if (version === JPACVersion.JPAC2_10 || version === JPACVersion.JPAC2_11)
         return parseJPAC2(buffer);
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 //#endregion

--- a/src/Common/N64/Image.ts
+++ b/src/Common/N64/Image.ts
@@ -39,7 +39,7 @@ export function getSizBitsPerPixel(siz: ImageSize): number {
     case ImageSize.G_IM_SIZ_8b:  return 8;
     case ImageSize.G_IM_SIZ_16b: return 16;
     case ImageSize.G_IM_SIZ_32b: return 32;
-    default: throw "whoops";
+    default: throw new Error("whoops");
     }
 }
 
@@ -49,7 +49,7 @@ export function getTLUTSize(siz: ImageSize) {
     case ImageSize.G_IM_SIZ_8b:  return 0x100;
     case ImageSize.G_IM_SIZ_16b: return 0x1000;
     case ImageSize.G_IM_SIZ_32b: return 0x10000;
-    default: throw "whoops";
+    default: throw new Error("whoops");
     }
 }
 

--- a/src/Common/N64/RDP.ts
+++ b/src/Common/N64/RDP.ts
@@ -604,7 +604,7 @@ function translateZMode(zmode: ZMode): GfxCompareMode {
         return GfxCompareMode.Less;
     if (zmode === ZMode.ZMODE_DEC)
         return GfxCompareMode.LessEqual;
-    throw "Unknown Z mode: " + zmode;
+    throw new Error("Unknown Z mode: ") + zmode;
 }
 
 export enum BlendParam_PM_Color {
@@ -643,7 +643,7 @@ function translateBlendParamB(paramB: BlendParam_B, srcParam: GfxBlendFactor): G
         return GfxBlendFactor.Zero;
     }
 
-    throw "Unknown Blend Param B: "+paramB;
+    throw new Error("Unknown Blend Param B: ")+paramB;
 }
 
 export function translateRenderMode(renderMode: number): Partial<GfxMegaStateDescriptor> {

--- a/src/Common/NW4R/ef.ts
+++ b/src/Common/NW4R/ef.ts
@@ -278,7 +278,7 @@ class EfEmitter {
         else if (volumeType === VolumeType.Point)
             this.calcVolumePoint(particle);
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     private createParticle(): EfParticle | null {

--- a/src/Common/NW4R/lyt/Font.ts
+++ b/src/Common/NW4R/lyt/Font.ts
@@ -191,7 +191,7 @@ export function parseBRFNT(buffer: NamedArrayBufferSlice): RFNT {
                     cmap[view.getUint16(tableIdx + 0x00)] = view.getUint16(tableIdx + 0x02);
             }
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         tableIdx += blockSize;

--- a/src/Common/NW4R/lyt/Layout.ts
+++ b/src/Common/NW4R/lyt/Layout.ts
@@ -647,7 +647,7 @@ export function parseBRLYT(buffer: ArrayBufferSlice): RLYT {
         } else if (fourcc === 'gre1') {
             groupStack.shift();
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         tableIdx += blockSize;
@@ -785,7 +785,7 @@ function parseBRLAN_AnimFourCCToTrackTypeBase(fourcc: string): RLANAnimationTrac
     if (fourcc === 'RLTS') return RLANAnimationTrackType._TextureTransform_First;
     if (fourcc === 'RLTP') return RLANAnimationTrackType._TexturePattern_First;
     if (fourcc === 'RLIM') return RLANAnimationTrackType._IndirectMatrix_First;
-    throw "whoops";
+    throw new Error("whoops");
 }
 
 export function parseBRLAN(buffer: ArrayBufferSlice): RLAN {
@@ -1017,7 +1017,7 @@ export class LayoutPane {
             window.parse(rlyt as RLYTWindow, layout);
             return window;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -1121,7 +1121,7 @@ export class LayoutPane {
         else if (basePositionX === 2) // right
             return -this.width;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     public getBasePositionY(): number {
@@ -1133,7 +1133,7 @@ export class LayoutPane {
         else if (basePositionY === 2) // bottom
             return this.height;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     protected setOnRenderInst(renderInst: GfxRenderInst): void {
@@ -1364,7 +1364,7 @@ export class LayoutTextbox extends LayoutPane {
         else if (textPositionX === 2) // right
             return 1.0;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     private getTextPositionY(): number {
@@ -1376,7 +1376,7 @@ export class LayoutTextbox extends LayoutPane {
         else if (textPositionY === 2) // bottom
             return 1.0;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     public getTextAlignment(): number {
@@ -1389,7 +1389,7 @@ export class LayoutTextbox extends LayoutPane {
         else if (this.textAlignment === RLYTTextAlignment.Right)
             return 1.0;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     private setCharWriterFont(charWriter: CharWriter): void {
@@ -1516,7 +1516,7 @@ export class LayoutWindow extends LayoutPane {
         else if (flip === RLYTTextureFlip.Rotate180)
             vec4.set(dst, 1, 1, 0, 0);
         else if (flip === RLYTTextureFlip.Rotate90 || flip === RLYTTextureFlip.Rotate270)
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     private drawFrameGetTexCoord(position: RLYTBasePosition, dst: vec2[], frameW: number, frameH: number, texW: number, texH: number, flip: RLYTTextureFlip): void {
@@ -1595,7 +1595,7 @@ export class LayoutWindow extends LayoutPane {
         else if (position === RLYTBasePosition.BottomRight)
             return this.frames[3];
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     private getFrameMaterial(layout: Layout, position: RLYTBasePosition): LayoutMaterial {
@@ -1652,7 +1652,7 @@ export class LayoutWindow extends LayoutPane {
         } else if (this.frames.length === 4) {
         } else if (this.frames.length === 8) {
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         renderInstManager.popTemplate();
@@ -1890,7 +1890,7 @@ function getAnimFrame(anim: RLAN, frame: number): number {
             frame -= lastFrame;
         return frame;
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -1928,7 +1928,7 @@ export class LayoutAnimation {
         else if (animation.type === RLANAnimationType.Material)
             return layout.findMaterialByName(animation.targetName);
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     public isOver(): boolean {

--- a/src/Common/PS2/GS.ts
+++ b/src/Common/PS2/GS.ts
@@ -545,7 +545,7 @@ export function gsMemoryMapUploadImage(map: GSMemoryMap, dpsm: GSPixelStorageFor
     else if (dpsm === GSPixelStorageFormat.PSMT4HL)
         gsMemoryMapUploadImagePSMT4HL(map, dbp, dbw, dsax, dsay, rrw, rrh, buffer);
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 export function gsMemoryMapReadImagePSMT4_PSMCT32(pixels: Uint8Array, map: GSMemoryMap, dbp: number, dbw: number, rrw: number, rrh: number, cbp: number, csa: number, alphaReg: number) {

--- a/src/Common/Unity/AssetManager.ts
+++ b/src/Common/Unity/AssetManager.ts
@@ -226,7 +226,7 @@ export class AssetFile {
             else if (this.fullData !== null)
                 buffer = this.fullData.subarray(Number(obj.byte_start), obj.byte_size);
             else
-                throw "whoops";
+                throw new Error("whoops");
 
             const location = this.createLocation(pathID);
             const classID = obj.class_id;
@@ -319,7 +319,7 @@ export class AssetFile {
         else if (type === UnityAssetResourceType.Shader)
             return this.fetchFromCache(assetSystem, pathID, this.createShaderData) as Promise<ResType<T>>;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     public destroy(device: GfxDevice): void {
@@ -618,7 +618,7 @@ function translateWrapMode(v: number): GfxWrapMode {
     else if (v === rust.UnityTextureWrapMode.MirrorOnce)
         return GfxWrapMode.Mirror; // TODO(jstpierre): what to do here?
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateSampler(header: UnityGLTextureSettings): GfxSamplerDescriptor {
@@ -653,7 +653,7 @@ function calcLevelSize(fmt: UnityTextureFormat, w: number, h: number): number {
         else if (fmt === rust.UnityTextureFormat.BC7)
             return count * 16;
         else
-            throw "whoops";
+            throw new Error("whoops");
     } else if (fmt === rust.UnityTextureFormat.Alpha8) {
         return w * h;
     } else if (fmt === rust.UnityTextureFormat.RGB24) {
@@ -665,7 +665,7 @@ function calcLevelSize(fmt: UnityTextureFormat, w: number, h: number): number {
     } else if (fmt === rust.UnityTextureFormat.ARGB32) {
         return w * h * 4;
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 

--- a/src/CrashWarped/script.ts
+++ b/src/CrashWarped/script.ts
@@ -410,10 +410,10 @@ class ArgStorer implements ArgHandler<number, void> {
     }
 
     public const(index: number, useAlt: boolean): void {
-        throw "store to const"
+        throw new Error("store to const")
     }
     public bool(value: boolean): void {
-        throw "store to bool"
+        throw new Error("store to bool")
     }
     public variable(src: Source, val: number): void {
         assert(src !== Source.SCRIPT_PTR)
@@ -429,7 +429,7 @@ class ArgStorer implements ArgHandler<number, void> {
     public literal(value: number): number {
         // literals are valid, as the game passes a pointer to scratch memory,
         // but can be ignored for our purposes
-        throw "store to literal"
+        throw new Error("store to literal")
     }
 }
 const argStorer = new ArgStorer();
@@ -518,7 +518,7 @@ class PointerBuilder implements ArgHandler<void, number > {
         return buildPointer(PointerBase.CONSTANTS, index);
     }
     public bool(value: boolean): number {
-        throw "pointer to bool";
+        throw new Error("pointer to bool");
     }
     public variable(src: Source): number {
         assert(src !== Source.STACK)
@@ -531,10 +531,10 @@ class PointerBuilder implements ArgHandler<void, number > {
             return buildPointer(PointerBase.PARAMETER, -offset);
     }
     public indirect(base: Source, src: Source): number {
-        throw "pointer to indirect"
+        throw new Error("pointer to indirect")
     }
     public literal(value: number): number {
-        throw "pointer to literal"
+        throw new Error("pointer to literal")
     }
 }
 const argPointerBuilder = new PointerBuilder();

--- a/src/DarkSouls/dds.ts
+++ b/src/DarkSouls/dds.ts
@@ -90,10 +90,10 @@ export function parse(buffer: ArrayBufferSlice, name: string, isSRGB: boolean): 
             assert(ddpf_dwABitMask === 0xFF000000);
             format = 'RGBA';
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     const dwCaps = view.getUint32(0x6C, true);

--- a/src/DarkSouls/mtd.ts
+++ b/src/DarkSouls/mtd.ts
@@ -153,7 +153,7 @@ class DataReader {
             assert(val.length === 4);
             return val as DataTypeRet<T>;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 }
@@ -235,7 +235,7 @@ export function parse(buffer: ArrayBufferSlice): MTD {
             value.push(reader.readFloat32());
             value.push(reader.readFloat32());
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         reader.assertChunkOptional(false); // User data?

--- a/src/DarkSouls/param.ts
+++ b/src/DarkSouls/param.ts
@@ -98,6 +98,6 @@ export class ParamFile {
         else if (field.type === 'u8')
             return this.view.getUint8(this.dataOffs[row] + field.fieldOffs);
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 }

--- a/src/DarkSouls/render.ts
+++ b/src/DarkSouls/render.ts
@@ -73,7 +73,7 @@ function translateLocation(attr: VertexAttribute): number {
         else if (attr.index === 1)
             return MaterialProgram_Base.a_TexCoord1;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
     case VertexInputSemantic.Normal:   return MaterialProgram_Base.a_Normal;
     case VertexInputSemantic.Tangent0: return MaterialProgram_Base.a_Tangent0;
@@ -108,7 +108,7 @@ function translateDataType(dataType: number): GfxFormat {
         // Everything else -- three floats.
         return GfxFormat.F32_RGBA;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 

--- a/src/DebugFloaters.ts
+++ b/src/DebugFloaters.ts
@@ -702,7 +702,7 @@ class GlobalMIDIControls {
         else if (midi.kind === 'slider')
             return 0 + midi.index;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     public bindObject(obj: { [k: string]: any }): void {

--- a/src/DonkeyKong64/f3dex2.ts
+++ b/src/DonkeyKong64/f3dex2.ts
@@ -509,5 +509,5 @@ export function runDL_F3DEX2(state: RSPState, addr: number): void {
         }
     }
 
-    throw "whoops";
+    throw new Error("whoops");
 }

--- a/src/DragonQuest8/chr.ts
+++ b/src/DragonQuest8/chr.ts
@@ -153,7 +153,7 @@ export function parse(cache: GfxRenderCache, buffer: ArrayBufferSlice, name: str
         motFileName = chrcfgInfo.motFileName;
     }
     else
-        throw "info.cfg not found"
+        throw new Error("info.cfg not found")
 
     if (chr.resInfo.has(imgFileName)) {
         chr.img = IMG.parse(buffer.slice(chr.resInfo.get(imgFileName)!.offset, chr.resInfo.get(imgFileName)!.offset + chr.resInfo.get(imgFileName)!.size), imgFileName);

--- a/src/DragonQuest8/img.ts
+++ b/src/DragonQuest8/img.ts
@@ -216,7 +216,7 @@ function processTIM2Texture(img: IMG, buffer: ArrayBufferSlice, name: string, bI
         }
     }
     else
-        throw "Unimplemented format";
+        throw new Error("Unimplemented format");
     img.textures.push({ name, width, height, pixels: finalPixelData });
 }
 
@@ -249,7 +249,7 @@ export function animateTexture(texAnim: TexAnim, animationController: AnimationC
         const srcTexName: string = texAnimData.srcTex;
         const dstTexName: string = texAnimData.dstTex;
         if (!img.texnameToAnimTexture.has(srcTexName) || !img.texnameToAnimTexture.get(dstTexName))
-            throw "srcTex or dstTex not found";
+            throw new Error("srcTex or dstTex not found");
 
         const srcTex: Texture = img.texnameToAnimTexture.get(srcTexName)!;
         const dstTex: Texture = img.texnameToAnimTexture.get(dstTexName)!;

--- a/src/DragonQuest8/map.ts
+++ b/src/DragonQuest8/map.ts
@@ -73,7 +73,7 @@ class SKY {
 function getTimeFlags(start: number, end: number): number {
     if (start === 0) {
         if (end !== 0 && end !== 24) //for 24, seen in purgatory island
-            throw "time flags with null start/end mismatch";
+            throw new Error("time flags with null start/end mismatch");
         return 0xF;//set all flags to true
     }
     if (end < start)
@@ -90,7 +90,7 @@ export function parseSkyCfg(cache: GfxRenderCache, buffer: ArrayBufferSlice): SK
     const skies: SKY[] = [];
     const rNameToInfo = BUNDLE.parseBundle(buffer);
     if (!rNameToInfo.has("info.cfg"))
-        throw "Sky bundle has no cfg file";
+        throw new Error("Sky bundle has no cfg file");
     const lines = decodeString(buffer, 0, buffer.byteLength, "sjis").split('\n');
     for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
@@ -151,7 +151,7 @@ export function parseSkyCfg(cache: GfxRenderCache, buffer: ArrayBufferSlice): SK
             const jointName = line.split("\"")[1];
             const angVel = parseFloat(line.split(",")[2].split(";")[0]);
             if (skies[time].mds === null)
-                throw "sky mds was not registered but anim info was found";
+                throw new Error("sky mds was not registered but anim info was found");
             else {
                 for (let k = 0; k < skies[time].mds!.joints.length; k++) {
                     if (skies[time].mds!.joints[k].name === jointName)
@@ -350,7 +350,7 @@ export async function parse(cache: GfxRenderCache, buffer: ArrayBufferSlice, dat
 
     const ipkInfo = BUNDLE.parseBundle(ipkBuffer);
     if (!ipkInfo.has(map.mapInfo.imgFileName))
-        throw "img file not found";
+        throw new Error("img file not found");
     map.img = IMG.parse(ipkBuffer.slice(ipkInfo.get(map.mapInfo.imgFileName)!.offset, ipkInfo.get(map.mapInfo.imgFileName)!.offset + ipkInfo.get(map.mapInfo.imgFileName)!.size), map.mapInfo.imgFileName);
     for (let i = 0; i < map.img.textures.length; i++) {
         const texture = map.img.textures[i];
@@ -373,7 +373,7 @@ export async function parse(cache: GfxRenderCache, buffer: ArrayBufferSlice, dat
 
     const mpkInfo = BUNDLE.parseBundle(mpkBuffer);
     if (!mpkInfo.has(map.mapInfo.pcpFileName))
-        throw "pcp file not found";
+        throw new Error("pcp file not found");
     const pcpInfo = BUNDLE.parseBundle(mpkBuffer.slice(mpkInfo.get(map.mapInfo.pcpFileName)!.offset), mpkInfo.get(map.mapInfo.pcpFileName)!.offset);
     const processedMDS = new Map<string, string>();
     const processedCHRS = new Map<string, CHR.CHR>();

--- a/src/DragonQuest8/mds.ts
+++ b/src/DragonQuest8/mds.ts
@@ -436,7 +436,7 @@ function parseMDTs(mds: MDS, buffer: ArrayBufferSlice, MDTCount: number, bIsFrom
                         }
                     }
                     else
-                        throw "Unsupported position datatype";
+                        throw new Error("Unsupported position datatype");
 
                     //Normal coords
                     if (normIdxBufferOffset) {
@@ -451,7 +451,7 @@ function parseMDTs(mds: MDS, buffer: ArrayBufferSlice, MDTCount: number, bIsFrom
                             }
                         }
                         else
-                            throw "Unsupported normal datatype";
+                            throw new Error("Unsupported normal datatype");
                     }
                     else {
                         for (let j = 0; j < 3; j++)
@@ -475,7 +475,7 @@ function parseMDTs(mds: MDS, buffer: ArrayBufferSlice, MDTCount: number, bIsFrom
                         }
                     }
                     else
-                        throw "Unsupported uv datatype";
+                        throw new Error("Unsupported uv datatype");
 
                     //Vcol: irrelevant datatype? 0x10 bits while data is obviously bytes, see m01h02-m for ex
                     if (vColIdxBufferOffset) {
@@ -499,7 +499,7 @@ function parseMDTs(mds: MDS, buffer: ArrayBufferSlice, MDTCount: number, bIsFrom
                                     jointSeenMap.set(idx, jointSeenMap.size);
                                     jointPalette.push(idx);
                                     if (jointPalette.length > MDS.maxJointCount)
-                                        throw "More matrices needed";
+                                        throw new Error("More matrices needed");
                                 }
                                 if (idx >= 0)
                                     finalAttribs.push(jointSeenMap.get(idx) as number);
@@ -508,7 +508,7 @@ function parseMDTs(mds: MDS, buffer: ArrayBufferSlice, MDTCount: number, bIsFrom
                             }
                         }
                         else
-                            throw "Unsupported joint index datatype";
+                            throw new Error("Unsupported joint index datatype");
                         //Joint weight
                         if (jWType === EAttributeDataType.SHORT) {
                             for (let j = 0; j < jointPerVertCount; j++) {
@@ -516,7 +516,7 @@ function parseMDTs(mds: MDS, buffer: ArrayBufferSlice, MDTCount: number, bIsFrom
                             }
                         }
                         else
-                            throw "Unsupported joint weight datatype";
+                            throw new Error("Unsupported joint weight datatype");
                     }
                     else if (bIsFromChar) {
                         const idx = mds.rigidTransformJointIds[mdts.length];
@@ -524,7 +524,7 @@ function parseMDTs(mds: MDS, buffer: ArrayBufferSlice, MDTCount: number, bIsFrom
                             jointSeenMap.set(idx, jointSeenMap.size);
                             jointPalette.push(idx);
                             if (jointPalette.length > MDS.maxJointCount)
-                                throw "More matrices needed";
+                                throw new Error("More matrices needed");
                         }
                         if (idx >= 0)
                             finalAttribs.push(jointSeenMap.get(idx) as number);

--- a/src/DragonQuest8/scenes.ts
+++ b/src/DragonQuest8/scenes.ts
@@ -327,7 +327,7 @@ class SceneDesc implements Viewer.SceneDesc {
             }
             for (const [k, v] of map.textureDataMap) {
                 if (texNameToTextureData.has(k))
-                    throw "already there";
+                    throw new Error("already there");
                 texNameToTextureData.set(k, v);
                 viewerTextures.push({ gfxTexture: v.texture });
             }

--- a/src/DragonQuest8/stb.ts
+++ b/src/DragonQuest8/stb.ts
@@ -96,7 +96,7 @@ class STBStackInfo {
 
 function stackOverflowCheck(stackInfo: STBStackInfo) {
     if (stackInfo.currentStackPtr >= stackInfo.maxStackPtr)
-        throw "stack overflow";
+        throw new Error("stack overflow");
 }
 
 function pop(stack: number[], stackInfo: STBStackInfo): number[] {
@@ -192,7 +192,7 @@ function externalFunctionCall(sceneInfo: SINFO.SceneInfo, buffer: ArrayBufferSli
         //Same as 0x3D
         func0x3E(sceneInfo, argvPtr, argc, stack);
     else
-        throw "unknown function id " + functionID.toString();
+        throw new Error("unknown function id ") + functionID.toString();
 }
 
 export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBufferSlice, stb: STB, stack: number[], callStack: number[], stackInfo: STBStackInfo, mdsInstance: MDSInstance): boolean {
@@ -210,7 +210,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
             const t1 = a[0];
             const v1 = a[1];
             if (t1 !== 0)
-                throw "Unexpected data type for 1 x 0x2 instruction";
+                throw new Error("Unexpected data type for 1 x 0x2 instruction");
             push(stack[stackInfo.currentBaseStackPtr + 2 * data0 + 2 * v1], stack[stackInfo.currentBaseStackPtr + 2 * data0 + 2 * v1 + 1], stack, stackInfo);
         }
         else if (data1 === 0x4) {
@@ -218,7 +218,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
             const t1 = a[0];
             const v1 = a[1];
             if (t1 !== 0)
-                throw "Unexpected data type for 1 x 0x4 instruction";
+                throw new Error("Unexpected data type for 1 x 0x4 instruction");
             const vPtr = stack[stackInfo.currentBaseStackPtr + 2 * data0 + 1 + 2 * v1];
             push(stack[vPtr], stack[vPtr + 1], stack, stackInfo);
         }
@@ -231,7 +231,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
             const t1 = a[0];
             const v1 = a[1];
             if (t1 !== 0)
-                throw "Unexpected data type for 1 x 0x10 instruction";
+                throw new Error("Unexpected data type for 1 x 0x10 instruction");
             stack[stackInfo.currentBaseStackPtr + 2 * data0 + 2 * v1] = 1;
             push(1, stack[stackInfo.currentBaseStackPtr + 2 * data0 + 1 + 2 * v1], stack, stackInfo);
         }
@@ -240,7 +240,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
             const t1 = a[0];
             const v1 = a[1];
             if (t1 !== 0)
-                throw "Unexpected data type for 1 x 0x20 instruction";
+                throw new Error("Unexpected data type for 1 x 0x20 instruction");
             stack[stack[stackInfo.currentBaseStackPtr + 2 * data0 + 1] + 2 * v1] = 1;
             push(1, stack[stack[stackInfo.currentBaseStackPtr + 2 * data0 + 1] + 2 * v1 + 1], stack, stackInfo);
         }
@@ -252,7 +252,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
             push(1, stack[stackInfo.field0x7 + 2 * data0 + 1], stack, stackInfo);
         }
         else
-            throw "unimplemented script instruction : " + instructionID.toString() + " " + data0.toString() + " " + data1.toString();
+            throw new Error("unimplemented script instruction : " + instructionID.toString() + " " + data0.toString() + " ") + data1.toString();
 
     }
     else if (instructionID === 0x2) {
@@ -269,7 +269,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
             const t1 = a[0];
             const v1 = a[1];
             if (t1 !== 0)
-                throw "Unexpected data type for 2 x 0x2 instruction";
+                throw new Error("Unexpected data type for 2 x 0x2 instruction");
             push(3, currentBaseStackPtr + 2 * data0 + 2 * v1, stack, stackInfo);
         }
         else if (data1 === 0x4) {
@@ -277,7 +277,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
             const t1 = a[0];
             const v1 = a[1];
             if (t1 !== 0)
-                throw "Unexpected data type for 2 x 0x4 instruction";
+                throw new Error("Unexpected data type for 2 x 0x4 instruction");
             push(3, stack[stackInfo.currentBaseStackPtr + 2 * data0 + 1 + 2 * v1], stack, stackInfo);
         }
         else if (data1 === 0x8) {
@@ -290,7 +290,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
             const t1 = a[0];
             const v1 = a[1];
             if (t1 !== 0)
-                throw "Unexpected data type for 2 x 0x10 instruction";
+                throw new Error("Unexpected data type for 2 x 0x10 instruction");
             push(3, stackInfo.currentBaseStackPtr + 2 * data0 + 2 * v1, stack, stackInfo);
         }
         else if (data1 === 0x20) {
@@ -298,7 +298,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
             const t1 = a[0];
             const v1 = a[1];
             if (t1 !== 0)
-                throw "Unexpected data type for 2 x 0x20 instruction";
+                throw new Error("Unexpected data type for 2 x 0x20 instruction");
             push(3, stack[stackInfo.currentBaseStackPtr + 2 * data0 + 1] + 2 * v1, stack, stackInfo);
         }
         else if (data1 === 0x40) {
@@ -309,7 +309,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
             push(3, stackInfo.field0x7 + 2 * data0, stack, stackInfo);
         }
         else
-            throw "unimplemented script instruction : " + instructionID.toString() + " " + data0.toString() + " " + data1.toString();
+            throw new Error("unimplemented script instruction : " + instructionID.toString() + " " + data0.toString() + " ") + data1.toString();
     }
     else if (instructionID === 0x3) {
         const data0 = view.getUint32(stackInfo.currentInstructionPtr + 0x4, true);
@@ -329,7 +329,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
             push(2, data1 + stackInfo.SB2SecondSectionPtr, stack, stackInfo);
         }
         else
-            throw "unimplemented script instruction : " + instructionID.toString() + " " + data0.toString();
+            throw new Error("unimplemented script instruction : " + instructionID.toString() + " ") + data0.toString();
     }
     else if (instructionID === 0x4) {
         stackInfo.currentStackPtr -= 2;
@@ -387,7 +387,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
         const t2 = b[0];
         const v2 = b[1];
         if (!v1)
-            throw "Division by 0 error";
+            throw new Error("Division by 0 error");
 
         if (!t1 && !t2)
             push(0, Math.floor(v2 / v1), stack, stackInfo);
@@ -403,7 +403,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
         const t2 = b[0];
         const v2 = b[1];
         if (t1 !== 0 || t2 !== 0) {
-            throw "Modulo operation only takes integers";
+            throw new Error("Modulo operation only takes integers");
         }
 
         push(0, v2 % v1, stack, stackInfo);
@@ -450,7 +450,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
         else if (data0 === 0x2d)
             push(0, v1 <= v2 ? 1 : 0, stack, stackInfo);
         else
-            throw "unimplemented script instruction : " + instructionID.toString() + " " + data0.toString();
+            throw new Error("unimplemented script instruction : " + instructionID.toString() + " ") + data0.toString();
     }
     else if (instructionID === 0xf) {
         //Return from "local" function
@@ -514,7 +514,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
         const currentInstructionPtr = stackInfo.currentInstructionPtr;
         const functionInfoPtr = stackInfo.SB2SecondSectionPtr + data1;
         if (stackInfo.callStackPtr >= stackInfo.maxCallStackPtr)
-            throw "Call stack overflow";
+            throw new Error("Call stack overflow");
         callStack[stackInfo.callStackPtr] = currentInstructionPtr;
         callStack[stackInfo.callStackPtr + 2] = stackInfo.functionInfoOffsetPtr;
         callStack[stackInfo.callStackPtr + 1] = stackInfo.currentBaseStackPtr;
@@ -541,7 +541,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
         if (!stackInfo.field0x10) {
             const functionID = stack[stackInfo.currentStackPtr + 1];
             if (functionID >= stackInfo.functionCount)
-                throw "function doesn't exist in table";
+                throw new Error("function doesn't exist in table");
             externalFunctionCall(sceneInfo, buffer, stb, functionID, stackInfo.currentStackPtr + 2, data0 - 1, stack, stackInfo, mdsInstance);
         }
     }
@@ -563,7 +563,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
         const t2 = b[0];
         const v2 = b[1];
         if (t1 !== 0 || t2 !== 0) {
-            throw "And operation only takes integers";
+            throw new Error("And operation only takes integers");
         }
 
         push(0, v2 & v1, stack, stackInfo);
@@ -577,7 +577,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
         const t2 = b[0];
         const v2 = b[1];
         if (t1 !== 0 || t2 !== 0) {
-            throw "Or operation only takes integers";
+            throw new Error("Or operation only takes integers");
         }
 
         push(0, v2 | v1, stack, stackInfo);
@@ -588,7 +588,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
         const t1 = a[0];
         const v1 = a[1];
         if (t1 !== 0) {
-            throw "Not operation only takes an integer";
+            throw new Error("Not operation only takes an integer");
         }
 
         push(0, (v1 !== 0) ? 0 : 1, stack, stackInfo);
@@ -612,7 +612,7 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
         const t1 = a[0];
         const v1 = a[1];
         if (t1 !== 0 && t1 !== 1)
-            throw "Wrong datatype for sin";
+            throw new Error("Wrong datatype for sin");
         push(1, Math.sin(v1), stack, stackInfo);
     }
     else if (instructionID === 0x1e) {
@@ -621,11 +621,11 @@ export function processInstruction(sceneInfo: SINFO.SceneInfo, buffer: ArrayBuff
         const t1 = a[0];
         const v1 = a[1];
         if (t1 !== 0 && t1 !== 1)
-            throw "Wrong datatype for cos";
+            throw new Error("Wrong datatype for cos");
         push(1, Math.cos(v1), stack, stackInfo);
     }
     else
-        throw "unimplemented script instruction : " + instructionID.toString();
+        throw new Error("unimplemented script instruction : ") + instructionID.toString();
     stackInfo.currentInstructionPtr += 0xC;
 
     return false;
@@ -668,7 +668,7 @@ export class STB {
             if (res)
                 return;
         }
-        throw "Possible script bug, 10000 iterations exceeded";
+        throw new Error("Possible script bug, 10000 iterations exceeded");
     }
 }
 
@@ -707,7 +707,7 @@ function func0x4(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, stac
         stack[stack[argvPtr + 5] + 1] = stack[argvPtr + 11] - stack[argvPtr + 17];
     }
     else
-        throw "Unexpected func0x4 argument count";
+        throw new Error("Unexpected func0x4 argument count");
 }
 
 function func0x7(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, stack: number[]) {
@@ -724,7 +724,7 @@ function func0x7(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, stac
         stack[stack[argvPtr + 7] + 1] = Math.sqrt(a * a + b * b + c * c);
     }
     else
-        throw "Unexpected func0x7 argument count";
+        throw new Error("Unexpected func0x7 argument count");
 }
 
 function func0x9(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, stack: number[]) {
@@ -734,7 +734,7 @@ function func0x9(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, stac
         stack[stack[argvPtr + 5] + 1] = Math.atan2(a, b);
     }
     else
-        throw "Unexpected func0x9 argument count";
+        throw new Error("Unexpected func0x9 argument count");
 }
 
 function func0xA(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, stack: number[]) {
@@ -759,10 +759,10 @@ function func0xA(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, stac
         if (stack[argvPtr + 6] === 3)
             stack[stack[argvPtr + 7] + 1] = res;
         else
-            throw "Unexpected func0xA argument type";
+            throw new Error("Unexpected func0xA argument type");
     }
     else
-        throw "Unexpected func0xA argument count";
+        throw new Error("Unexpected func0xA argument count");
 }
 
 function func0xB(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, stack: number[]) {
@@ -780,10 +780,10 @@ function func0xB(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, stac
             stack[stack[argvPtr + 1] + 1] = angle;
         }
         else
-            throw "Unexpected func0xB argument type";
+            throw new Error("Unexpected func0xB argument type");
     }
     else
-        throw "Unexpected func0xB argument count";
+        throw new Error("Unexpected func0xB argument count");
 }
 
 function func0xC(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, stack: number[]) {
@@ -796,7 +796,7 @@ function func0xC(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, stac
             stack[stack[argvPtr + 3] + 1] = Math.floor(v);
     }
     else
-        throw "Unexpected func0xC argument count";
+        throw new Error("Unexpected func0xC argument count");
 }
 
 function func0xD(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, stack: number[]) {
@@ -806,7 +806,7 @@ function func0xD(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, stac
         stack[stack[argvPtr + 17] + 1] = stack[argvPtr + 5] + stack[argvPtr + 11];
     }
     else
-        throw "Unexpected func0xD argument count";
+        throw new Error("Unexpected func0xD argument count");
 }
 
 function func0x14(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, stack: number[]) {
@@ -817,10 +817,10 @@ function func0x14(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, sta
             return;
         }
         else
-            throw "Unexpected func0x14 argument type";
+            throw new Error("Unexpected func0x14 argument type");
     }
     else
-        throw "Unexpected func0x14 argument count";
+        throw new Error("Unexpected func0x14 argument count");
 }
 
 function func0x15(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, stack: number[]) {
@@ -831,7 +831,7 @@ function func0x15(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, sta
             return;
         }
         else
-            throw "Unexpected func0x15 argument type";
+            throw new Error("Unexpected func0x15 argument type");
     }
     else if (argc === 3) {
         if (stack[argvPtr + 1] === 1 && stack[argvPtr + 4] === 3) //block not completely accurate for convenience, should be enough for now
@@ -848,7 +848,7 @@ function func0x15(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, sta
         }
     }
     else
-        throw "Unexpected func0x15 argument count";
+        throw new Error("Unexpected func0x15 argument count");
 }
 
 function func0x16(sceneInfo: SINFO.SceneInfo, argvPtr: number, argc: number, stack: number[]) {
@@ -872,10 +872,10 @@ function func0x1F(argvPtr: number, argc: number, stack: number[], stackInfo: STB
             return;
         }
         else
-            throw "Unexpected func0x1F argument type";
+            throw new Error("Unexpected func0x1F argument type");
     }
     else
-        throw "Unexpected func0x1F argument count";
+        throw new Error("Unexpected func0x1F argument count");
 }
 
 function func0x20(argvPtr: number, argc: number, stack: number[], stackInfo: STBStackInfo) {
@@ -886,15 +886,15 @@ function func0x20(argvPtr: number, argc: number, stack: number[], stackInfo: STB
             return;
         }
         else
-            throw "Unexpected func0x20 argument type";
+            throw new Error("Unexpected func0x20 argument type");
     }
     else
-        throw "Unexpected func0x20 argument count";
+        throw new Error("Unexpected func0x20 argument count");
 }
 
 function func0x32(argvPtr: number, argc: number, stack: number[], stackInfo: STBStackInfo, mdsInstance: MDSInstance) {
     if (stack[argvPtr + 1] !== stackInfo.npcID && stack[argvPtr + 1] !== 0) {
-        throw "trying to get info of another NPC (0x32)! " + stack[argvPtr + 1].toString();
+        throw new Error("trying to get info of another NPC (0x32)! ") + stack[argvPtr + 1].toString();
 
     }
     else if (stack[argvPtr + 1] === 0) {
@@ -906,7 +906,7 @@ function func0x32(argvPtr: number, argc: number, stack: number[], stackInfo: STB
                 stack[outPtr + 1] = 10000;
             }
             else
-                throw "unexpected type for func0x32";
+                throw new Error("unexpected type for func0x32");
         }
         return;
     }
@@ -918,7 +918,7 @@ function func0x32(argvPtr: number, argc: number, stack: number[], stackInfo: STB
             stack[outPtr + 1] = v[i];
         }
         else
-            throw "unexpected type for func0x32";
+            throw new Error("unexpected type for func0x32");
     }
 }
 
@@ -933,7 +933,7 @@ function func0x33(argvPtr: number, argc: number, stack: number[], stackInfo: STB
 
 function func0x34(argvPtr: number, argc: number, stack: number[], stackInfo: STBStackInfo, mdsInstance: MDSInstance) {
     //if (stack[argvPtr + 1] !== stackInfo.npcID)
-    //    throw "trying to get info of another NPC (0x34)! " + stack[argvPtr + 1].toString();
+    //    throw new Error("trying to get info of another NPC (0x34)! ") + stack[argvPtr + 1].toString();
     const v: vec3 = mdsInstance.eulerRot;
     //computeEulerAngleRotationFromSRTMatrix(v, mdsInstance.modelMatrix);
     if (argc === 4) {
@@ -943,7 +943,7 @@ function func0x34(argvPtr: number, argc: number, stack: number[], stackInfo: STB
                 stack[outPtr + 1] = v[i];
             }
             else
-                throw "unexpected type for func0x34 argc 4";
+                throw new Error("unexpected type for func0x34 argc 4");
         }
     }
     else if (argc === 2) {
@@ -952,10 +952,10 @@ function func0x34(argvPtr: number, argc: number, stack: number[], stackInfo: STB
             stack[outPtr + 1] = v[1];
         }
         else
-            throw "unexpected type for func0x34 argc 2";
+            throw new Error("unexpected type for func0x34 argc 2");
     }
     else
-        throw "Unexpected argument count";
+        throw new Error("Unexpected argument count");
 }
 
 function func0x35(argvPtr: number, argc: number, stack: number[], stackInfo: STBStackInfo, mdsInstance: MDSInstance) {
@@ -970,7 +970,7 @@ function func0x35(argvPtr: number, argc: number, stack: number[], stackInfo: STB
         out[1] = stack[argvPtr + 3];
     }
     else
-        throw "Unexpected func0x35 argument count";
+        throw new Error("Unexpected func0x35 argument count");
     const s: vec3 = vec3.create();
     const t: vec3 = vec3.create();
     mat4.getScaling(s, mdsInstance.modelMatrix);

--- a/src/Fez/Sky.ts
+++ b/src/Fez/Sky.ts
@@ -160,7 +160,7 @@ function getDayPhaseStartTime(phase: DayPhase): number {
     else if (phase === DayPhase.Night)
         return 20 / 24;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function getDayPhaseEndTime(phase: DayPhase): number {
@@ -173,7 +173,7 @@ function getDayPhaseEndTime(phase: DayPhase): number {
     else if (phase === DayPhase.Night)
         return 4 / 24;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function ease(t: number): number {

--- a/src/FinalFantasyX/bin.ts
+++ b/src/FinalFantasyX/bin.ts
@@ -58,7 +58,7 @@ function getVifUnpackFormatByteSize(format: number): number {
         assert(vn === 0x03);
         return 2;
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -685,7 +685,7 @@ function parseLevelModel(id: number, view: DataView, offs: number, gsMap: GSMemo
                 }
             } else {
                 console.error(`Unsupported format ${hexzero(format, 2)}`);
-                throw "whoops";
+                throw new Error("whoops");
             }
         } else if ((cmd & 0x7F) === 0x50 || (cmd & 0x7F) === 0x51) { // DIRECT
             // We need to be at the start of a vertex run.
@@ -725,7 +725,7 @@ function parseLevelModel(id: number, view: DataView, offs: number, gsMap: GSMemo
                     currentGSConfiguration.depthWrite = (data1 & 1) === 0;
                 } else {
                     console.warn(`Unknown GS Register ${hexzero(addr, 2)}`);
-                    throw "whoops";
+                    throw new Error("whoops");
                 }
 
                 packetsIdx += 0x10;
@@ -789,7 +789,7 @@ function parseLevelModel(id: number, view: DataView, offs: number, gsMap: GSMemo
             packetsIdx += 0x04;
         } else {
             console.error(`Unknown VIF command ${hexzero(cmd, 2)} at ${hexzero(packetsIdx, 4)}`);
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 }

--- a/src/Glover/parsers/kaitai-struct/KaitaiStream.js
+++ b/src/Glover/parsers/kaitai-struct/KaitaiStream.js
@@ -511,7 +511,7 @@ KaitaiStream.prototype.readBytesTerm = function(terminator, include, consume, eo
   if (i === blen) {
     // we've read all the buffer and haven't found the terminator
     if (eosError) {
-      throw "End of stream reached, but no terminator " + terminator + " found";
+      throw new Error("End of stream reached, but no terminator " + terminator + " found");
     } else {
       return this.mapUint8Array(i);
     }
@@ -583,7 +583,7 @@ KaitaiStream.bytesToStr = function(arr, encoding) {
           return new Buffer(arr).toString(encoding);
           break;
         default:
-          throw "Unsupported"; // NOTE (noclip/naclomi): Removed iconv-lite decoding support since we don't need it here
+          throw new Error("Unsupported"); // NOTE (noclip/naclomi): Removed iconv-lite decoding support since we don't need it here
       }
     }
   }
@@ -630,7 +630,7 @@ KaitaiStream.processRotateLeft = function(data, amount, groupSize) {
 };
 
 KaitaiStream.processZlib = function(buf) {
-  throw "Unsupported"; // NOTE (noclip/naclomi): Removed zlib support since we don't need it here
+  throw new Error("Unsupported"); // NOTE (noclip/naclomi): Removed zlib support since we don't need it here
 };
 
 // ========================================================================
@@ -639,7 +639,7 @@ KaitaiStream.processZlib = function(buf) {
 
 KaitaiStream.mod = function(a, b) {
   if (b <= 0)
-    throw "mod divisor <= 0";
+    throw new Error("mod divisor <= 0");
   var r = a % b;
   if (r < 0)
     r += b;

--- a/src/Halo1/scenes.ts
+++ b/src/Halo1/scenes.ts
@@ -256,7 +256,7 @@ vec4 AB, CD, ABCD;
             else if (input === rust.ShaderInput.Constant1Alpha)
                 return `u_Color1[${stage}].aaa`;
             else
-                throw "whoops";
+                throw new Error("whoops");
         }
 
         function genInputAlpha(input: ShaderAlphaInput, stage: number): string { // float
@@ -311,7 +311,7 @@ vec4 AB, CD, ABCD;
             else if (input === rust.ShaderAlphaInput.Constant1Blue)
                 return `u_Color1[${stage}].b`;
             else
-                throw "whoops";
+                throw new Error("whoops");
         }
 
         function genMapping(input: string, mapping: ShaderMapping, color: boolean): string {
@@ -333,7 +333,7 @@ vec4 AB, CD, ABCD;
             else if (mapping === rust.ShaderMapping.SignedNegate)
                 return `-${input}`;
             else
-                throw "whoops";
+                throw new Error("whoops");
         }
 
         function genInput(colorInput: ShaderInput, colorMapping: ShaderMapping, alphaInput: ShaderAlphaInput, alphaMapping: ShaderMapping, stage: number): string {
@@ -348,7 +348,7 @@ vec4 AB, CD, ABCD;
             else if (func === rust.ShaderOutputFunction.Multiply)
                 return `(${a} * ${b})`;
             else
-                throw "whoops";
+                throw new Error("whoops");
         }
 
         function genMux(mux: boolean, ab: string, cd: string): string {
@@ -369,7 +369,7 @@ vec4 AB, CD, ABCD;
             else if (mapping === rust.ShaderOutputMapping.ExpandNormal)
                 return `${v} = (${v} - 0.5) * 2.0;`;
             else
-                throw "whoops";
+                throw new Error("whoops");
         }
 
         function genOutputColor(output: ShaderOutput, v: string): string {
@@ -392,7 +392,7 @@ vec4 AB, CD, ABCD;
             else if (output === rust.ShaderOutput.Texture3)
                 return `t3.rgb = ${v};`;
             else
-                throw "whoops";
+                throw new Error("whoops");
         }
 
         function genOutputAlpha(output: ShaderOutput, v: string): string {
@@ -415,7 +415,7 @@ vec4 AB, CD, ABCD;
             else if (output === rust.ShaderOutput.Texture3)
                 return `t3.a = ${v};`;
             else
-                throw "whoops";
+                throw new Error("whoops");
         }
 
         const stages = this.shader.get_stages();

--- a/src/Halo1/tex.ts
+++ b/src/Halo1/tex.ts
@@ -65,7 +65,7 @@ function getTextureDimension(type: number): GfxTextureDimension {
     else if (type === rust.BitmapDataType.Tex2D)
         return GfxTextureDimension.n2D;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function makeTexture(device: GfxDevice, bitmap: HaloBitmap, mgr: HaloSceneManager, bitmapReader: HaloBitmapReader, submap = 0): GfxTexture {

--- a/src/JetSetRadio/Render.ts
+++ b/src/JetSetRadio/Render.ts
@@ -513,7 +513,7 @@ export class NjsActionInstance {
             else if (this.frame > duration - 1)
                 this.frame = 0;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         for (let i = 0; i < this.motions.length; ++i)

--- a/src/KatamariDamacy/bin.ts
+++ b/src/KatamariDamacy/bin.ts
@@ -57,7 +57,7 @@ function getVifUnpackFormatByteSize(format: number): number {
         assert(vn === 0x03);
         return 2;
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -378,7 +378,7 @@ function parseModelSector(buffer: ArrayBufferSlice, gsMemoryMap: GSMemoryMap[], 
                 skipVertices = true;
             } else {
                 console.warn(`Unknown vertex run flags format code ${vertexRunFlags2}`);
-                throw "whoops";
+                throw new Error("whoops");
             }
         };
 
@@ -500,7 +500,7 @@ function parseModelSector(buffer: ArrayBufferSlice, gsMemoryMap: GSMemoryMap[], 
                     }
                 } else {
                     console.error(`Unsupported format ${hexzero(format, 2)}`);
-                    throw "whoops";
+                    throw new Error("whoops");
                 }
             } else if ((cmd & 0x7F) === 0x50) { // DIRECT
                 // We need to be at the start of a vertex run.
@@ -564,7 +564,7 @@ function parseModelSector(buffer: ArrayBufferSlice, gsMemoryMap: GSMemoryMap[], 
                         currentGSConfiguration.test_1_data1 = data1;
                     } else {
                         console.warn(`Unknown GS Register ${hexzero(addr, 2)}`);
-                        throw "whoops";
+                        throw new Error("whoops");
                     }
                     // TODO(jstpierre): Other register settings.
 
@@ -626,7 +626,7 @@ function parseModelSector(buffer: ArrayBufferSlice, gsMemoryMap: GSMemoryMap[], 
                 // Don't need to do anything.
             } else {
                 console.error(`Unknown VIF command ${hexzero(cmd, 2)}`);
-                throw "whoops";
+                throw new Error("whoops");
             }
         }
 

--- a/src/KatamariDamacy/render.ts
+++ b/src/KatamariDamacy/render.ts
@@ -189,7 +189,7 @@ function translateWrapMode(wm: CLAMP1_WM): GfxWrapMode {
     case CLAMP1_WM.CLAMP: return GfxWrapMode.Clamp;
     // TODO(jstpierre): Support REGION_* clamp modes.
     case CLAMP1_WM.REGION_REPEAT: return GfxWrapMode.Repeat;
-    default: throw "whoops";
+    default: throw new Error("whoops");
     }
 }
 
@@ -257,7 +257,7 @@ export class BINModelPartInstance {
                 blendDstFactor: GfxBlendFactor.One,
             });
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         // Katamari should not have any mipmaps.

--- a/src/KingdomHearts2FinalMix/map.ts
+++ b/src/KingdomHearts2FinalMix/map.ts
@@ -278,7 +278,7 @@ function parseTextures(buffer: ArrayBufferSlice, textureFile: BarFile, gsMemoryM
             }
 
             if (tex0 === null || clamp === null)
-                throw "whoops";
+                throw new Error("whoops");
 
             if (!textureBlock) {
                 textureBlock = new TextureBlock;
@@ -352,7 +352,7 @@ function processTextureUpload(buffer: ArrayBufferSlice, offs: number, gsMemoryMa
         }
     }
     if (bitbltbuf === null || trxpos === null || trxreg === null)
-        throw "whoops";
+        throw new Error("whoops");
     const imageOffs = textureFile.offset + view.getUint32(offs + 0x74, true);
     let imageBytesize = (view.getUint32(offs + 0x70, true) & 0xFFFFFFF) * 0x10;
     if (imageOffs + imageBytesize > buffer.byteLength) {

--- a/src/LuigisMansion/scenes.ts
+++ b/src/LuigisMansion/scenes.ts
@@ -21,7 +21,7 @@ function fetchBin(path: string, dataFetcher: DataFetcher): Promise<BIN.BIN> {
             const roomBinFile = assertExists(rarc.findFile('room.bin'));
             binBuffer = roomBinFile.buffer;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         const name = path.split('/').pop()!;

--- a/src/MarioKart8Deluxe/AGLParameter.ts
+++ b/src/MarioKart8Deluxe/AGLParameter.ts
@@ -218,7 +218,7 @@ export function parse(buffer: ArrayBufferSlice): ParameterArchive {
             const value = view.getUint32(dataOffset + 0x00, littleEndian);
             return { nameHash, type, value };
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 

--- a/src/MarioKart8Deluxe/Render.ts
+++ b/src/MarioKart8Deluxe/Render.ts
@@ -91,7 +91,7 @@ function translateAddressMode(addrMode: TextureAddressMode): GfxWrapMode {
         // TODO(jstpierre): This requires GL_ARB_texture_mirror_clamp_to_edge
         return GfxWrapMode.Mirror;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -103,7 +103,7 @@ function translateMipFilterMode(filterMode: FilterMode): GfxMipFilterMode {
     case FilterMode.Point:
         return GfxMipFilterMode.Nearest;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -114,7 +114,7 @@ function translateTexFilterMode(filterMode: FilterMode): GfxTexFilterMode {
     case FilterMode.Point:
         return GfxTexFilterMode.Point;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -891,7 +891,7 @@ ${this.generateAlphaTest()}
         case GfxCompareMode.NotEqual:     return `t_PixelOut.a != ${ref}`;
         case GfxCompareMode.GreaterEqual: return `t_PixelOut.a >= ${ref}`;
         case GfxCompareMode.Always:       return `true`;
-        default: throw "whoops";
+        default: throw new Error("whoops");
         }
     }
 
@@ -927,7 +927,7 @@ function getRenderInfoBoolean(renderInfo: FMAT_RenderInfo): boolean {
     else if (value === 'false' || value === '0')
         return false;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateCullMode(fmat: FMAT): GfxCullMode | null {
@@ -941,7 +941,7 @@ function translateCullMode(fmat: FMAT): GfxCullMode | null {
     else if (display_face === 'none')
         return null;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateDepthWrite(fmat: FMAT): boolean {
@@ -957,7 +957,7 @@ function getRenderInfoCompareMode(renderInfo: FMAT_RenderInfo): GfxCompareMode {
     else if (value === 'greater')
         return GfxCompareMode.Greater;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateDepthCompare(fmat: FMAT): GfxCompareMode {
@@ -973,7 +973,7 @@ function getRenderInfoBlendMode(renderInfo: FMAT_RenderInfo): GfxBlendMode {
     if (value === 'add')
         return GfxBlendMode.Add;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateRenderInfoBlendFactor(renderInfo: FMAT_RenderInfo): GfxBlendFactor {
@@ -987,7 +987,7 @@ function translateRenderInfoBlendFactor(renderInfo: FMAT_RenderInfo): GfxBlendFa
     else if (value === 'zero')
         return GfxBlendFactor.Zero;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function findShaderParam(fmat: FMAT, name: string): FMAT_ShaderParam {
@@ -1071,7 +1071,7 @@ function createShaderProgram(fmat: FMAT): DeviceProgram {
     if (shaderAssign.shadingModelName === 'turbo_uber' || shaderAssign.shadingModelName === 'turbo_uber_xlu')
         return new TurboUBER(fmat);
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 class FMATInstance {
@@ -1175,7 +1175,7 @@ class FMATInstance {
         } else if (blendMode === 'none') {
             // Nothing.
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         const pass = getRenderInfoSingleString(fmat.renderInfo.get('gsys_pass')!);
@@ -1219,7 +1219,7 @@ class FMATInstance {
         } else if (render_state_mode === 'translucent') {
             this.sortKey = makeSortKey(GfxRendererLayer.TRANSLUCENT, programKey);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         parseFMAT_ShaderParam_Texsrt(this.texCoordSRT0, findShaderParam(fmat, 'tex_mtx0'));
@@ -1305,7 +1305,7 @@ function translateAttributeFormat(attributeFormat: AttributeFormat): GfxFormat {
         return GfxFormat.F32_RGB;
     default:
         console.error(getChannelFormat(attributeFormat), getTypeFormat(attributeFormat));
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -1461,7 +1461,7 @@ function translateIndexFormat(indexFormat: IndexFormat): GfxFormat {
     case IndexFormat.Uint8:  return GfxFormat.U8_R;
     case IndexFormat.Uint16: return GfxFormat.U16_R;
     case IndexFormat.Uint32: return GfxFormat.U32_R;
-    default: throw "whoops";
+    default: throw new Error("whoops");
     }
 }
 
@@ -1691,7 +1691,7 @@ export class TurboLightEnv {
             vec3.negate(scratchVec3, hemiLight.Direction);
             offs += fillVec3v(d, offs, scratchVec3);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         return offs - baseOffs;

--- a/src/MarioKartWii/Scenes_MarioKartWii.ts
+++ b/src/MarioKartWii/Scenes_MarioKartWii.ts
@@ -100,7 +100,7 @@ function getModelInstance(baseObj: BaseObject): MDL0ModelInstance {
     else if (baseObj instanceof MDL0ModelInstance)
         return baseObj;
     else
-        throw "Object's class does not have a known model instance.";
+        throw new Error("Object's class does not have a known model instance.");
 }
 
 class MarioKartWiiRenderer {
@@ -787,7 +787,7 @@ class MarioKartWiiSceneDesc implements Viewer.SceneDesc {
                 spawnSimpleObject(`kinoko`, `kinoko_d_kuki`);
                 spawnSimpleObject(`kinoko`, `kinoko_d_r`);
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         } else if (objName === `VolcanoRock1`) {
             spawnSimpleObject(`VolcanoRock1`);
@@ -803,7 +803,7 @@ class MarioKartWiiSceneDesc implements Viewer.SceneDesc {
                 spawnSimpleObject(`kinoko`, `kinoko_d_kuki`);
                 spawnSimpleObject(`kinoko`, `kinoko_d_g`);
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         } else if (objName === `Crane`) {
             spawnSimpleObject(`Crane`);

--- a/src/MetroidPrime/mrea.ts
+++ b/src/MetroidPrime/mrea.ts
@@ -1419,7 +1419,7 @@ function parseMaterialSet_MP3(stream: InputStream, resourceSystem: ResourceSyste
                     hasOPAC = true;
                 }
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         }
 
@@ -1537,7 +1537,7 @@ function areaVersionToGameVersion(areaVersion: AreaVersion): GameVersion {
     else if (areaVersion === AreaVersion.DKCR)
         return GameVersion.DKCR;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 export function parseMaterialSet(stream: InputStream, resourceSystem: ResourceSystem, version: GameVersion): MaterialSet {

--- a/src/MetroidPrime/pak.ts
+++ b/src/MetroidPrime/pak.ts
@@ -189,5 +189,5 @@ export function parse(buffer: ArrayBufferSlice, gameCompressionMethod: Compressi
         return parse_MP3(stream, gameCompressionMethod);
     }
 
-    throw "whoops";
+    throw new Error("whoops");
 }

--- a/src/Morrowind/NIFBase.ts
+++ b/src/Morrowind/NIFBase.ts
@@ -236,7 +236,7 @@ function translateAlphaFunction(mode: NIFParse.AlphaFunction): GfxBlendFactor {
     case NIFParse.AlphaFunction.DEST_ALPHA: return GfxBlendFactor.DstAlpha;
     case NIFParse.AlphaFunction.INV_DEST_ALPHA: return GfxBlendFactor.OneMinusDstAlpha;
     case NIFParse.AlphaFunction.SRC_ALPHA_SATURATE: return GfxBlendFactor.Src; // ???
-    default: throw "whoops";
+    default: throw new Error("whoops");
     }
 }
 
@@ -250,7 +250,7 @@ function translateTestFunction(mode: NIFParse.TestFunction): GfxCompareMode {
     case NIFParse.TestFunction.TEST_NOT_EQUAL: return GfxCompareMode.NotEqual;
     case NIFParse.TestFunction.TEST_GREATER_EQUAL: return GfxCompareMode.GreaterEqual;
     case NIFParse.TestFunction.TEST_NEVER: return GfxCompareMode.Never;
-    default: throw "whoops";
+    default: throw new Error("whoops");
     }
 }
 

--- a/src/Morrowind/NIFParse.ts
+++ b/src/Morrowind/NIFParse.ts
@@ -1694,7 +1694,7 @@ export function newRecord(recordType: string): NiParse {
         case 'NiVertexColorProperty': return new NiVertexColorProperty();
         case 'NiZBufferProperty': return new NiZBufferProperty();
         case 'RootCollisionNode': return new RootCollisionNode();
-        default: throw "whoops";
+        default: throw new Error("whoops");
     }
 }
 }

--- a/src/Morrowind/tools/NIFParseGen.ts
+++ b/src/Morrowind/tools/NIFParseGen.ts
@@ -223,7 +223,7 @@ class UnaryExpr implements Expr {
 
         switch (this.op) {
             case '!': return !rhs;
-            default: throw "whoops";
+            default: throw new Error("whoops");
         }
     }
 
@@ -1206,7 +1206,7 @@ class CodeGenerator {
         const newRecord = `export function newRecord(recordType: string): NiParse {
     switch (recordType) {
 ${objects.map((type) => `        case '${type.name}': return new ${type.name}();`).join('\n')}
-        default: throw "whoops";
+        default: throw new Error("whoops");
     }
 }`;
 

--- a/src/NeedForSpeedMostWanted/region.ts
+++ b/src/NeedForSpeedMostWanted/region.ts
@@ -106,7 +106,7 @@ export class NfsRegion {
                 });
                 return false;
             default:
-                throw "Invalid load status";
+                throw new Error("Invalid load status");
         }
     }
 
@@ -325,7 +325,7 @@ export class NfsRegion {
             case GfxFormat.U8_R_NORM:
                 return width * height;
             default:
-                throw "Invalid texture format";
+                throw new Error("Invalid texture format");
         }
     }
 
@@ -342,7 +342,7 @@ export class NfsRegion {
             case 0x29000000:
                 return GfxFormat.U8_R_NORM;
             default:
-                throw "Invalid texture format";
+                throw new Error("Invalid texture format");
         }
     }
 

--- a/src/OcarinaOfTime3D/cmab.ts
+++ b/src/OcarinaOfTime3D/cmab.ts
@@ -126,7 +126,7 @@ function parseTrack(version: Version, buffer: ArrayBufferSlice): AnimationTrack 
         assert(scale === 1);
         assert(bias === 0);
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     let keyframeTableIdx: number = 0x10;
@@ -165,7 +165,7 @@ function parseTrack(version: Version, buffer: ArrayBufferSlice): AnimationTrack 
         }
         return { timeStart, timeEnd, type, frames };
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -429,7 +429,7 @@ function sampleAnimationTrack(track: AnimationTrack, frame: number): number {
     else if (track.type === AnimationTrackType.Integer)
         return sampleAnimationTrackInteger(track, frame);
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function getAnimFrame(anim: AnimationBase, frame: number): number {
@@ -444,7 +444,7 @@ function getAnimFrame(anim: AnimationBase, frame: number): number {
             frame -= lastFrame;
         return frame;
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -469,7 +469,7 @@ export class TextureSRTAnimator {
             const sy = this.animEntry.tracks[1] !== undefined ? sampleAnimationTrack(this.animEntry.tracks[1], animFrame) : 1;
             calcTexMtx(dst, sx, sy, 0, 0, 0);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 }

--- a/src/OcarinaOfTime3D/cmb.ts
+++ b/src/OcarinaOfTime3D/cmb.ts
@@ -334,7 +334,7 @@ function translateBumpTexture(bumpTexture: number): number {
     case BumpTexture.TEXTURE2: return 2;
     case BumpTexture.TEXTURE3: return 3;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -348,7 +348,7 @@ function translateCullModeFlags(cullModeFlags: number): GfxCullMode {
     case 0x02:
         return GfxCullMode.Front;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -363,7 +363,7 @@ function translateCompareMode(compareMode: number): GfxCompareMode {
     case 0x0205: return GfxCompareMode.NotEqual;
     case 0x0206: return GfxCompareMode.GreaterEqual;
     case 0x0207: return GfxCompareMode.Always;
-    default: throw "whoops";
+    default: throw new Error("whoops");
     }
 }
 
@@ -373,7 +373,7 @@ function translateBlendMode(blendMode: number): GfxBlendMode {
     case 0x8006: return GfxBlendMode.Add;
     case 0x800A: return GfxBlendMode.Subtract;
     case 0x800B: return GfxBlendMode.ReverseSubtract;
-    default: throw "whoops";
+    default: throw new Error("whoops");
     }
 }
 
@@ -392,7 +392,7 @@ function translateBlendFactor(blendFactor: number): GfxBlendFactor {
     case 0x0307: return GfxBlendFactor.OneMinusDst;
     case 0x8001: case 0x8003: return GfxBlendFactor.ConstantColor;
     case 0x8002: case 0x8004: return GfxBlendFactor.OneMinusConstantColor;
-    default: throw "whoops";
+    default: throw new Error("whoops");
     }
 }
 
@@ -1160,7 +1160,7 @@ export function parse(buffer: ArrayBufferSlice): CMB {
     else if (version === 0x06)
         cmb.version = Version.Ocarina;
     else
-        throw "whoops";
+        throw new Error("whoops");
 
     let chunkIdx = 0x24;
 

--- a/src/OcarinaOfTime3D/csab.ts
+++ b/src/OcarinaOfTime3D/csab.ts
@@ -116,7 +116,7 @@ function parseTrackOcarina(version: Version, isRotationInt16: boolean, buffer: A
         }
         return { type, timeStart, timeEnd, frames };
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -164,7 +164,7 @@ function parseTrackMajora(version: Version, buffer: ArrayBufferSlice): Animation
         return { type, timeStart, timeEnd, frames };
     }
     else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -174,7 +174,7 @@ function parseTrack(version: Version, isRotationInt16: boolean, buffer: ArrayBuf
     else if (version === Version.Majora || version === Version.LuigisMansion)
         return parseTrackMajora(version, buffer);
     else
-        throw "xxx";
+        throw new Error("xxx");
 }
 
 // "Animation Node"?
@@ -314,7 +314,7 @@ export function parse(version: Version, buffer: ArrayBufferSlice): CSAB {
     else if (version === Version.Majora || version === Version.LuigisMansion)
         return parseMajora(version, buffer);
     else
-        throw "xxx";
+        throw new Error("xxx");
 }
 
 function getAnimFrame(anim: AnimationBase, frame: number): number {
@@ -329,7 +329,7 @@ function getAnimFrame(anim: AnimationBase, frame: number): number {
             frame -= lastFrame;
         return frame;
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -405,7 +405,7 @@ export function sampleAnimationTrack(track: AnimationTrack, frame: number): numb
     else if (track.type === AnimationTrackType.HERMITE)
         return sampleAnimationTrackHermite(track, frame);
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function sampleAnimationTrackRotation(track: AnimationTrack, frame: number): number {
@@ -414,7 +414,7 @@ function sampleAnimationTrackRotation(track: AnimationTrack, frame: number): num
     else if (track.type === AnimationTrackType.HERMITE)
         return sampleAnimationTrackHermite(track, frame);
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 export function calcBoneMatrix(dst: mat4, animationController: AnimationController | null, csab: CSAB | null, bone: Bone): void {

--- a/src/OcarinaOfTime3D/oot3d_scenes.ts
+++ b/src/OcarinaOfTime3D/oot3d_scenes.ts
@@ -922,7 +922,7 @@ class SceneDesc implements Viewer.SceneDesc {
             else if (whichModel === 0x05) //Guillotine Blade (Fast)
                 buildModel(zar, `model/m_Hgiro_model.cmb`, 0.1);
             else
-                throw "whoops";
+                throw new Error("whoops");
         } else if (actor.actorId === ActorId.Demo_Gj) {
             const zar = await fetchArchive(`zelda_gj.zar`);
             const whichModel = actor.variable & 0xFFFF;
@@ -979,7 +979,7 @@ class SceneDesc implements Viewer.SceneDesc {
                 const zar = await fetchArchive(`zelda_ice_objects.zar`);
                 buildModel(zar, `model/ice_trap_model.cmb`, 0.1);
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         } else if (actor.actorId === ActorId.Bg_Haka_Ship) {
             buildModel(await fetchArchive(`zelda_haka_objects.zar`), `model/m_Hship_model.cmb`, 0.1);
@@ -1039,7 +1039,7 @@ class SceneDesc implements Viewer.SceneDesc {
             } else if (whichBox === 0x0C) { // Large
                 setChest(Chest.LARGE_WOODEN);
             } else {
-                throw "Starschulz";
+                throw new Error("Starschulz");
             }
         } else if (actor.actorId === ActorId.En_Door) {
             const zar = await fetchArchive(`zelda_keep.zar`);
@@ -1057,7 +1057,7 @@ class SceneDesc implements Viewer.SceneDesc {
             } else if (whichModel === 0x03) { // Unknown (Seen in Ganon's Castle)
                 // TODO(jstpierre)
             } else {
-                throw "Starschulz";
+                throw new Error("Starschulz");
             }
         } else if (actor.actorId === ActorId.Bg_Bowl_Wall) {
             const zar = await fetchArchive(`zelda_bowl.zar`);
@@ -1069,7 +1069,7 @@ class SceneDesc implements Viewer.SceneDesc {
                 const b = buildModel(zar, `model/bowling_p2_model.cmb`, 1);
                 b.bindCMAB(parseCMAB(zar, `misc/bowling_p2_model.cmab`));
             } else {
-                throw "Starschulz";
+                throw new Error("Starschulz");
             }
         }
         else if (actor.actorId === ActorId.En_Tana) {
@@ -1082,7 +1082,7 @@ class SceneDesc implements Viewer.SceneDesc {
             } else if (whichModel === 0x02) {
                 buildModel(zar, `model/shop_tana03_model.cmb`, 1);  // Granite Shelves ( Goron )
             } else {
-                throw "Starschulz";
+                throw new Error("Starschulz");
             }
         }
         else if (actor.actorId === ActorId.Bg_Bdan_Objects) {
@@ -1097,7 +1097,7 @@ class SceneDesc implements Viewer.SceneDesc {
             } else if (whichModel === 0x03) {
                 buildModel(zar, `model/bdan_fdai_model.cmb`, 0.1);      // Lowering Platform
             } else {
-                throw "Starschulz";
+                throw new Error("Starschulz");
             }
         } else if (actor.actorId === ActorId.Bg_Bdan_Switch) {
             const zar = await fetchArchive(`zelda_bdan_objects.zar`);
@@ -1113,7 +1113,7 @@ class SceneDesc implements Viewer.SceneDesc {
             } else if (whichModel === 0x04) {
                 buildModel(zar, `model/bdan_switch_y_model.cmb`, 0.1);
             } else {
-                throw "Starschulz";
+                throw new Error("Starschulz");
             }
         } else if (actor.actorId === ActorId.En_Bombf) {
             const zar = await fetchArchive(`zelda_bombf.zar`);
@@ -1140,7 +1140,7 @@ class SceneDesc implements Viewer.SceneDesc {
                 const b = buildModel(zar, `model/rezsulfos.cmb`, 0.02);  // Lizalfos drops from ceiling
                 b.bindCSAB(parseCSAB(zar, `anim/zf_matsu.csab`));
             } else {
-                throw "Starschulz";
+                throw new Error("Starschulz");
             }
 
     //    } else if (actor.actorId === ActorId.En_Bx) fetchArchive(`zelda_bxa.zar`).then((zar) => {
@@ -1158,7 +1158,7 @@ class SceneDesc implements Viewer.SceneDesc {
     //        } else if (whichEnemy === 0x05) {
     //            buildModel(zar, `model/balinadetrap.cmb`, 0.025);  //+ Blackish gray
     //        } else {
-    //            throw "Starschulz";
+    //            throw new Error("Starschulz");
     //        }
     //    });
     //   I believe this is the right match of actor and model, but it doesn't really fit right. wrong size, missing something that
@@ -1176,7 +1176,7 @@ class SceneDesc implements Viewer.SceneDesc {
             } else if (whichModel === 0x02) {
                 buildModel(zar, 'model/field_fshot2_model.cmb', 0.1); // Square Wall Target
             } else {
-                throw "starschulz";
+                throw new Error("starschulz");
             }
         } else if (actor.actorId === ActorId.Bg_Gate_Shutter) { // kakariko guard gate
             const zar = await fetchArchive(`zelda_spot01_matoyab.zar`);
@@ -1194,7 +1194,7 @@ class SceneDesc implements Viewer.SceneDesc {
 
                 b.modelMatrix[13] += 5;
             } else {
-                throw "starschulz";
+                throw new Error("starschulz");
             }
         } else if (actor.actorId === ActorId.Bg_Relay_Objects) {
             const zar = await fetchArchive(`zelda_relay_objects.zar`);
@@ -1204,7 +1204,7 @@ class SceneDesc implements Viewer.SceneDesc {
             } else if (whichModel === 0x01) {
                 buildModel(zar, 'model/l_doorpou_model.cmb', 0.1);  // Stone door
             } else {
-                throw "starschulz";
+                throw new Error("starschulz");
             }
         } else if (actor.actorId === ActorId.Bg_Spot06_Objects) { // Lake Hylia Objects
             const zar = await fetchArchive(`zelda_spot06_objects.zar`);
@@ -1218,7 +1218,7 @@ class SceneDesc implements Viewer.SceneDesc {
                 b.bindCMAB(parseCMAB(zar, `misc/c_s06beforewater_modelT.cmab`));
 
             } else {
-                throw "starschulz";
+                throw new Error("starschulz");
             }
         } else if (actor.actorId === ActorId.Bg_Spot02_Objects) {
             const zar = await fetchArchive(`zelda_spot02_objects.zar`);
@@ -1234,7 +1234,7 @@ class SceneDesc implements Viewer.SceneDesc {
                // buildModel(zar, 'model/haka_l_ring_modelT.cmb', 0.1); // Light Aura for when grave explodes
             } else if (whichModel === 0x05) {
             } else {
-                throw "starschulz";
+                throw new Error("starschulz");
             }
         } else if (actor.actorId === ActorId.Bg_Spot16_Doughnut) {
             const zar = await fetchArchive(`zelda_efc_doughnut.zar`);
@@ -1330,7 +1330,7 @@ class SceneDesc implements Viewer.SceneDesc {
             else if (whichModel === 0x04) // Shooting Gallery (Finished)
                 buildModel(await fetchArchive(`zelda_spot01_matoya.zar`), `model/c_matoate_house_model.cmb`, 0.1);
             else
-                throw "whoops";
+                throw new Error("whoops");
         } else if (actor.actorId === ActorId.Door_Warp1) {
             const zar = await fetchArchive(`zelda_warp1.zar`);
             const b = buildModel(zar, `model/warp_2_modelT.cmb`, 1);
@@ -1345,7 +1345,7 @@ class SceneDesc implements Viewer.SceneDesc {
             else if (whichModel === 0x02) // Three Rising Platforms
                 buildModel(zar, `model/ydan_maruta_model.cmb`, 0.1);
             else
-                throw "whoops";
+                throw new Error("whoops");
         } else if (actor.actorId === ActorId.Bg_Ydan_Maruta) {
             const zar = await fetchArchive(`zelda_ydan_objects.zar`);
             const whichModel = (actor.variable >>> 8) & 0x0F;
@@ -1398,7 +1398,7 @@ class SceneDesc implements Viewer.SceneDesc {
             } else if (scene === Scene.GerudoTrainingGround) {
                 buildModel(zar, `model/brick_15_gerd_La_model.cmb`, scale);
             } else
-                throw "whoops";
+                throw new Error("whoops");
         } else if (actor.actorId === ActorId.Obj_Switch) {
             const zar = await fetchArchive(`zelda_dangeon_keep.zar`);
             // TODO(jstpierre): What determines the diff. between the yellow and silver eye switches?
@@ -1414,14 +1414,14 @@ class SceneDesc implements Viewer.SceneDesc {
                 else if (isAdultDungeon(scene))
                     buildModel(zar, `model/switch_5_model.cmb`, 0.1);
                 else
-                    throw "whoops";
+                    throw new Error("whoops");
             else if (whichSwitch === 0x03) // Crystal Switch
                 // TODO(jstpierre): Green vs. red? Is this only used in Fire and Forest?
                 buildModel(zar, `model/switch_6_model.cmb`, 0.1);
             else if (whichSwitch === 0x04) // Targetable Crystal Switch
                 buildModel(zar, `model/switch_9_model.cmb`, 0.1);
             else
-                throw "whoops";
+                throw new Error("whoops");
         } else if (actor.actorId === ActorId.Door_Ana) {
             buildModel(await fetchArchive(`zelda_field_keep.zar`), `model/ana01_modelT.cmb`);
         } else if (actor.actorId === ActorId.Bg_Mjin) {
@@ -1455,7 +1455,7 @@ class SceneDesc implements Viewer.SceneDesc {
             else if (whichModel === 0x02) // Web-Hovered Hole
                 buildModel(zar, `model/ydan_spyuka_modelT.cmb`, 0.1);
             else
-                throw "whoops";
+                throw new Error("whoops");
         } else if (actor.actorId === ActorId.Grezzo_DekuTreeWeb) {
             const zar = await fetchArchive(`zelda_ydan_objects.zar`);
             const b = buildModel(zar, `model/deku_kumo_kabe.cmb`, 0.05);
@@ -1498,7 +1498,7 @@ class SceneDesc implements Viewer.SceneDesc {
                 // const b = buildModel(zar, `model/tokinoma_hikari3_modelT.cmb`, 1);
                 // b.bindCMAB(parseCMAB(zar, `misc/tokinoma_hikari3_modelT.cmab`));
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         } else if (actor.actorId === ActorId.Bg_Haka) {
             const zar = await fetchArchive(`zelda_haka.zar`);
@@ -1522,7 +1522,7 @@ class SceneDesc implements Viewer.SceneDesc {
             } else if (whichModel === 0x02) {
                 buildModel(zar, `model/grass05_model.cmb`, 0.4);
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         } else if (actor.actorId === ActorId.Bg_Spot03_Taki) {
             const zar = await fetchArchive(`zelda_spot03_object.zar`);
@@ -1599,7 +1599,7 @@ class SceneDesc implements Viewer.SceneDesc {
                 b.shapeInstances[6].visible = false;
                 b.bindCSAB(parseCSAB(zar, `anim/fad_n_wait.csab`));
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         } else if (actor.actorId === ActorId.En_Ossan) {
             const whichShopkeeper = actor.variable & 0x0F;
@@ -1645,7 +1645,7 @@ class SceneDesc implements Viewer.SceneDesc {
 
             } else {
                 console.log(whichShopkeeper);
-                throw "Starschulz";
+                throw new Error("Starschulz");
             }
         } else if (actor.actorId === ActorId.En_Brob) {
             const zar = await fetchArchive('zelda_brob.zar');
@@ -1666,7 +1666,7 @@ class SceneDesc implements Viewer.SceneDesc {
                 const b = buildModel(zar, `model/soldier2.cmb`);
 
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         } else if (actor.actorId === ActorId.En_Eiyer) {
             const zar = await fetchArchive(`zelda_ei.zar`);
@@ -1692,7 +1692,7 @@ class SceneDesc implements Viewer.SceneDesc {
                 b.bindCSAB(parseCSAB(zar, `anim/ei_swim.csab`));
 
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         } else if (actor.actorId === ActorId.En_Horse_Link_Child) {
             const zar = await fetchArchive(`zelda_hlc.zar`);
@@ -1952,7 +1952,7 @@ class SceneDesc implements Viewer.SceneDesc {
                 b.setConstantColor(3, colorNewFromRGBA(0.11765, 0.94118, 0.78431));
                 b.setConstantColor(4, colorNewFromRGBA(0.35294, 0.23529, 0.03992));
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         } else if (actor.actorId === ActorId.En_Dog) {
             const zar = await fetchArchive(`zelda_dog.zar`);

--- a/src/OcarinaOfTime3D/pica_texture.ts
+++ b/src/OcarinaOfTime3D/pica_texture.ts
@@ -52,7 +52,7 @@ export function computeTextureByteSize(format: TextureFormat, width: number, hei
     case TextureFormat.A4:
         return (width * height) / 2;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 

--- a/src/OcarinaOfTime3D/render.ts
+++ b/src/OcarinaOfTime3D/render.ts
@@ -142,7 +142,7 @@ uniform samplerCube u_Cubemap;
         case GfxCompareMode.Greater: return `t_CmbOut.a >  ${ref}`;
         case GfxCompareMode.GreaterEqual:  return `t_CmbOut.a >= ${ref}`;
         case GfxCompareMode.Always:  return `true`;
-        default: throw "whoops";
+        default: throw new Error("whoops");
         }
     }
 
@@ -1026,7 +1026,7 @@ class SepdData {
             } else if (dataType === CMB.DataType.UInt) {
                 return Float32Array.from(buffer.createTypedArray(Uint32Array), (v) => v * scale);
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         };
 

--- a/src/OcarinaOfTime3D/zar.ts
+++ b/src/OcarinaOfTime3D/zar.ts
@@ -133,5 +133,5 @@ export function parse(buffer: ArrayBufferSlice): ZAR {
     else if ([Magic.GAR5].includes(magic))
         return parseLM3DS(buffer);
     else
-        throw "whoops";
+        throw new Error("whoops");
 }

--- a/src/PaperMario64/evt.ts
+++ b/src/PaperMario64/evt.ts
@@ -315,7 +315,7 @@ export class evtmgr {
         else if (expr < -20000000)
             evt.lw[expr - -30000000] = v;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     private scanend(evt: evt_exec, opena: op[], close: op): void {
@@ -863,7 +863,7 @@ export class evtmgr {
         } break;
         default:
             console.warn("unimplemented op", op[evt.opcode]);
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         if (evt.pc === oldpc && !(evt.flags & evt_flags.userfuncblock))

--- a/src/PaperMario64/map_shape.ts
+++ b/src/PaperMario64/map_shape.ts
@@ -106,7 +106,7 @@ export function parse(buffer: ArrayBufferSlice): MapShapeBinary {
                 return { id, type, value };
             }
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -137,7 +137,7 @@ export function parse(buffer: ArrayBufferSlice): MapShapeBinary {
             if (p.type === PropertyType.FLOAT)
                 return p.value1 as number;
             else
-                throw "whoops";
+                throw new Error("whoops");
         }
 
         function expectPropertyString(id: number) {
@@ -146,7 +146,7 @@ export function parse(buffer: ArrayBufferSlice): MapShapeBinary {
             if (p.type === PropertyType.STRING)
                 return p.value as (string | null);
             else
-                throw "whoops";
+                throw new Error("whoops");
         }
 
         const minX = expectPropertyFloat(0x61);

--- a/src/PaperMario64/render.ts
+++ b/src/PaperMario64/render.ts
@@ -286,7 +286,7 @@ function translateCullMode(m: number): GfxCullMode {
     const cullFront = !!(m & 0x200);
     const cullBack = !!(m & 0x400);
     if (cullFront && cullBack)
-        throw "whoops";
+        throw new Error("whoops");
     else if (cullFront)
         return GfxCullMode.Front;
     else if (cullBack)
@@ -452,7 +452,7 @@ class ModelTreeLeafInstance {
             offsetS = this.secondaryTileOffsetS / 0x04;
             offsetT = this.secondaryTileOffsetT / 0x04;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         dst[0] *= scaleS;
@@ -669,7 +669,7 @@ export class PaperMario64ModelTreeRenderer {
         } else if (modelTreeNode.type === 'leaf') {
             return new ModelTreeLeafInstance(device, this.cache, this.textureArchive, this.textureHolder, modelTreeNode);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 

--- a/src/PaperMario64/tex.ts
+++ b/src/PaperMario64/tex.ts
@@ -161,7 +161,7 @@ export function parseTextureArchive(buffer: ArrayBufferSlice): TextureArchive {
             images.push(image0);
             images.push(image1);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         const hasSecondImage = images.length === 2;

--- a/src/PaperMarioTTYD/AnimGroup.ts
+++ b/src/PaperMarioTTYD/AnimGroup.ts
@@ -172,7 +172,7 @@ function animGroupDrawLoadVertexData(draw: AnimGroupData_Draw, vtxArrays: GX_Arr
             } else if (format === GfxFormat.U8_RGBA_NORM) {
                 dstView.setUint32(dstOffs + 0x00, srcView.getUint32(srcOffs + 0x00));
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         }
     }

--- a/src/PaperMarioTTYD/REL.ts
+++ b/src/PaperMarioTTYD/REL.ts
@@ -89,7 +89,7 @@ export function linkREL(buffer: ArrayBufferSlice, baseAddress: number): void {
             } else if (op === RelocationOp.R_DOLPHIN_END) {
                 break;
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
 
             relocIdx += 0x08;

--- a/src/PaperMarioTTYD/evt.ts
+++ b/src/PaperMarioTTYD/evt.ts
@@ -980,7 +980,7 @@ export class evtmgr {
         } break;
         default:
             console.warn("unimplemented op", op[evt.opcode]);
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         if (evt.pc === oldpc && !(evt.flags & evt_flags.userfuncblock))
@@ -1314,6 +1314,6 @@ function intplGetValue(a: number, b: number, mode: number, frm: number, numFrm: 
     case 2: return a + frm**3 * (b - a) / numFrm**3;
     case 3: return a + frm**4 * (b - a) / numFrm**4;
     case 11: return a + (b - a) * (1.0 - Math.cos(Math.PI * frm) / numFrm) / 2.0;
-    default: throw "whoops";
+    default: throw new Error("whoops");
     }
 }

--- a/src/Pilotwings64/Scenes.ts
+++ b/src/Pilotwings64/Scenes.ts
@@ -2987,7 +2987,7 @@ function envIndex(level: number, weather: number): number {
     } else if (level === 3) {
         return weather < 3 ? base + 1 : base; // skip 3, but states has an extra
     }
-    throw "Unknown level " + level;
+    throw new Error("Unknown level " + level);
 }
 
 // mapping from env_loadtpal (2e1990) combined with envIndex

--- a/src/PokemonSnap/animation.ts
+++ b/src/PokemonSnap/animation.ts
@@ -439,7 +439,7 @@ export function findNewTextures(dataMap: DataMap, track: AnimationTrack | null, 
     const textureCache = model.sharedOutput.textureCache;
     const dc = model.rspOutput?.drawCalls.find((d) => d.materialIndex === index);
     if (dc === undefined)
-        throw "no corresponding draw call for material";
+        throw new Error("no corresponding draw call for material");
     if (track === null) {
         if (matData.optional)
             return; // we've already gotten the default values

--- a/src/PokemonSnap/f3dex2.ts
+++ b/src/PokemonSnap/f3dex2.ts
@@ -35,7 +35,7 @@ export function translateCullMode(geoMode: number): GfxCullMode {
     const cullBack = !!(geoMode & RSP_Geometry.G_CULL_BACK);
     const cullFront = !!(geoMode & RSP_Geometry.G_CULL_FRONT);
     if (cullBack && cullFront) {
-        throw "whoops";
+        throw new Error("whoops");
     } else if (cullBack) {
         return GfxCullMode.Back;
     } else if (cullFront) {

--- a/src/SYSDOLPHIN/SYSDOLPHIN.ts
+++ b/src/SYSDOLPHIN/SYSDOLPHIN.ts
@@ -740,9 +740,9 @@ function HSD_PObjLoadDesc(pobjs: HSD_PObj[], ctx: HSD_LoadContext, buffer: Array
         assert(envelopeDesc.length <= 10);
         pobjs.push({ flags, loadedVertexLayout, loadedVertexData, kind: 'Envelope', envelopeDesc });
     } else if (objType === HSD_PObjFlags.OBJTYPE_SHAPEANIM) {
-        // throw "whoops";
+        // throw new Error("whoops");
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     if (nextSiblingOffs !== 0)
@@ -914,9 +914,9 @@ function HSD_JObjLoadJointInternal(jobjs: HSD_JObj[], ctx: HSD_LoadContext, buff
     if (contentsOffs === 0) {
         jobjs.push({ ... base, kind: 'None' });
     } else if (!!(flags & HSD_JObjFlags.SPLINE)) {
-        // throw "whoops";
+        // throw new Error("whoops");
     } else if (!!(flags & HSD_JObjFlags.PTCL)) {
-        // throw "whoops";
+        // throw new Error("whoops");
     } else {
         const dobj: HSD_DObj[] = [];
         HSD_DObjLoadDesc(dobj, ctx, HSD_LoadContext__ResolvePtr(ctx, contentsOffs));
@@ -1093,7 +1093,7 @@ export function HSD_FObjLoadKeyframes(ctx: HSD_LoadContext, buffer: ArrayBufferS
             res = view.getUint8(dataIdx + 0x00);
             dataIdx += 0x01;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         return res / (1 << shift);

--- a/src/SYSDOLPHIN/SYSDOLPHIN_Render.ts
+++ b/src/SYSDOLPHIN/SYSDOLPHIN_Render.ts
@@ -428,7 +428,7 @@ export class HSD_TObj_Instance {
                         HSD_TEInput.TE_X, HSD_TExpCnstTObj(list, tobjIdx, HSD_TExpCnstVal.TOBJ_TEV1_A, HSD_TEInput.TE_X));
                     exp[i] = tmp;
                 } else {
-                    throw "whoops";
+                    throw new Error("whoops");
                 }
             }
 
@@ -475,7 +475,7 @@ export class HSD_TObj_Instance {
                         HSD_TEInput.TE_X, HSD_TExpCnstTObj(list, tobjIdx, HSD_TExpCnstVal.TOBJ_TEV1_A, HSD_TEInput.TE_X));
                     exp[i] = tmp;
                 } else {
-                    throw "whoops";
+                    throw new Error("whoops");
                 }
             }
 
@@ -529,7 +529,7 @@ export class HSD_TObj_Instance {
             HSD_TExpColorOp(e0, GX.TevOp.SUB, GX.TevBias.ZERO, GX.TevScale.SCALE_1, true);
             HSD_TExpColorIn(e0, HSD_TEInput.TE_RGB, src.c, HSD_TEInput.TE_0, null, HSD_TEInput.TE_0, null, HSD_TEInput.TE_RGB, last.c);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
         last.c = e0;
 
@@ -558,7 +558,7 @@ export class HSD_TObj_Instance {
                 HSD_TExpAlphaOp(e0, GX.TevOp.SUB, GX.TevBias.ZERO, GX.TevScale.SCALE_1, true);
                 HSD_TExpAlphaIn(e0, HSD_TEInput.TE_A, src.a, HSD_TEInput.TE_0, null, HSD_TEInput.TE_0, null, HSD_TEInput.TE_A, last.a);
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
             last.a = e0;
         }
@@ -1201,7 +1201,7 @@ class HSD_DObj_Instance {
                     mat4.mul(dst, viewerInput.camera.viewMatrix, dst);
                 }
             } else if (pobj.kind === 'ShapeAnim') {
-                throw "whoops";
+                throw new Error("whoops");
             }
 
             const renderInst = renderInstManager.newRenderInst();
@@ -1216,7 +1216,7 @@ class HSD_DObj_Instance {
             else if (cullMode === HSD_PObjFlags.CULLBACK)
                 megaStateFlags.cullMode = GfxCullMode.Back;
             else
-                throw "whoops";
+                throw new Error("whoops");
 
             pobjData.setOnRenderInst(renderInst);
             this.mobj.materialHelper.allocateDrawParamsDataOnInst(renderInst, drawParams);

--- a/src/Scenes_FileDrops.ts
+++ b/src/Scenes_FileDrops.ts
@@ -67,7 +67,7 @@ async function loadArbitraryFile(context: SceneContext, buffer: ArrayBufferSlice
     if (magic === 'bres')
         return RRES.createBasicRRESRendererFromBRRES(device, [buffer]);
 
-    throw "whoops";
+    throw new Error("whoops");
 }
 
 export async function createSceneFromFiles(context: SceneContext, buffers: NamedArrayBufferSlice[]): Promise<SceneGfx> {
@@ -113,7 +113,7 @@ export async function createSceneFromFiles(context: SceneContext, buffers: Named
     if (buffer.name.endsWith('.bsp') || buffer.name.endsWith('.gma'))
         return SourceFileDrops.createFileDropsScene(context, buffer); 
 
-    throw "whoops";
+    throw new Error("whoops");
 }
 
 export class DroppedFileSceneDesc implements SceneDesc {
@@ -180,7 +180,7 @@ async function traverseFileSystemEntry(entry: FileSystemEntry, path: string = ''
             });
         });
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 

--- a/src/SourceEngine/BSPFile.ts
+++ b/src/SourceEngine/BSPFile.ts
@@ -1096,7 +1096,7 @@ export class BSPFile {
                 size = view.getUint32(idx + 0x08, true);
                 uncompressedSize = view.getUint32(idx + 0x0C, true);
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
 
             if (uncompressedSize !== 0) {

--- a/src/SourceEngine/DMX.ts
+++ b/src/SourceEngine/DMX.ts
@@ -192,7 +192,7 @@ export function parse(buffer: ArrayBufferSlice): DMXFile {
                 m03, m13, m23, m33,
             );
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 

--- a/src/SourceEngine/EntitySystem.ts
+++ b/src/SourceEngine/EntitySystem.ts
@@ -402,7 +402,7 @@ export class BaseEntity {
 
     private updateStudioPose(): void {
         if (this.modelStudio === null)
-            throw "whoops";
+            throw new Error("whoops");
 
         mat4.copy(this.modelStudio.modelMatrix, this.modelMatrix);
         this.modelStudio.setupPoseFromSequence(this.seqindex, this.seqtime);
@@ -528,7 +528,7 @@ export class BaseEntity {
 
     public getAttachmentMatrix(attachmentIndex: number): ReadonlyMat4 {
         if (this.modelStudio === null)
-            throw "whoops";
+            throw new Error("whoops");
 
         this.updateModelMatrix();
         this.updateStudioPose();

--- a/src/SourceEngine/Materials/MaterialBase.ts
+++ b/src/SourceEngine/Materials/MaterialBase.ts
@@ -649,7 +649,7 @@ export abstract class BaseMaterial {
             megaStateFlags.depthWrite = true;
             this.isTranslucent = false;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 

--- a/src/SourceEngine/Materials/MaterialParameters.ts
+++ b/src/SourceEngine/Materials/MaterialParameters.ts
@@ -27,12 +27,12 @@ export class ParameterTexture {
     }
 
     public index(i: number): Parameter {
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     public set(param: Parameter): void {
         // Cannot dynamically change at runtime.
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     public async fetch(materialCache: MaterialCache, entityParams: EntityMaterialParameters | null): Promise<void> {
@@ -80,12 +80,12 @@ export class ParameterString {
     }
 
     public index(i: number): Parameter {
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     public set(param: Parameter): void {
         // Cannot dynamically change at runtime.
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -100,7 +100,7 @@ export class ParameterNumber {
     }
 
     public index(i: number): Parameter {
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     public set(param: Parameter): void {
@@ -179,11 +179,11 @@ export class ParameterMatrix {
     }
 
     public index(i: number): Parameter {
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     public set(param: Parameter): void {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -222,7 +222,7 @@ export class ParameterVector {
             this.internal[1].value = param.value;
             this.internal[2].value = param.value;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 

--- a/src/SourceEngine/Materials/WorldLight.ts
+++ b/src/SourceEngine/Materials/WorldLight.ts
@@ -55,7 +55,7 @@ function worldLightDistanceFalloff(light: WorldLight, delta: ReadonlyVec3): numb
     } else if (light.type === WorldLightType.QuakeLight) {
         return Math.max(0.0, light.distAttenuation[1] - vec3.length(delta));
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -95,7 +95,7 @@ function worldLightAngleFalloff(light: WorldLight, surfaceNormal: ReadonlyVec3, 
     } else if (light.type === WorldLightType.SkyAmbient) {
         return 1.0;
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 

--- a/src/SourceEngine/ParticleSystem.ts
+++ b/src/SourceEngine/ParticleSystem.ts
@@ -61,7 +61,7 @@ function getAttribValue<T extends DMX.DMXAttributeType>(elem: DMX.DMXElement, na
         if (defaultValue !== null)
             return defaultValue;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
     assert(attrib.type === type);
     return attrib.value as DMXType<T>;
@@ -127,7 +127,7 @@ function getStreamStride(bit: StreamMask): number {
     else if (bit === StreamMask.SequenceNum2)
         return 1;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 abstract class ModuleBase {
@@ -1276,7 +1276,7 @@ class Sheet {
             calcScaleBiasFromCoord(dst1, f1.coords[coord]);
             return (time - t0) / f0.duration;
         }
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -1806,7 +1806,7 @@ export class ParticleSystemInstance {
                 } else if (stream === StreamMask.Radius) {
                     this.particleDataF32[offs] = this.constRadius;
                 } else {
-                    throw "whoops";
+                    throw new Error("whoops");
                 }
                 streamConstBits &= ~stream;
             }

--- a/src/SourceEngine/Studio.ts
+++ b/src/SourceEngine/Studio.ts
@@ -1833,7 +1833,7 @@ class StudioModelMeshInstance {
         else if (data.vertexSize === 3*0x04)
             this.staticLightingMode = StaticLightingMode.StudioVertexLighting3;
         else
-            throw "whoops";
+            throw new Error("whoops");
 
         const colorDescriptor: GfxVertexBufferDescriptor = { buffer: data.buffer, byteOffset: mesh.byteOffset };
         [this.inputLayout, this.vertexBufferDescriptors, this.indexBufferDescriptor] = this.meshData.createVertexInput(cache, this.staticLightingMode, colorDescriptor);

--- a/src/SourceEngine/VMT.ts
+++ b/src/SourceEngine/VMT.ts
@@ -57,7 +57,7 @@ export class ValveKeyValueParser {
                 this.pos = this.S.indexOf('*/', this.pos) + 2;
                 return true;
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         }
         else if (tok === '#') {
@@ -112,7 +112,7 @@ export class ValveKeyValueParser {
                 val += tok;
         }
         debugger;
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     private run(t: RegExp, start: string): string {
@@ -155,7 +155,7 @@ export class ValveKeyValueParser {
             return this.num(tok);
         console.log(tok);
         debugger;
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     public pair<T extends VKFPairUnit>(): VKFPair<T> {

--- a/src/SourceEngine/VPK.ts
+++ b/src/SourceEngine/VPK.ts
@@ -40,7 +40,7 @@ export function parseVPKDirectory(buffer: ArrayBufferSlice): VPKDirectory {
         const signatureSize = view.getUint32(0x18, true);
         idx = 0x1C;
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     // Parse directory.

--- a/src/SourceEngine/VTF.ts
+++ b/src/SourceEngine/VTF.ts
@@ -58,7 +58,7 @@ function imageFormatGetBPP(fmt: ImageFormat): number {
         return 2;
     if (fmt === ImageFormat.I8)
         return 1;
-    throw "whoops";
+    throw new Error("whoops");
 }
 
 function imageFormatCalcLevelSize(fmt: ImageFormat, width: number, height: number, depth: number): number {
@@ -73,7 +73,7 @@ function imageFormatCalcLevelSize(fmt: ImageFormat, width: number, height: numbe
         else if (fmt === ImageFormat.DXT5)
             return count * 16;
         else
-            throw "whoops";
+            throw new Error("whoops");
     } else {
         return (width * height * depth) * imageFormatGetBPP(fmt);
     }
@@ -108,7 +108,7 @@ function imageFormatToGfxFormat(device: GfxDevice, fmt: ImageFormat, srgb: boole
     else if (fmt === ImageFormat.RGBA16161616F)
         return GfxFormat.F16_RGBA;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function imageFormatConvertData(device: GfxDevice, fmt: ImageFormat, data: ArrayBufferSlice, width: number, height: number, depth: number): ArrayBufferView {
@@ -321,7 +321,7 @@ export class VTF {
                 imageDataIdx = dataIdx;
             }
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         const isCube = !!(this.flags & VTFFlags.ENVMAP);

--- a/src/Studio.ts
+++ b/src/Studio.ts
@@ -1116,7 +1116,7 @@ export class CameraAnimationManager {
         else if (interpType === InterpolationType.Hold)
             return p0;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     private calcAnimationPose(dst: InterpolationStep, animation: Readonly<CameraAnimation>, time: number): void {
@@ -2702,7 +2702,7 @@ export class StudioPanel extends FloatingPanel {
 
         const addKeyframeIcon = (time: number, kfType: KeyframeIconType, tracks: KeyframeTrackType[], kfs: Keyframe[], y: number) => {
             if (tracks.length !== kfs.length)
-                throw "Mismatched track/kf array length";
+                throw new Error("Mismatched track/kf array length");
 
             const kfMap = new Map<KeyframeTrackType, Keyframe>();
             for (let i = 0; i < tracks.length; i++) {
@@ -2769,7 +2769,7 @@ export class StudioPanel extends FloatingPanel {
                 [KeyframeTrackType.bankTrack], [this.animation.bankTrack.keyframes[i]], Timeline.KEYFRAME_ICONS_BASE_Y_POS + (Timeline.TRACK_HEIGHT * 6));
             }
         } else {
-            throw "Bad timelineMode";
+            throw new Error("Bad timelineMode");
         }
     }
 
@@ -2789,7 +2789,7 @@ export class StudioPanel extends FloatingPanel {
         else if (trackType === KeyframeTrackType.bankTrack)
             return animation.bankTrack;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     private onChangeValueInput(input: HTMLInputElement): void {
@@ -2867,7 +2867,7 @@ export class StudioPanel extends FloatingPanel {
         else if (trackType === KeyframeTrackType.bankTrack)
             return this.bankValueInput;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     private drawBankRotationWheel(angleRads: number, prevAngleRads?: number) {
@@ -3252,7 +3252,7 @@ export class StudioPanel extends FloatingPanel {
 
         const addKeyframeIcon = (tracks: KeyframeTrackType[], kfs: Keyframe[], y: number) => {
             if (tracks.length !== kfs.length)
-                throw "Mismatched track/kf array length";
+                throw new Error("Mismatched track/kf array length");
 
             const kfMap = new Map<KeyframeTrackType, Keyframe>();
             for (let i = 0; i < tracks.length; i++) {
@@ -3303,7 +3303,7 @@ export class StudioPanel extends FloatingPanel {
             if (tracks & KeyframeTrackType.bankTrack)
                 addKeyframeIcon([KeyframeTrackType.bankTrack], [keyframeSet.bankKf], Timeline.KEYFRAME_ICONS_BASE_Y_POS + (Timeline.TRACK_HEIGHT * 6));
         } else {
-            throw "Bad timelineMode";
+            throw new Error("Bad timelineMode");
         }
 
         this.updatePreviewSteps();
@@ -3355,7 +3355,7 @@ export class StudioPanel extends FloatingPanel {
             addLoopKeyframe([KeyframeTrackType.lookAtZTrack], Timeline.KEYFRAME_ICONS_BASE_Y_POS + (Timeline.TRACK_HEIGHT * 5))
             addLoopKeyframe([KeyframeTrackType.bankTrack], Timeline.KEYFRAME_ICONS_BASE_Y_POS + (Timeline.TRACK_HEIGHT * 6))
         } else {
-            throw "Bad timelineMode";
+            throw new Error("Bad timelineMode");
         }
 
         this.ensureTimelineLength(time);

--- a/src/SuperMario64DS/sm64ds_bca.ts
+++ b/src/SuperMario64DS/sm64ds_bca.ts
@@ -138,7 +138,7 @@ function getAnimFrame(anim: BCA, frame: number): number {
             frame -= lastFrame;
         return frame;
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 

--- a/src/SuperMario64DS/sm64ds_bmd.ts
+++ b/src/SuperMario64DS/sm64ds_bmd.ts
@@ -116,7 +116,7 @@ function expand5to8(n: number): number {
 function translateCullMode(renderWhichFaces: number): GfxCullMode {
     switch (renderWhichFaces) {
     case 0x00: // Render Nothing
-        throw "whoops";
+        throw new Error("whoops");
     case 0x01: // Render Back
         return GfxCullMode.Front;
     case 0x02: // Render Front

--- a/src/SuperMarioGalaxy/ActorUtil.ts
+++ b/src/SuperMarioGalaxy/ActorUtil.ts
@@ -1677,7 +1677,7 @@ function excludeCalcShadowToSensorAll(actor: LiveActor, hitSensor: HitSensor): v
 
 export function excludeCalcShadowToMyCollision(actor: LiveActor, collisionName: string | null = null): void {
     if (collisionName !== null)
-        throw "whoops";
+        throw new Error("whoops");
     else
         excludeCalcShadowToSensorAll(actor, actor.collisionParts!.hitSensor);
 }

--- a/src/SuperMarioGalaxy/Actors/Enemy.ts
+++ b/src/SuperMarioGalaxy/Actors/Enemy.ts
@@ -1153,7 +1153,7 @@ export class Unizo extends LiveActor<UnizoNrv> {
             this.breakModel = new ModelObj(zoneAndLayer, sceneObjHolder, `UnizoShoalBreak`, `UnizoShoalBreak`, null, DrawBufferType.Enemy, -2, -2);
             this.breakModel.makeActorDead(sceneObjHolder);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         initDefaultPos(sceneObjHolder, this, infoIter);
@@ -2249,7 +2249,7 @@ export class Kuribo extends LiveActor<KuriboNrv> {
 
     private requestAttackSuccess(sceneObjHolder: SceneObjHolder): void {
         // should never happen in practice
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     private requestStagger(sceneObjHolder: SceneObjHolder, otherSensor: HitSensor, thisSensor: HitSensor): boolean {
@@ -2528,7 +2528,7 @@ export class KuriboMini extends LiveActor<KuriboMiniNrv> {
 
     private requestAttackSuccess(sceneObjHolder: SceneObjHolder): void {
         // should never happen in practice
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     private requestStagger(sceneObjHolder: SceneObjHolder, otherSensor: HitSensor, thisSensor: HitSensor): boolean {
@@ -2618,7 +2618,7 @@ class HomingKiller extends LiveActor<HomingKillerNrv> {
         else if (this.name === 'MagnumKiller')
             this.type = HomingKillerType.MagnumKiller;
         else
-            throw "whoops";
+            throw new Error("whoops");
 
         initDefaultPos(sceneObjHolder, this, infoIter);
         this.chaseStartDistance = fallback(getJMapInfoArg0(infoIter), 2000.0);
@@ -2925,7 +2925,7 @@ class HomingKiller extends LiveActor<HomingKillerNrv> {
         } else if (this.type === HomingKillerType.MagnumKiller) {
             speed = 12.0;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         vec3.scale(this.velocity, this.axisZ, speed);
@@ -4767,7 +4767,7 @@ export class Snakehead extends LiveActor<SnakeheadNrv> {
         else if (name === 'Back')
             bckName = dataTable.bckBackName;
         else
-            throw "whoops";
+            throw new Error("whoops");
 
         if (bckName === null)
             return;
@@ -4888,7 +4888,7 @@ export class Snakehead extends LiveActor<SnakeheadNrv> {
         else if (objectName === 'SnakeheadSmall' && subtype === 1)
             return SnakeheadType.SmallRace;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     public static override requestArchives(sceneObjHolder: SceneObjHolder, infoIter: JMapInfoIter): void {
@@ -4922,7 +4922,7 @@ class HanachanParts extends LiveActor<HanachanPartsNrv> {
         else if (partsName === 'HanachanBodyS')
             this.type = HanachanPartsType.BodyS;
         else
-            throw "whoops";
+            throw new Error("whoops");
 
         this.initNerve(HanachanPartsNrv.Walk);
         this.initHitSensor();
@@ -7423,7 +7423,7 @@ class SkeletalFishRailControl {
         if (railCoord >= 0.0 || isLoopRail(this.railActor)) {
             calcRailPosAtCoord(dst, this.railActor, railCoord);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -7433,7 +7433,7 @@ class SkeletalFishRailControl {
             calcRailPosAtCoord(scratchVec3a, this.railActor, railCoord);
             calcRailDirectionAtCoord(scratchVec3b, this.railActor, railCoord);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         vec3.normalize(scratchVec3b, scratchVec3b);
@@ -7572,9 +7572,9 @@ export class ExterminationChecker extends LiveActor {
                 else if (childObjName === 'ChildSkeletalFishBaby')
                     return new SkeletalFishBaby(zoneAndLayer, sceneObjHolder, childInfoIter);
                 else if (childObjName === 'ChildMeramera')
-                    throw "whoops";
+                    throw new Error("whoops");
                 else
-                    throw "whoops";
+                    throw new Error("whoops");
             };
 
             const actor = createActor(childInfoIter);
@@ -8304,7 +8304,7 @@ export class Meramera extends LiveActor<MerameraNrv> {
         else if (v === MerameraEffectHead.Escape)
             return 'Escape';
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     private emitEffectHead(sceneObjHolder: SceneObjHolder, effect: MerameraEffectHead): void {

--- a/src/SuperMarioGalaxy/Actors/MapObj.ts
+++ b/src/SuperMarioGalaxy/Actors/MapObj.ts
@@ -840,7 +840,7 @@ export class OceanWaveFloater extends MapObjActor {
             this.rippleStopThreshold = 150;
             this.rippleStartThreshold = 100;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         this.waveForce = new WaveFloatingForce(frequency, amplitude);
@@ -2314,7 +2314,7 @@ export class BreakableCage extends LiveActor<BreakableCageNrv> {
         else if (this.name === 'BreakableTrash')
             this.type = BreakableCageType.Trash;
         else
-            throw "whoops";
+            throw new Error("whoops");
 
         if (this.type === BreakableCageType.Trash)
             joinToGroupArray(sceneObjHolder, this, infoIter, 'BreakableTrash', 32);
@@ -2834,7 +2834,7 @@ export class MeteorStrike extends LiveActor<MeteorStrikeNrv> {
         else if (objectName === 'MeteorCannon')
             return MeteorStrikeType.MeteorCannon;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     public static override requestArchives(sceneObjHolder: SceneObjHolder, infoIter: JMapInfoIter): void {
@@ -4484,7 +4484,7 @@ export class SpaceMine extends MapObjActor<SpaceMineNrv> {
         else if (this.shadowType === SpaceMineShadowType.OnlyWhenExistRail)
             return isExistRail(this);
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 }
 
@@ -4898,7 +4898,7 @@ function getGlaringLightModelName(parentName: string): string {
     else if (parentName === 'TeresaMansionLightB')
         return 'TeresaMansionGlaringLightB';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 class LightCylinder extends MapObjActor {

--- a/src/SuperMarioGalaxy/Actors/MiscActor.ts
+++ b/src/SuperMarioGalaxy/Actors/MiscActor.ts
@@ -88,7 +88,7 @@ function setClippingFar(f: number): number {
         return 2;
     if (f === 600)
         return 1;
-    throw "whoops";
+    throw new Error("whoops");
 }
 
 function isGalaxyDarkCometAppearInCurrentStage(sceneObjHolder: SceneObjHolder): boolean {
@@ -1331,7 +1331,7 @@ export class MiniRoutePart extends LiveActor {
         else if (partsTypeName === 'StarPieceMine')
             modelName = 'MiniStarPieceMine';
         else
-            throw "whoops";
+            throw new Error("whoops");
 
         this.initModelManagerWithAnm(sceneObjHolder, modelName);
         if (partsTypeName === 'WorldWarpPoint')
@@ -2416,7 +2416,7 @@ export class CrystalCage extends LiveActor<CrystalCageNrv> {
         else if (objName === 'CrystalCageL')
             return CrystalCageSize.L;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     public static override requestArchives(sceneObjHolder: SceneObjHolder, infoIter: JMapInfoIter): void {
@@ -3203,7 +3203,7 @@ export class FishGroup extends LiveActor {
         else if (actorName === 'FishGroupF')
             return 'FishF';
 
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     public static override requestArchives(sceneObjHolder: SceneObjHolder, infoIter: JMapInfoIter): void {
@@ -4238,7 +4238,7 @@ export class WaterPlantDrawInit extends NameObj {
         else if (plantType === 3)
             this.waterPlantD.fillTextureMapping(m);
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     public override destroy(device: GfxDevice): void {
@@ -4424,7 +4424,7 @@ export class Shellfish extends LiveActor<ShellfishNrv> {
         else if (objName === 'ShellfishKinokoOneUp')
             return ShellfishItemType.KinokoOneUp;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     private putItem(): void {
@@ -6104,7 +6104,7 @@ export class Flag extends LiveActor {
             } else if (flagName === 'FlagRaceA' || flagName === 'FlagTamakoro' || flagName === 'Flag') {
                 // Nothing to do.
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
 
             calcActorAxis(null, this.axisY, this.windDirection, this);
@@ -9506,7 +9506,7 @@ export class MorphItemObjNeo extends LiveActor<MorphItemObjNeoNrv> {
         else if (objName === 'MorphItemNeoFoo')
             return MorphItemObjNeoType.Foo;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     private static getModelName(type: MorphItemObjNeoType): string {
@@ -9523,7 +9523,7 @@ export class MorphItemObjNeo extends LiveActor<MorphItemObjNeoNrv> {
         else if (type === MorphItemObjNeoType.Foo)
             return 'PowerUpFoo';
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     public override makeActorDead(sceneObjHolder: SceneObjHolder): void {

--- a/src/SuperMarioGalaxy/Collision.ts
+++ b/src/SuperMarioGalaxy/Collision.ts
@@ -231,7 +231,7 @@ export class CollisionParts {
             // Equalize the scale.
             scale = getAvgScale(scratchVec3a);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         vec3.set(scratchVec3a, scale / scratchVec3a[0], scale / scratchVec3a[1], scale / scratchVec3a[2]);
@@ -340,7 +340,7 @@ export class CollisionParts {
         } else if (classification === KCHitSphereClassification.Vertex3) {
             this.collisionServer.getPos(dst, prism, 2);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -387,7 +387,7 @@ export class CollisionParts {
         if (!movingReaction || this.notMovedCounter === 0) {
             return this.checkStrikeBallCore(sceneObjHolder, hitInfo, dstIdx, scratchVec3a, Vec3Zero, scaledRadius, invAvgScale, avgScale, triFilter, null);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -1200,7 +1200,7 @@ export class Binder {
 
             if (this.useMovingReaction) {
                 // add on "hitVel" field.
-                throw "whoops";
+                throw new Error("whoops");
             }
         }
 

--- a/src/SuperMarioGalaxy/Demo.ts
+++ b/src/SuperMarioGalaxy/Demo.ts
@@ -229,7 +229,7 @@ class DemoActionInfo {
             else if (this.actionType === DemoActionType.Kill)
                 actor.makeActorDead(sceneObjHolder);
             else if (this.actionType === DemoActionType.Functor)
-                throw "whoops";
+                throw new Error("whoops");
             else if (this.actionType === DemoActionType.Nerve)
                 actor.setNerve(this.nerves[i]);
             else if (this.actionType === DemoActionType.OnSwitchA)
@@ -256,7 +256,7 @@ class DemoActionInfo {
 
 function translateJpName(sceneObjHolder: SceneObjHolder, jp_name: string): string {
     if (!sceneObjHolder.objNameTable.findRecord((infoIter) => infoIter.getValueString('jp_name') === jp_name))
-        throw "whoops";
+        throw new Error("whoops");
     return sceneObjHolder.objNameTable.getValueString('en_name')!;
 }
 
@@ -458,7 +458,7 @@ export class DemoCastGroupHolder<T extends DemoCastGroup> extends NameObjGroup<T
         for (let i = 0; i < this.objArray.length; i++)
             if (this.objArray[i].name === name)
                 return this.objArray[i];
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     public tryRegisterDemoActor(sceneObjHolder: SceneObjHolder, actor: LiveActor, infoIter: JMapInfoIter, idInfo: JMapIdInfo): boolean {
@@ -491,7 +491,7 @@ export class DemoDirector extends NameObj {
                 const zoneName = sceneObjHolder.scenarioData.zoneNames[zoneId];
                 this.demoSheetArchives[zoneId] = sceneObjHolder.modelCache.getArchive(`StageData/${zoneName}/${zoneName}Demo.arc`);
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         }
 
@@ -517,7 +517,7 @@ export class DemoDirector extends NameObj {
         if (subPartName === null)
             demoExecutor.start(sceneObjHolder, requester, demoName, movementControlType);
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     public startDemoTimeKeep(sceneObjHolder: SceneObjHolder, requester: NameObj, demoName: string, movementControlType: number, frameType: CinemaFrameType, subPartName: string | null): void {
@@ -578,7 +578,7 @@ function startDemoSystem(sceneObjHolder: SceneObjHolder, requester: NameObj, dem
     if (demoType === DemoType.TimeKeep) {
         sceneObjHolder.demoDirector!.startDemoTimeKeep(sceneObjHolder, requester, demoName, movementControlType, frameType, subPartName);
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -591,7 +591,7 @@ function requestStartTimeKeepDemo(sceneObjHolder: SceneObjHolder, requester: Nam
     if (canStartDemo(sceneObjHolder)) {
         startDemoSystem(sceneObjHolder, requester, demoName, movementControlType, demoType, frameType, starPointerType, deleteEffectType, subPartName);
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 

--- a/src/SuperMarioGalaxy/Gravity.ts
+++ b/src/SuperMarioGalaxy/Gravity.ts
@@ -350,7 +350,7 @@ class ParallelGravity extends PlanetGravity {
         else if (this.distanceCalcType === ParallelGravityDistanceCalcType.Z)
             return this.baseDistance + (Math.abs(dotZ) / Math.sqrt(extentsSq[2]));
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     private isInCylinderRange(coord: ReadonlyVec3): number {
@@ -375,7 +375,7 @@ class ParallelGravity extends PlanetGravity {
         else if (this.rangeType === ParallelGravityRangeType.Cylinder)
             return this.isInCylinderRange(coord);
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     protected calcOwnGravityVector(dst: vec3, coord: ReadonlyVec3): number {

--- a/src/SuperMarioGalaxy/HitSensor.ts
+++ b/src/SuperMarioGalaxy/HitSensor.ts
@@ -234,7 +234,7 @@ export class HitSensorInfo {
 
         if (this.useCallback) {
             // this.sensor.actor.updateHitSensor();
-            throw "whoops";
+            throw new Error("whoops");
         } else if (this.baseMtx !== null) {
             transformVec3Mat4w1(dst, this.baseMtx, this.offset);
         } else {

--- a/src/SuperMarioGalaxy/KCollisionServer.ts
+++ b/src/SuperMarioGalaxy/KCollisionServer.ts
@@ -417,7 +417,7 @@ export class KCollisionServer {
         } else if (dst.classification === KCHitSphereClassification.Plane) {
             dst.distance = radius - dotFaceNrm;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         const maxDist = this.prismThickness * scale;

--- a/src/SuperMarioGalaxy/Layout.ts
+++ b/src/SuperMarioGalaxy/Layout.ts
@@ -284,7 +284,7 @@ class CustomTagProcessor implements TagProcessor {
         } else if (code === 0x1A) {
             return this.exCmd(writer, rect, str, i);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -384,7 +384,7 @@ class LayoutManager {
         for (let i = 0; i < this.paneInfo.length; i++)
             if (this.paneInfo[i].pane.name === name)
                 return i;
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     private getPaneInfo(name: string | null = null): LayoutPaneInfo {

--- a/src/SuperMarioGalaxy/LightData.ts
+++ b/src/SuperMarioGalaxy/LightData.ts
@@ -136,7 +136,7 @@ export class AreaLightInfo {
         else if (lightType === LightType.Planet)
             return this.Planet;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 }
 
@@ -155,7 +155,7 @@ function blendActorLightPos(dst: LightInfo, camera: Camera, a: LightInfo, b: Lig
         vec3.transformMat4(scratchVec3, dst.Position, camera.viewMatrix);
         vec3.lerp(dst.Position, a.Position, b.Position, t);
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 

--- a/src/SuperMarioGalaxy/Main.ts
+++ b/src/SuperMarioGalaxy/Main.ts
@@ -1074,7 +1074,7 @@ class AreaObjContainer extends NameObj {
         for (let i = 0; i < this.managers.length; i++)
             if (this.managers[i].name === managerName)
                 return this.managers[i];
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     public getAreaObj<T extends AreaObj>(managerName: string, position: ReadonlyVec3): T | null {

--- a/src/SuperMarioGalaxy/MapParts.ts
+++ b/src/SuperMarioGalaxy/MapParts.ts
@@ -512,7 +512,7 @@ export class MapPartsRailMover extends MapPartsFunction<MapPartsRailMoverNrv> {
             const length = getRailPartLength(this.actor, currentRailPart);
             return length / moveTimeToNextPoint;
         } else {
-            throw "whoops"; // not sure what to do in this case
+            throw new Error("whoops"); // not sure what to do in this case
         }
     }
 

--- a/src/SuperMarioGalaxy/MessageData.ts
+++ b/src/SuperMarioGalaxy/MessageData.ts
@@ -188,7 +188,7 @@ export class MessageData {
             const userParam = flw1.getUint32(offs + 0x04);
             return { type, eventID, branchInfoIndex, userParam };
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 

--- a/src/SuperMarioGalaxy/NameObj.ts
+++ b/src/SuperMarioGalaxy/NameObj.ts
@@ -410,7 +410,7 @@ export class SceneNameObjListExecutor {
             else if (drawCameraType === DrawCameraType.DrawCameraType_2D)
                 nameObj.calcViewAndEntry(sceneObjHolder, null, Mat4Identity);
             else
-                throw "whoops";
+                throw new Error("whoops");
         }
     }
 

--- a/src/SuperMarioGalaxy/RailRider.ts
+++ b/src/SuperMarioGalaxy/RailRider.ts
@@ -305,7 +305,7 @@ export class BezierRail {
         }
 
         // Should be unreachable.
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     public getCurrentCtrlPointIndex(coord: number, direction: RailDirection): number {
@@ -329,7 +329,7 @@ export class BezierRail {
         }
 
         // Should never happen.
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     private getCoordForRailPartIdx(railPartIdx: number, coord: number): number {

--- a/src/SuperMarioGalaxy/Shadow.ts
+++ b/src/SuperMarioGalaxy/Shadow.ts
@@ -254,7 +254,7 @@ class ShadowController {
         else if (this.calcCollisionMode === CalcCollisionMode.OneTime)
             return (this.calcCollisionTimer === 0);
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     public updateProjection(sceneObjHolder: SceneObjHolder): void {
@@ -971,7 +971,7 @@ function findPosNrmMtxIndexFromModel(modelData: J3DModelData, jointIndex: number
             return posNrmMtxIndex;
     }
 
-    throw "whoops";
+    throw new Error("whoops");
 }
 
 class ShadowVolumeFlatModel extends ShadowVolumeModel {
@@ -1310,7 +1310,7 @@ function addShadowFromCSV(sceneObjHolder: SceneObjHolder, actor: LiveActor, info
     } else if (shadowType === 'VolumeLine') {
         createShadowVolumeLineFromCSV(sceneObjHolder, actor, infoIter);
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -1323,7 +1323,7 @@ export function initShadowFromCSV(sceneObjHolder: SceneObjHolder, actor: LiveAct
     else if (sceneObjHolder.sceneLoader.gameBit === GameBits.SMG2)
         shadowFile = resourceHolder.arc.findFileData(`ActorInfo/${filename}.bcsv`);
     else
-        throw "whoops";
+        throw new Error("whoops");
 
     actor.shadowControllerList = new ShadowControllerList();
 

--- a/src/SuperSmashBrosMelee/Scenes_SuperSmashBrosMelee.ts
+++ b/src/SuperSmashBrosMelee/Scenes_SuperSmashBrosMelee.ts
@@ -89,7 +89,7 @@ class HSDDesc implements SceneDesc {
             // Look for the first thing with _joint suffix.
             const joint = arc.publics.find((sym) => sym.name.endsWith('_joint'));
             if (joint === undefined) {
-                throw "whoops";
+                throw new Error("whoops");
             }
             this.rootName = joint.name.slice(0, -6);
         }

--- a/src/TheWitness/Assets.ts
+++ b/src/TheWitness/Assets.ts
@@ -79,7 +79,7 @@ function get_gfx_format(format: D3DFormat, srgb: boolean): GfxFormat {
     else if (format === D3DFormat.L16)
         return GfxFormat.U16_R_NORM;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function is_block_compressed(format: D3DFormat): boolean {
@@ -108,7 +108,7 @@ function get_mipmap_size(format: D3DFormat, width: number, height: number, depth
         else if (format === D3DFormat.ATI2)
             return count * 16;
         else
-            throw "whoops";
+            throw new Error("whoops");
     } else {
         const num_pixels = width * height * depth;
         if (format === D3DFormat.A8R8G8B8)
@@ -118,7 +118,7 @@ function get_mipmap_size(format: D3DFormat, width: number, height: number, depth
         else if (format === D3DFormat.L16)
             return num_pixels * 2;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 }
 

--- a/src/TheWitness/Entity_Types.ts
+++ b/src/TheWitness/Entity_Types.ts
@@ -168,7 +168,7 @@ function unpack_portable_item_value(stream: Stream, item: Metadata_Item): any {
     } else if (item.type === Metadata_Type.PARTICLE_PATH) {
         return unpack_metadata_particle_path(stream);
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 

--- a/src/TokyoMirageSessionsSharpFE/bfres_helpers.ts
+++ b/src/TokyoMirageSessionsSharpFE/bfres_helpers.ts
@@ -53,7 +53,7 @@ function convert_wrap_mode(wrap_mode: nngfx_enum.TextureAddressMode)
 
         default:
             console.error(`wrap mode ${wrap_mode} not found`);
-            throw "whoops";
+            throw new Error("whoops");
     }
 }
 
@@ -87,7 +87,7 @@ function convert_depth_compare_mode(depth_compare_mode: nngfx_enum.CompareMode):
 
         default:
             console.error(`depth compare mode ${depth_compare_mode} not found`);
-            throw "whoops";
+            throw new Error("whoops");
     }
 }
 
@@ -103,7 +103,7 @@ function convert_tex_filter_mode(texture_filter_mode: nngfx_enum.FilterMode): Gf
 
         default:
             console.error(`texture filter mode ${texture_filter_mode} not found`);
-            throw "whoops";
+            throw new Error("whoops");
     }
 }
 
@@ -119,7 +119,7 @@ function convert_mip_filter_mode(mip_filter_mode: nngfx_enum.FilterMode): GfxPla
 
         default:
             console.error(`mip filter mode ${mip_filter_mode} not found`);
-            throw "whoops";
+            throw new Error("whoops");
     }
 }
 
@@ -204,7 +204,7 @@ export function convert_attribute_format(format: nngfx_enum.AttributeFormat): Gf
 
         default:
             console.error(`attribute format ${format} not found`);
-            throw "whoops";
+            throw new Error("whoops");
     }
 }
 
@@ -302,7 +302,7 @@ export function convert_index_format(format: nngfx_enum.IndexFormat): GfxPlatfor
 
         default:
             console.error(`index format ${format} not found`);
-            throw "whoops";
+            throw new Error("whoops");
     }
 }
 

--- a/src/ZeldaSkywardSword/Main.ts
+++ b/src/ZeldaSkywardSword/Main.ts
@@ -268,7 +268,7 @@ class ZSSModelInstance {
                     child.parentNodeMtxBindIdx = nodes[i].mtxId;
                     return
                 }
-            throw "could not find node";
+            throw new Error("could not find node");
         }
     }
     public findNode(name: string): BRRES.MDL0_NodeEntry | undefined {

--- a/src/ZeldaTwilightPrincess/Main.ts
+++ b/src/ZeldaTwilightPrincess/Main.ts
@@ -420,7 +420,7 @@ export class TwilightPrincessRenderer implements Viewer.SceneGfx {
         for (let i = 0; i < this.rooms.length; i++)
             if (this.rooms[i].roomNo === roomNo)
                 return this.rooms[i].visible;
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     private getSingleRoomVisible(): number {

--- a/src/ZeldaTwilightPrincess/d_kankyo.ts
+++ b/src/ZeldaTwilightPrincess/d_kankyo.ts
@@ -396,7 +396,7 @@ function findTimeInSchejule(schedule: dScnKy__Schedule, time: number): dScnKy__S
             return entry;
     }
 
-    throw "whoops";
+    throw new Error("whoops");
 }
 
 export function dKy_plight_priority_set(envLight: dScnKy_env_light_c, lightInfluence: LIGHT_INFLUENCE): void {

--- a/src/ZeldaTwilightPrincess/d_resorce.ts
+++ b/src/ZeldaTwilightPrincess/d_resorce.ts
@@ -152,7 +152,7 @@ export class dRes_info_c {
             } else if (resType === ResType.Raw) {
                 resEntry.res = file.buffer as ResAssetType<T>;
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         }
 
@@ -164,7 +164,7 @@ export class dRes_info_c {
         for (let i = 0; i < resList.length; i++)
             if (resList[i].file.index === resIndex)
                 return resList[i];
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     private getResEntryByID<T extends ResType>(resType: T, resID: number): ResEntry<ResAssetType<T>> {
@@ -172,7 +172,7 @@ export class dRes_info_c {
         for (let i = 0; i < resList.length; i++)
             if (resList[i].file.id === resID)
                 return resList[i];
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     private getResEntryByName<T extends ResType>(resType: T, resName: string): ResEntry<ResAssetType<T>> | null {

--- a/src/ZeldaTwilightPrincess/f_op_actor.ts
+++ b/src/ZeldaTwilightPrincess/f_op_actor.ts
@@ -105,7 +105,7 @@ export class fopAc_ac_c extends leafdraw_class {
 
         // Make sure that all culling matrices are filled in, before I forget...
         if (this.cullMtx === null)
-            throw "whoops";
+            throw new Error("whoops");
 
         const frustum = camera.frustum;
 

--- a/src/ZeldaWindWaker/d_a.ts
+++ b/src/ZeldaWindWaker/d_a.ts
@@ -1780,7 +1780,7 @@ class d_a_mgameboard extends fopAc_ac_c {
             else if (size === 4)
                 this.shipModels.push(new J3DModelInstance(resCtrl.getObjectRes(ResType.Model, d_a_mgameboard.arcName, 0x06)));
             else
-                throw "whoops";
+                throw new Error("whoops");
         }
 
         this.cursorX = 0;
@@ -3280,7 +3280,7 @@ function dLib_pathMove(dst: vec3, pointIdxCurr: number, path: dPath, speed: numb
         vec3.normalize(scratchVec3a, scratchVec3a);
 
         // todo
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     return pointIdxCurr;

--- a/src/ZeldaWindWaker/d_kankyo.ts
+++ b/src/ZeldaWindWaker/d_kankyo.ts
@@ -274,7 +274,7 @@ function findTimeInSchejule(schedule: dScnKy__Schedule, time: number): dScnKy__S
             return entry;
     }
 
-    throw "whoops";
+    throw new Error("whoops");
 }
 
 function dKy_light_influence_id(lights: LIGHT_INFLUENCE[], pos: vec3): number {
@@ -890,7 +890,7 @@ function dKy_event_proc(globals: dGlobals): void {
                         if (envLight.rainCount < 250)
                             dKyw_rain_set(envLight, envLight.rainCount + 1);
                     } else {
-                        throw "whoops";
+                        throw new Error("whoops");
                     }
 
                     if (envLight.colpatWeather !== colpat) {

--- a/src/ZeldaWindWaker/d_resorce.ts
+++ b/src/ZeldaWindWaker/d_resorce.ts
@@ -182,7 +182,7 @@ export class dRes_info_c {
             } else if (resType === ResType.Raw || resType === ResType.Stb) {
                 resEntry.res = file.buffer as ResAssetType<T>;
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         }
 
@@ -194,7 +194,7 @@ export class dRes_info_c {
         for (let i = 0; i < resList.length; i++)
             if (resList[i].file.index === resIndex)
                 return resList[i];
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     private getResEntryByID<T extends ResType>(resType: T, resID: number): ResEntry<ResAssetType<T>> {
@@ -202,7 +202,7 @@ export class dRes_info_c {
         for (let i = 0; i < resList.length; i++)
             if (resList[i].file.id === resID)
                 return resList[i];
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     private getResEntryByName<T extends ResType>(resType: T, resName: string): ResEntry<ResAssetType<T>> | null {

--- a/src/ZeldaWindWaker/f_op_actor.ts
+++ b/src/ZeldaWindWaker/f_op_actor.ts
@@ -118,7 +118,7 @@ export class fopAc_ac_c extends leafdraw_class {
 
         // Make sure that all culling matrices are filled in, before I forget...
         if (this.cullMtx === null)
-            throw "whoops";
+            throw new Error("whoops");
 
         const frustum = camera.frustum;
 

--- a/src/ZeldaWindWaker/framework.ts
+++ b/src/ZeldaWindWaker/framework.ts
@@ -268,7 +268,7 @@ function fpcLy_Layer(globals: fGlobals, layerID: number): layer_class {
     } else if (layerID === 0) {
         return globals.lyRoot;
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 

--- a/src/ZipFile.ts
+++ b/src/ZipFile.ts
@@ -193,6 +193,6 @@ export function decompressZipFileEntry(entry: ZipFileEntry): ArrayBufferSlice {
         const compressedData = entry.data.slice(0x04 + propertiesSize);
         return LZMA.decompress(compressedData, properties, entry.uncompressedSize!);
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }

--- a/src/byml.ts
+++ b/src/byml.ts
@@ -452,7 +452,7 @@ function classifyNodeValue(w: WriteContext, v: Node): NodeType {
     } else if (v.constructor === Object) {
         return NodeType.Dictionary;
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -553,7 +553,7 @@ function writeValue(w: WriteContext, nodeType: NodeType, v: Node, valueOffs: num
         stream.setUint32(valueOffs, stream.offs, w.littleEndian);
         writeComplexValueDict(w, v as NodeDict);
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -574,7 +574,7 @@ function gatherStrings(v: Node, keyStrings: Set<string>, valueStrings: Set<strin
         for (let i = 0; i < keys.length; i++)
             gatherStrings(v[keys[i]], keyStrings, valueStrings);
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 

--- a/src/fres_nx/bfres.ts
+++ b/src/fres_nx/bfres.ts
@@ -1295,7 +1295,7 @@ export function isMarkerLittleEndian(marker: number): boolean {
     else if (marker === 0xFEFF)
         return false;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 export function parse(buffer: ArrayBufferSlice): FRES {

--- a/src/fres_nx/render.ts
+++ b/src/fres_nx/render.ts
@@ -86,7 +86,7 @@ function translateAddressMode(addrMode: TextureAddressMode): GfxWrapMode {
         // TODO(jstpierre): This requires GL_ARB_texture_mirror_clamp_to_edge
         return GfxWrapMode.Mirror;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -98,7 +98,7 @@ function translateMipFilterMode(filterMode: FilterMode): GfxMipFilterMode {
     case FilterMode.Point:
         return GfxMipFilterMode.Nearest;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -109,7 +109,7 @@ function translateTexFilterMode(filterMode: FilterMode): GfxTexFilterMode {
     case FilterMode.Point:
         return GfxTexFilterMode.Point;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -202,7 +202,7 @@ uniform sampler2D u_Texture7;
         else if (componentMask === 60)
             return '.a';
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     public genSample(shadingModelSamplerBindingName: string): string {
@@ -259,9 +259,9 @@ uniform sampler2D u_Texture7;
             else if (instance === 6)
                 return `vec4(1.0)`;
             else
-                throw "whoops";
+                throw new Error("whoops");
         } else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     public blendIsTranslucent(instance: number): boolean {
@@ -384,7 +384,7 @@ function translateRenderInfoBoolean(renderInfo: FMAT_RenderInfo): boolean {
     else if (value === 'false')
         return false;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateCullMode(fmat: FMAT): GfxCullMode {
@@ -396,7 +396,7 @@ function translateCullMode(fmat: FMAT): GfxCullMode {
     else if (display_face === 'both')
         return GfxCullMode.None;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateDepthWrite(fmat: FMAT): boolean {
@@ -409,7 +409,7 @@ function translateDepthCompare(fmat: FMAT): GfxCompareMode {
         if (depth_test_func === 'Lequal')
             return GfxCompareMode.LessEqual;
         else
-            throw "whoops";
+            throw new Error("whoops");
     } else {
         return GfxCompareMode.Always;
     }
@@ -426,7 +426,7 @@ function translateRenderInfoBlendFactor(renderInfo: FMAT_RenderInfo): GfxBlendFa
     else if (value === 'zero')
         return GfxBlendFactor.Zero;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateBlendSrcFactor(fmat: FMAT): GfxBlendFactor {
@@ -529,7 +529,7 @@ function translateAttributeFormat(attributeFormat: AttributeFormat): GfxFormat {
         return GfxFormat.F32_RGB;
     default:
         console.error(getChannelFormat(attributeFormat), getTypeFormat(attributeFormat));
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -705,7 +705,7 @@ function translateIndexFormat(indexFormat: IndexFormat): GfxFormat {
     case IndexFormat.Uint8:  return GfxFormat.U8_R;
     case IndexFormat.Uint16: return GfxFormat.U16_R;
     case IndexFormat.Uint32: return GfxFormat.U32_R;
-    default: throw "whoops";
+    default: throw new Error("whoops");
     }
 }
 

--- a/src/fres_nx/tegra_texture.ts
+++ b/src/fres_nx/tegra_texture.ts
@@ -107,7 +107,7 @@ export function getFormatBytesPerBlock(channelFormat: ChannelFormat): number {
     case ChannelFormat.Bc5:
         return 16;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -154,7 +154,7 @@ export function decompress(textureEntry: BRTI, pixels: Uint8Array<ArrayBuffer>):
         return { ... textureEntry, flag: 'SRGB', type: 'RGBA', pixels };
     default:
         console.error(channelFormat.toString(16));
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -237,7 +237,7 @@ function getChannelFormatString(channelFormat: ChannelFormat): string {
     case ChannelFormat.R16_G16_B16_A16:
         return 'R16_G16_B16_A16';
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -252,7 +252,7 @@ function getTypeFormatString(typeFormat: TypeFormat): string {
     case TypeFormat.UnormSrgb:
         return 'SRGB';
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -276,6 +276,6 @@ export function translateImageFormat(imageFormat: ImageFormat): GfxFormat {
     case TypeFormat.Float:
         return GfxFormat.F16_RGBA;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }

--- a/src/gfx/helpers/RenderGraphHelpers.ts
+++ b/src/gfx/helpers/RenderGraphHelpers.ts
@@ -33,7 +33,7 @@ function selectFormatSimple(slot: GfxrAttachmentSlot): GfxFormat {
     else if (slot === GfxrAttachmentSlot.DepthStencil)
         return GfxFormat.D24;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function selectSampleCount(renderInput: RenderInput): number {

--- a/src/gfx/helpers/ReversedDepthHelpers.ts
+++ b/src/gfx/helpers/ReversedDepthHelpers.ts
@@ -60,5 +60,5 @@ export function compareDepthValues(a: number, b: number, op: GfxCompareMode, isD
     else if (op === GfxCompareMode.GreaterEqual)
         return a >= b;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }

--- a/src/gfx/platform/GfxPlatformFormat.ts
+++ b/src/gfx/platform/GfxPlatformFormat.ts
@@ -161,7 +161,7 @@ export function getFormatTypeFlagsByteSize(typeFlags: FormatTypeFlags): 1 | 2 | 
     case FormatTypeFlags.S8:
         return 1;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -195,7 +195,7 @@ export function getFormatByteSize(fmt: GfxFormat): number {
     case FormatTypeFlags.BC5_UNORM:
     case FormatTypeFlags.BC5_SNORM:
     case FormatTypeFlags.BC7:
-        throw "whoops"; // Not valid to call on compressed texture formats...
+        throw new Error("whoops"); // Not valid to call on compressed texture formats...
     default:
         const typeByteSize = getFormatTypeFlagsByteSize(typeFlags);
         const componentCount = getFormatCompFlagsComponentCount(getFormatCompFlags(fmt));
@@ -227,7 +227,7 @@ export function getFormatSamplerKind(fmt: GfxFormat): GfxSamplerFormatKind {
     else if (typeFlags === FormatTypeFlags.S8 || typeFlags === FormatTypeFlags.S16 || typeFlags === FormatTypeFlags.S32)
         return GfxSamplerFormatKind.Sint;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 export function isFormatTextureCompressionBC(fmt: GfxFormat): boolean {

--- a/src/gfx/platform/GfxPlatformWebGL2.ts
+++ b/src/gfx/platform/GfxPlatformWebGL2.ts
@@ -117,7 +117,7 @@ function translateQueryPoolType(type: GfxQueryPoolType): GLenum {
     case GfxQueryPoolType.OcclusionConservative:
         return WebGL2RenderingContext.ANY_SAMPLES_PASSED_CONSERVATIVE;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -141,7 +141,7 @@ function translateVertexFormat(fmt: GfxFormat): { size: number, type: GLenum, no
         case FormatTypeFlags.F32:
             return WebGL2RenderingContext.FLOAT;
         default:
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -192,7 +192,7 @@ function translateIndexFormat(format: GfxFormat): GLenum {
     case GfxFormat.U32_R:
         return WebGL2RenderingContext.UNSIGNED_INT;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -215,7 +215,7 @@ function translateBufferUsageToTarget(usage: GfxBufferUsage): GLenum {
     else if (usage & (GfxBufferUsage.Storage | GfxBufferUsage.CopySrc))
         return WebGL2RenderingContext.COPY_WRITE_BUFFER;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateWrapMode(wrapMode: GfxWrapMode): GLenum {
@@ -227,7 +227,7 @@ function translateWrapMode(wrapMode: GfxWrapMode): GLenum {
     case GfxWrapMode.Mirror:
         return WebGL2RenderingContext.MIRRORED_REPEAT;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -272,7 +272,7 @@ function translateTextureDimension(dimension: GfxTextureDimension): GLenum {
     else if (dimension === GfxTextureDimension.n3D)
         return WebGL2RenderingContext.TEXTURE_3D;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateCompareMode(compareMode: GfxCompareMode): GLenum {
@@ -771,7 +771,7 @@ class GfxImplP_GL implements GfxSwapChain, GfxDevice {
         case GfxFormat.D24:
             return WebGL2RenderingContext.DEPTH_COMPONENT24;
         default:
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -832,7 +832,7 @@ class GfxImplP_GL implements GfxSwapChain, GfxDevice {
         case FormatTypeFlags.D32FS8:
             return WebGL2RenderingContext.FLOAT_32_UNSIGNED_INT_24_8_REV;
         default:
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -974,7 +974,7 @@ class GfxImplP_GL implements GfxSwapChain, GfxDevice {
             gl.texStorage2D(gl_target, numLevels, internalformat, descriptor.width, descriptor.height);
             assert(descriptor.depthOrArrayLayers === 6);
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
         const texture: GfxTextureP_GL = { _T: _T.Texture, ResourceUniqueId: this.getNextUniqueId(),
             gl_texture, gl_target,
@@ -1071,7 +1071,7 @@ class GfxImplP_GL implements GfxSwapChain, GfxDevice {
     }
 
     public createComputeProgram(program: GfxComputeProgramDescriptor): GfxProgram {
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     public createProgram(descriptor: GfxRenderProgramDescriptor): GfxProgramP_GL {
@@ -1172,7 +1172,7 @@ class GfxImplP_GL implements GfxSwapChain, GfxDevice {
     }
 
     public createComputePipeline(descriptor: GfxComputePipelineDescriptor): GfxComputePipeline {
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     public createReadback(byteSize: number): GfxReadback {
@@ -1324,7 +1324,7 @@ class GfxImplP_GL implements GfxSwapChain, GfxDevice {
     }
 
     public createComputePass(): GfxComputePass {
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     public submitPass(o: GfxPass): void {
@@ -1621,7 +1621,7 @@ class GfxImplP_GL implements GfxSwapChain, GfxDevice {
 
         if (program.compileState === GfxProgramCompileStateP_GL.NeedsCompile) {
             // This should not happen.
-            throw "whoops";
+            throw new Error("whoops");
         } if (program.compileState === GfxProgramCompileStateP_GL.Compiling) {
             let complete: boolean;
 
@@ -2013,7 +2013,7 @@ class GfxImplP_GL implements GfxSwapChain, GfxDevice {
         else if (gl_target === gl.TEXTURE_CUBE_MAP)
             return this._fallbackTextureCube;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     public setBindings(bindingLayoutIndex: number, bindings_: GfxBindings, dynamicByteOffsets: number[]): void {

--- a/src/gfx/platform/GfxPlatformWebGPU.ts
+++ b/src/gfx/platform/GfxPlatformWebGPU.ts
@@ -106,7 +106,7 @@ function translateWrapMode(wrapMode: GfxWrapMode): GPUAddressMode {
     else if (wrapMode === GfxWrapMode.Mirror)
         return 'mirror-repeat';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateMinMagFilter(texFilter: GfxTexFilterMode): GPUFilterMode {
@@ -115,7 +115,7 @@ function translateMinMagFilter(texFilter: GfxTexFilterMode): GPUFilterMode {
     else if (texFilter === GfxTexFilterMode.Point)
         return 'nearest';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateMipFilter(mipFilter: GfxMipFilterMode): GPUFilterMode {
@@ -124,7 +124,7 @@ function translateMipFilter(mipFilter: GfxMipFilterMode): GPUFilterMode {
     else if (mipFilter === GfxMipFilterMode.Nearest)
         return 'nearest';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateTextureFormat(format: GfxFormat): GPUTextureFormat {
@@ -193,7 +193,7 @@ function translateTextureFormat(format: GfxFormat): GPUTextureFormat {
     else if (format === GfxFormat.BC7_SRGB)
         return 'bc7-rgba-unorm-srgb';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateTextureDimension(dimension: GfxTextureDimension): GPUTextureDimension {
@@ -206,7 +206,7 @@ function translateTextureDimension(dimension: GfxTextureDimension): GPUTextureDi
     else if (dimension === GfxTextureDimension.Cube)
         return '2d';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateViewDimension(dimension: GfxTextureDimension): GPUTextureViewDimension {
@@ -219,7 +219,7 @@ function translateViewDimension(dimension: GfxTextureDimension): GPUTextureViewD
     else if (dimension === GfxTextureDimension.Cube)
         return 'cube';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateTextureUsage(usage: GfxTextureUsage): GPUTextureUsageFlags {
@@ -249,7 +249,7 @@ function translateTopology(topology: GfxPrimitiveTopology): GPUPrimitiveTopology
     else if (topology === GfxPrimitiveTopology.Lines)
         return 'line-list';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateCullMode(cullMode: GfxCullMode): GPUCullMode {
@@ -260,7 +260,7 @@ function translateCullMode(cullMode: GfxCullMode): GPUCullMode {
     else if (cullMode === GfxCullMode.Back)
         return 'back';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateFrontFace(frontFaceMode: GfxFrontFaceMode): GPUFrontFace {
@@ -269,7 +269,7 @@ function translateFrontFace(frontFaceMode: GfxFrontFaceMode): GPUFrontFace {
     else if (frontFaceMode === GfxFrontFaceMode.CW)
         return 'cw';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translatePrimitiveState(topology: GfxPrimitiveTopology, megaStateDescriptor: GfxMegaStateDescriptor): GPUPrimitiveState {
@@ -306,7 +306,7 @@ function translateBlendFactor(factor: GfxBlendFactor): GPUBlendFactor {
     else if (factor === GfxBlendFactor.OneMinusConstantColor)
         return 'one-minus-constant';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateBlendMode(mode: GfxBlendMode): GPUBlendOperation {
@@ -317,7 +317,7 @@ function translateBlendMode(mode: GfxBlendMode): GPUBlendOperation {
     else if (mode === GfxBlendMode.ReverseSubtract)
         return 'reverse-subtract';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateBlendComponent(ch: GfxChannelBlendState): GPUBlendComponent {
@@ -384,7 +384,7 @@ function translateCompareMode(compareMode: GfxCompareMode): GPUCompareFunction {
     else if (compareMode === GfxCompareMode.Always)
         return 'always';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateDepthStencilState(format: GfxFormat | null, megaStateDescriptor: GfxMegaStateDescriptor): GPUDepthStencilState | undefined {
@@ -409,7 +409,7 @@ function translateIndexFormat(format: GfxFormat | null): GPUIndexFormat | undefi
     else if (format === GfxFormat.U32_R)
         return 'uint32';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateVertexFormat(format: GfxFormat): GPUVertexFormat {
@@ -462,14 +462,14 @@ function translateVertexFormat(format: GfxFormat): GPUVertexFormat {
     else if (format === GfxFormat.F32_RGBA)
         return 'float32x4';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateQueryPoolType(type: GfxQueryPoolType): GPUQueryType {
     if (type === GfxQueryPoolType.OcclusionConservative)
         return 'occlusion';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateSampleType(type: GfxSamplerFormatKind): GPUTextureSampleType {
@@ -480,7 +480,7 @@ function translateSampleType(type: GfxSamplerFormatKind): GPUTextureSampleType {
     else if (type === GfxSamplerFormatKind.Depth)
         return 'depth';
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function translateBindGroupTextureBinding(sampler: GfxBindingLayoutSamplerDescriptor): GPUTextureBindingLayout {
@@ -1304,7 +1304,7 @@ class GfxImplP_WebGPU implements GfxSwapChain, GfxDevice {
         else if (dimension === GfxTextureDimension.Cube)
             return this._fallbackTextureCube;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     private _getFallbackSampler(samplerEntry: GfxBindingLayoutSamplerDescriptor): GfxSampler {
@@ -1557,7 +1557,7 @@ class GfxImplP_WebGPU implements GfxSwapChain, GfxDevice {
     public createWebXRLayer(webXRSession: XRSession): Promise<XRWebGLLayer> {
         // There is currently no way to use WebGPU with WebXR.
         // This method should never be called.
-        throw "createWebXRLayer not implemented on WebGPU";
+        throw new Error("createWebXRLayer not implemented on WebGPU");
     }
 
     public destroyBuffer(o: GfxBuffer): void {

--- a/src/gx/DDraw.ts
+++ b/src/gx/DDraw.ts
@@ -24,7 +24,7 @@ function getGfxToplogyFromCommand(cmd: GX.Command): GfxTopology {
     else if (cmd === GX.Command.DRAW_TRIANGLE_FAN)
         return GfxTopology.TriFans;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 abstract class TDDrawBase {

--- a/src/gx/GXMaterialBuilder.ts
+++ b/src/gx/GXMaterialBuilder.ts
@@ -438,7 +438,7 @@ export class GXMaterialBuilder {
             texGenType = GX.TexGenType.SRTG;
             texGenSrc = GX.TexGenSrc.COLOR1;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         // TODO(jstpierre): XF_MATRIXINDEX0_ID
@@ -506,7 +506,7 @@ export class GXMaterialBuilder {
                 case GX.TevScale.$HWB_BGR24: return sub ? GX.TevOp.COMP_BGR24_EQ : GX.TevOp.COMP_BGR24_GT;
                 case GX.TevScale.$HWB_RGB8: return sub ? GX.TevOp.COMP_RGB8_EQ : GX.TevOp.COMP_RGB8_GT;
                 default:
-                    throw "whoops 2";
+                    throw new Error("whoops 2");
                 }
             } else {
                 return sub ? GX.TevOp.SUB : GX.TevOp.ADD;

--- a/src/gx/gx_displaylist.ts
+++ b/src/gx/gx_displaylist.ts
@@ -98,7 +98,7 @@ function getAttrInputForAttr(attrib: GX.Attr): VertexAttributeInput {
     else if (attrib === GX.Attr.CLR1)
         return VertexAttributeInput.CLR1;
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 export interface SingleVertexInputLayout {
@@ -356,7 +356,7 @@ function getComponentShift(vtxAttrib: GX.Attr, vatFormat: GX_VtxAttrFmt): number
         else if (vatFormat.compType === GX.CompType.U16 || vatFormat.compType === GX.CompType.S16)
             return 14;
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     return getComponentShiftRaw(vatFormat.compType, vatFormat.compShift);
@@ -456,7 +456,7 @@ export function compileLoadedVertexLayout(vcd: GX_VtxDesc[], useNBT: boolean = f
         case VertexAttributeInput.TEX67:
             return GfxFormat.F32_RGBA;
         default:
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -536,7 +536,7 @@ export function compileLoadedVertexLayout(vcd: GX_VtxDesc[], useNBT: boolean = f
             input = allocateVertexInput(attrInput);
             fieldFormat = input.format;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         const fieldByteOffset = getFormatCompByteSize(input.format) * fieldCompOffset;
@@ -606,7 +606,7 @@ function generateRunVertices(loadedVertexLayout: LoadedVertexLayout, vatLayout: 
             case GX.CompType.S16:
                 return compileShift(`${viewName}.getInt16(${attrOffset})`);
             default:
-                throw "whoops";
+                throw new Error("whoops");
             }
         }
 
@@ -642,7 +642,7 @@ function generateRunVertices(loadedVertexLayout: LoadedVertexLayout, vatLayout: 
             else if (typeFlags === FormatTypeFlags.U8)
                 return compileWriteOneComponentU8(offs, value);
             else
-                throw "whoops";
+                throw new Error("whoops");
         }
 
         function compileOneAttribColor(viewName: string, attrOffs: string): string {
@@ -690,7 +690,7 @@ function generateRunVertices(loadedVertexLayout: LoadedVertexLayout, vatLayout: 
     ${compileWriteOneComponent(dstOffs + 3, `${viewName}.getUint8(${attrOffs} + 3) / 0xFF`)};
 `;
             } else {
-                throw "whoops";
+                throw new Error("whoops");
             }
         }
 
@@ -747,7 +747,7 @@ function generateRunVertices(loadedVertexLayout: LoadedVertexLayout, vatLayout: 
                 else
                     return compileOneAttribOther(viewName, attrOffsetBase);
             } else if (outputMode === GX_VtxDescOutputMode.Index) {
-                throw "whoops";
+                throw new Error("whoops");
             } else {
                 return ``;
             }
@@ -819,7 +819,7 @@ function generateRunVertices(loadedVertexLayout: LoadedVertexLayout, vatLayout: 
     // ${getAttrName(vtxAttrib)} - ZERO
     ${compileZero()}`;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -1400,7 +1400,7 @@ export function displayListToString(buffer: ArrayBufferSlice) {
 
         default:
             console.error(`Unknown command ${cmd} at ${i} (buffer: 0x${buffer.byteOffset.toString(16)})`);
-            throw "whoops 1";
+            throw new Error("whoops 1");
         }
     }
 
@@ -1456,7 +1456,7 @@ export function displayListRegistersRun(r: DisplayListRegisters, buffer: ArrayBu
 
         default:
             console.error(`Unknown command ${cmd} at ${i} (buffer: 0x${buffer.byteOffset.toString(16)})`);
-            throw "whoops 1";
+            throw new Error("whoops 1");
         }
     }
 }

--- a/src/gx/gx_material.ts
+++ b/src/gx/gx_material.ts
@@ -527,7 +527,7 @@ export class GX_Program extends DeviceProgram {
             const pnMtxIdx = (pnt - GX.TexGenMatrix.PNMTX0) / 3;
             return nrm ? `MulNormalMatrix(UnpackMatrix(u_PosMtx[${pnMtxIdx}]), ${src})` : `(UnpackMatrix(u_PosMtx[${pnMtxIdx}]) * ${src})`;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -545,7 +545,7 @@ export class GX_Program extends DeviceProgram {
         if (index === GX.TexCoordID.TEXCOORD5) return `(a_TexMtx4567Idx.y * 256.0)`;
         if (index === GX.TexCoordID.TEXCOORD6) return `(a_TexMtx4567Idx.z * 256.0)`;
         if (index === GX.TexCoordID.TEXCOORD7) return `(a_TexMtx4567Idx.w * 256.0)`;
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     // TexGen
@@ -588,7 +588,7 @@ export class GX_Program extends DeviceProgram {
             const texMtxIdx = (texCoordGen.postMatrix - GX.PostTexGenMatrix.PTTEXMTX0) / 3;
             return `(UnpackMatrix(u_PostTexMtx[${texMtxIdx}]) * ${src})`;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -710,7 +710,7 @@ varying vec4 v_Color1;
         case GX.IndTexScale._64: return `1.0/64.0`;
         case GX.IndTexScale._128: return `1.0/128.0`;
         case GX.IndTexScale._256: return `1.0/256.0`;
-        default: throw "whoops";
+        default: throw new Error("whoops");
         }
     }
 
@@ -815,7 +815,7 @@ varying vec4 v_Color1;
         case GX.IndTexAlphaSel.T: return `${baseCoord}.y`;
         case GX.IndTexAlphaSel.U: return `${baseCoord}.z`;
         default:
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -827,7 +827,7 @@ varying vec4 v_Color1;
         case GX.IndTexFormat._4: return `TevMask(${baseCoord}, 0xF0)`;
         case GX.IndTexFormat._3: return `TevMask(${baseCoord}, 0xF8)`;
         default:
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -884,7 +884,7 @@ varying vec4 v_Color1;
         case GX.CC.RASA:
             return `${swapA}${swapA}${swapA}`;
         default:
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -920,7 +920,7 @@ varying vec4 v_Color1;
         case GX.CA.KONST: return `${this.generateKonstAlphaSel(stage.konstAlphaSel)}`;
         case GX.CA.ZERO:  return `0.0`;
         default:
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -1076,7 +1076,7 @@ varying vec4 v_Color1;
         case GX.IndTexMtxID.T2:
             return `(u_IndTexMtx[${indTexMtxIdx}].mx.w * ReadTexCoord${stage.texCoordId}() * ${indTexCoord}.yy)`;
         default:
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -1232,7 +1232,7 @@ varying vec4 v_Color1;
         } else if (fogType === GX.FogType.ORTHO_REVEXP2) {
             return `1.0 - exp2(-8.0 * (1.0 - ${base}) * (1.0 - ${base}));`;
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 
@@ -1268,7 +1268,7 @@ ${this.generateFogAdj(`t_FogBase`)}
         case GfxFormat.F32_RG:   return 'vec2';
         case GfxFormat.F32_RGB:  return 'vec3';
         case GfxFormat.F32_RGBA: return 'vec4';
-        default: throw "whoops";
+        default: throw new Error("whoops");
         }
     }
 
@@ -1534,7 +1534,7 @@ export function getRasColorChannelID(v: GX.ColorChannelID): GX.RasColorChannelID
     case GX.ColorChannelID.COLOR_NULL:
         return GX.RasColorChannelID.COLOR_ZERO;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 

--- a/src/gx/gx_render.ts
+++ b/src/gx/gx_render.ts
@@ -256,7 +256,7 @@ export function translateMaxAnisotropy(anisotropy: GX.Anisotropy): number {
     case GX.Anisotropy._4:
         return 4;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -409,7 +409,7 @@ export function autoOptimizeMaterial(material: GX_Material.GXMaterial): void {
 export function translateCullMode(cullMode: GX.CullMode): GfxCullMode {
     switch (cullMode) {
     case GX.CullMode.ALL:
-        throw "whoops";
+        throw new Error("whoops");
     case GX.CullMode.FRONT:
         return GfxCullMode.Front;
     case GX.CullMode.BACK:

--- a/src/main.ts
+++ b/src/main.ts
@@ -1034,7 +1034,7 @@ class Main {
 
         if (promise === null) {
             console.error(`Cannot load ${sceneDesc.id}. Probably an unsupported file extension.`);
-            throw "whoops";
+            throw new Error("whoops");
         }
 
         promise.then((scene: SceneGfx) => {

--- a/src/nns_g3d/NNS_G3D.ts
+++ b/src/nns_g3d/NNS_G3D.ts
@@ -220,7 +220,7 @@ function expand5to8(n: number): number {
 function translateCullMode(renderWhichFaces: number): GfxCullMode {
     switch (renderWhichFaces) {
     case 0x00: // Render Nothing
-        throw "whoops";
+        throw new Error("whoops");
     case 0x01: // Render Back
         return GfxCullMode.Front;
     case 0x02: // Render Front
@@ -264,7 +264,7 @@ export function calcTexMtx(dst: mat2d, texMtxMode: TexMtxMode, texScaleS: number
     case TexMtxMode.MAX:
         return calcTexMtx_Max(dst, texScaleS, texScaleT, scaleS, scaleT, sinR, cosR, translationS, translationT);
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -610,7 +610,7 @@ export function getAnimFrame(anim: AnimationBase, frame: number, loopMode: LoopM
             frame -= lastFrame;
         return frame;
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 

--- a/src/psychonauts/ppf.ts
+++ b/src/psychonauts/ppf.ts
@@ -101,7 +101,7 @@ function getTextureFormatGetBytesPerPixel(fmt: TextureFormat): number {
     case TextureFormat.P8:
         return 1;
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 

--- a/src/rres/Scenes_Okami.ts
+++ b/src/rres/Scenes_Okami.ts
@@ -397,7 +397,7 @@ function patchMaterialSetAlpha(material: BRRES.MDL0_MaterialEntry, alpha: number
         material.gxMaterial.ropInfo.blendDstFactor = GX.BlendFactor.INVSRCALPHA;
     } else {
         // TODO(jstpierre): Rest of them.
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     /*
@@ -506,7 +506,7 @@ function patchMaterialSetTest(material: BRRES.MDL0_MaterialEntry, test: number):
         material.gxMaterial.alphaTest.op = GX.AlphaOp.OR;
         material.gxMaterial.alphaTest.compareA = GX.CompareType.ALWAYS;
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 

--- a/src/rres/brres.ts
+++ b/src/rres/brres.ts
@@ -106,7 +106,7 @@ function calcTexMtx(dst: mat4, texMtxMode: TexMatrixMode, scaleS: number, scaleT
     case TexMatrixMode.Max:
         return calcTexMtx_Max(dst, scaleS, scaleT, rotation, translationS, translationT);
     default:
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 //#endregion
@@ -1008,7 +1008,7 @@ function parseMDL0_NodeTreeBytecode(buffer: ArrayBufferSlice): NodeTreeOp[] {
             i += 0x05;
             nodeTreeOps.push({ op, toMtxId, fromMtxId });
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
     return nodeTreeOps;
@@ -1056,7 +1056,7 @@ function parseMDL0_NodeMixBytecode(buffer: ArrayBufferSlice): NodeMixOp[] {
             i += 0x05;
             nodeMixOps.push({ op, mtxId, nodeId });
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
     return nodeMixOps;
@@ -1084,7 +1084,7 @@ function parseMDL0_DrawBytecode(buffer: ArrayBufferSlice): DrawOp[] {
             i += 0x08;
             drawOps.push({ matId, shpId, nodeId });
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
     return drawOps;
@@ -1282,7 +1282,7 @@ function getAnimFrame(anim: AnimationBase, frame: number): number {
             frame -= lastFrame;
         return frame;
     } else {
-        throw "whoops";
+        throw new Error("whoops");
     }
 }
 
@@ -1357,7 +1357,7 @@ function sampleFloatAnimationTrack(track: FloatAnimationTrack, frame: number): n
     else if (track.type === AnimationTrackType.HERMITE)
         return sampleFloatAnimationTrackHermite(track, frame);
     else
-        throw "whoops";
+        throw new Error("whoops");
 }
 
 function lerpColor(k0: number, k1: number, t: number): number {

--- a/src/rres/render.ts
+++ b/src/rres/render.ts
@@ -626,7 +626,7 @@ export class MDL0ModelInstance {
 
     public getNodeToWorldMatrixReference(nodeMtxIdx : number): mat4 {
         if (nodeMtxIdx >= this.instanceStateData.jointToWorldMatrixArray.length || nodeMtxIdx < 0) {
-            throw "Invalid Node";
+            throw new Error("Invalid Node");
         }
         return this.instanceStateData.jointToWorldMatrixArray[nodeMtxIdx];
     }

--- a/src/rres/u8.ts
+++ b/src/rres/u8.ts
@@ -151,7 +151,7 @@ export function parse(buffer: ArrayBufferSlice): U8Archive {
             const nodeBuffer = buffer.subarray(nodeDataBegin, nodeDataSize);
             return { kind: 'file', name: nodeName, buffer: nodeBuffer };
         } else {
-            throw "whoops";
+            throw new Error("whoops");
         }
     }
 

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -344,7 +344,7 @@ export abstract class ScrollSelect implements Widget {
                 else if (item.name !== undefined)
                     textSpan.textContent = item.name;
                 else
-                    throw "whoops";
+                    throw new Error("whoops");
                 selector.appendChild(textSpan);
 
                 const index = i;
@@ -404,7 +404,7 @@ export abstract class ScrollSelect implements Widget {
                 else if (item.name !== undefined)
                     textSpan.appendChild(document.createTextNode(item.name));
                 else
-                    throw "whoops";
+                    throw new Error("whoops");
                 outer.appendChild(textSpan);
                 hasHeader = true;
             }

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -414,5 +414,5 @@ export function makeErrorUI(errorCode: InitErrorCode): DocumentFragment {
 <p>Please try to update your browser to a more recent version.
 `);
     else
-        throw "whoops";
+        throw new Error("whoops");
 }

--- a/src/zelview/f3dzex.ts
+++ b/src/zelview/f3dzex.ts
@@ -103,7 +103,7 @@ function translateBlendParamB(paramB: BlendParam_B, srcParam: GfxBlendFactor): G
     if (paramB === BlendParam_B.G_BL_0)
         return GfxBlendFactor.Zero;
 
-    throw "Unknown Blend Param B: "+paramB;
+    throw new Error("Unknown Blend Param B: ")+paramB;
 }
 
 function translateZMode(zmode: ZMode): GfxCompareMode {
@@ -115,14 +115,14 @@ function translateZMode(zmode: ZMode): GfxCompareMode {
         return GfxCompareMode.Greater;
     if (zmode === ZMode.ZMODE_DEC)
         return GfxCompareMode.GreaterEqual;
-    throw "Unknown Z mode: " + zmode;
+    throw new Error("Unknown Z mode: ") + zmode;
 }
 
 export function translateCullMode(geoMode: number): GfxCullMode {
     const cullBack = !!(geoMode & RSP_Geometry.G_CULL_BACK);
     const cullFront = !!(geoMode & RSP_Geometry.G_CULL_FRONT);
     if (cullBack && cullFront) {
-        throw "whoops";
+        throw new Error("whoops");
     } else if (cullBack) {
         return GfxCullMode.Back;
     } else if (cullFront) {

--- a/src/zelview/zelview0.ts
+++ b/src/zelview/zelview0.ts
@@ -32,7 +32,7 @@ export class ZELVIEW0 {
         for (let i = 0; i < this.entries.length; i++)
             if (this.entries[i].vStart === vStart)
                 return this.entries[i];
-        throw "whoops";
+        throw new Error("whoops");
     }
 
     public lookupAddress(file: VFSEntry, offs: number): { buffer: ArrayBufferSlice, offs: number } {
@@ -129,7 +129,7 @@ function readHeaders(rom: ZELVIEW0, file: VFSEntry, banks: RomBanks, sharedOutpu
         else if (bankIdx === 0x03)
             return assertExists(banks.room);
         else
-            throw "whoops";
+            throw new Error("whoops");
     }
 
     function lookupAddress(addr: number): { buffer: ArrayBufferSlice, offs: number } {


### PR DESCRIPTION
## Pull Request Checklist

Please check one of the boxes below:
- [ ] Generative AI was used in the creation of this PR (for any part, including but not limited to coding, reverse engineering, or debugging). I have read [/README.md#ai-contributions-policy](AI Contributions Policy). All comments and documentation are human-authored.
- [x] Generative AI was not used in the creation of this PR.

## Description
Fixes sad paths where `throw "string"` is used. These paths have really bad stack tracing; see this example where I use an unsupported `TextureFormat`:

```
:3000/#FinalFantasyX…9uinq8/lr:Ugw]:VS:1 Uncaught (in promise) whoops
Promise.then		
_loadSceneDesc	@	main.ts:1042
_loadInitialStateFromHash	@	main.ts:620
init	@	main.ts:453
await in init		
constructor	@	main.ts:408
(anonymous)	@	main.ts:1096
__webpack_require__	@	index.js:43
(anonymous)	@	jsonp_chunk_loading:590
(anonymous)	@	on_chunk_loaded:27
(anonymous)	@	jsonp_chunk_loading:590
(anonymous)	@	jsonp_chunk_loading:590
```

This has no information about where the error has occurred. After this PR, such errors will look like the following:

```
GfxPlatformWebGL2.ts:774 Uncaught (in promise) Error: whoops
    at GfxImplP_GL.translateTextureInternalFormat (GfxPlatformWebGL2.ts:774:1)
    at GfxImplP_GL._createTexture (GfxPlatformWebGL2.ts:955:1)
    at GfxImplP_GL.createTexture (GfxPlatformWebGL2.ts:995:1)
    at Texture.createGfxTextureThroughDirectUpload (Texture.ts:87:1)
    at Texture.createGfxTexture (Texture.ts:56:1)
    at processTextures (render.ts:260:1)
    at new FFXivSceneRenderer (render.ts:41:1)
    at FFXIVMapDesc.createScene (scenes.ts:26:1)
```

This PR was created using the following search and replace: `throw (".*")` to `throw new Error($1)`.