### PR TITLE
Camera Hover Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Hold `\` | Make camera move slower
 `I`/`J`/`K`/`L` | Tilt camera
 `O` | Rotate camera clockwise
 `U` | Rotate camera counterclockwise
+`X` | in WASD camera mode; enables "Hover Mode", locking changes to the y axis to the "Move camera up/down" controls
 `1`/`2`/`3`/`4`/`5`/`6`/`7`/`8`/`9` | Load savestate
 `Shift`+`1`/`2`/`3`/`4`/`5`/`6`/`7`/`8`/`9` | Save savestate
 `Numpad 3` | Export save states

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -345,8 +345,9 @@ export class FPSCameraController implements CameraController {
                 this.isInHoverMode = !this.isInHoverMode;
             }
             if (this.isInHoverMode) {
-                viewForward[1] = 0;
+                viewForward[1] = viewRight[1] = 0;
                 vec3.normalize(viewForward, viewForward);
+                vec3.normalize(viewRight, viewRight);
             }
         }
 

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -243,6 +243,8 @@ export class FPSCameraController implements CameraController {
     private keyMoveDrag = 0.8;
     private keyAngleChangeVelFast = 0.1;
     private keyAngleChangeVelSlow = 0.02;
+    public isHoverModeAvailable = true;
+    private isInHoverMode = false;
 
     private mouseLookSpeed = 500;
     private isMoving = false;
@@ -337,6 +339,17 @@ export class FPSCameraController implements CameraController {
             vec3.copy(upAxis, Vec3UnitY);
         }
 
+        // Hover Mode
+        if (this.isHoverModeAvailable){
+            if (inputManager.isKeyDownEventTriggered("KeyX")) {
+                this.isInHoverMode = !this.isInHoverMode;
+            }
+            if (this.isInHoverMode) {
+                viewForward[1] = 0;
+                vec3.normalize(viewForward, viewForward);
+            }
+        }
+
         const linearVelocity = camera.linearVelocity;
         if (!vec3.exactEquals(linearMoveDir, Vec3Zero)) {
             vec3.scale(linearVelocity, viewRight, linearMoveDir[0]);
@@ -419,6 +432,7 @@ export class FPSCameraController implements CameraController {
 export class StudioCameraController extends FPSCameraController {
     public isAnimationPlaying: boolean = false;
     private interpStep: InterpolationStep = new InterpolationStep();
+    public override isHoverModeAvailable: boolean = false;
 
     constructor(private animationManager: CameraAnimationManager, private studioPanel: StudioPanel) {
         super();


### PR DESCRIPTION
Adds a toggle-able "hover mode" to the WASD camera. When enabled, changes to the camera altitude (y axis) can only be made by the camera move up/down controls. Moving the camera with wasd doesn't change the camera altitude regardless of the camera pitch, yaw and roll.

## Pull Request Checklist

Please check one of the boxes below:
- [ ] Generative AI was used in the creation of this PR (for any part, including but not limited to coding, reverse engineering, or debugging). I have read [AI Contributions Policy](https://github.com/magcius/noclip.website/blob/main/README.md#ai-contributions-policy). All comments and documentation are human-authored.
- [x] Generative AI was not used in the creation of this PR.
