### PR TITLE
Ratchet & Clank - Fix moby textures on mobile, fix tfrag transparency

### DIFF
--- a/src/RatchetAndClank/bin-core.ts
+++ b/src/RatchetAndClank/bin-core.ts
@@ -29,8 +29,7 @@ export function readGsRamTableEntry(view: DataViewExt) {
 export interface TieClass {
     header: TieClassHeader,
     normalsData: { x: number, y: number, z: number }[],
-    rgbaRemaps: (RgbaRemapPacket[] | null)[] | null; // [lod][packet], not present in rac1
-    remapsReadable: boolean[],
+    rgbaRemaps: RgbaRemap[][] | null; // [lod][remap], not present in rac1
     nearDist: number,
     midDist: number,
     farDist: number,
@@ -58,62 +57,47 @@ export function readTieClass(gn: GN, view: DataViewExt, oClass: number): TieClas
 
     const normalsData = view.subdivide(header.normalsOffset, header.normalsCount, 8).map(view => view.getInt16_Xyzw(0));
 
-    let rgbaRemaps = null;
-    const remapsReadable = [false, false, false];
-    if (gn >= 2) {
-        rgbaRemaps = header.rgbaRemapOffsets!.map((offset, i) => {
-            if (offset === header.adGifsOffset || header.lodHeaders![i].vertCount === 0) return null;
-            return readTieRgbaRemap(view.subview(header.normalsOffset + offset), header);
-        });
-    }
-
     // there are always 3 lods
     for (let i = 0; i < 3; i++) {
         const packetOffset = header.packetOffsets[i];
         const packetCount = header.packetCounts[i];
         const packetHeaders = view.subdivide(packetOffset, packetCount, SIZEOF_TIE_PACKET_HEADER).map(readTiePacketHeader);
 
-        const hasBlock3 = rgbaRemaps?.[i]?.some(packet => !!packet.block3);
-        const hasBlock4 = rgbaRemaps?.[i]?.some(packet => !!packet.block4);
-        const knownRemapFormat = !hasBlock3 && !hasBlock4;
-        const rgbaRemap = knownRemapFormat ? rgbaRemaps?.[i] : null;
-        let rgbaRemapIndex = 0;
-        let regularVertPtr = 0;
-        let morphingVertPtr = 0;
-
         const packetsInThisLod: TiePacket[] = [];
         for (let j = 0; j < packetCount; j++) {
             const packetDataOffset = packetOffset + packetHeaders[j].data;
-            const packetBody = readTiePacketBody(gn, view.subview(packetDataOffset), packetHeaders[j], rgbaRemap ? rgbaRemap[rgbaRemapIndex] : null, regularVertPtr, morphingVertPtr, adGifs, oClass, i, j);
+            const packetBody = readTiePacketBody(gn, view.subview(packetDataOffset), packetHeaders[j], adGifs, oClass, i, j);
             packetsInThisLod.push({
                 header: packetHeaders[j],
                 body: packetBody,
             });
-            // disabled, needs more reverse engineering work
-            // if (rgbaRemap) {
-            //     const rgbaRemapEntry = rgbaRemap[rgbaRemapIndex];
-            //     regularVertPtr += packetBody.regularVerts.length;
-            //     morphingVertPtr += packetBody.morphingVerts.length;
-            //     if (regularVertPtr * 2 >= rgbaRemapEntry.block1!.length) {
-            //         assert(regularVertPtr * 2 === rgbaRemapEntry.block1!.length);
-            //         if (rgbaRemapEntry.block2) {
-            //             assert(morphingVertPtr * 2 === rgbaRemapEntry.block2!.length);
-            //         }
-            //         rgbaRemapIndex++;
-            //         regularVertPtr = 0;
-            //         morphingVertPtr = 0;
-            //     }
-            // }
         }
 
         packets.push(packetsInThisLod);
+    }
+
+    const rgbaRemaps: RgbaRemap[][] = [[], [], []]; // [lod][remapIndex]
+    if (gn >= 2) {
+        for (let i = 0; i < 3; i++) {
+            const offset = header.rgbaRemapOffsets![i];
+            if (offset === header.adGifsOffset || header.lodHeaders![i].vertCount === 0) continue;
+            rgbaRemaps[i] = readTieRgbaRemaps(view.subview(header.normalsOffset + offset));
+
+            // const remapsInThisLod = rgbaRemaps[i];
+            // const packetsInThisLod = packets[i];
+            // for (let j = 0; j  < remapsInThisLod.length; j++) {
+            //     const dest = remapsInThisLod[j].dest;
+            //     let vertexPtr = 0;
+            //     for (let k = 0; k < packetsInThisLod.length; k++) {
+            //     }
+            // }
+        }
     }
 
     return {
         header,
         normalsData,
         rgbaRemaps,
-        remapsReadable,
         nearDist: header.nearDist,
         midDist: header.midDist,
         farDist: header.farDist,
@@ -124,31 +108,31 @@ export function readTieClass(gn: GN, view: DataViewExt, oClass: number): TieClas
     };
 }
 
-type RgbaRemapPacket = {
-    packetSizeBytes: number,
-    block1: number[] | null, // <- looks a map from non-morphing vert index to rgba index
-    block2: number[] | null,
-    block3: number[] | null,
-    block4: number[] | null,
-    block5: number[] | null,
-    block6: number[] | null,
+export interface RgbaRemap {
+    dest: number,
+    src: [number, number, number, number] | 0,
 }
 
 // needs more reverse engineering work
 // I can parse the headers but no idea what the inner data is
-export function readTieRgbaRemap(view: DataViewExt, header: TieClassHeader): RgbaRemapPacket[] {
-    const packetSizeList = view.getArrayOfNumbers(0x0, 32, Uint8Array);
-    const packetSizeListBytes = [];
-    for (let i = 0; i < packetSizeList.length; i++) {
-        if (packetSizeList[i] === 0) break;
-        packetSizeListBytes.push(packetSizeList[i] * 16);
+export function readTieRgbaRemaps(view: DataViewExt): RgbaRemap[] {
+    const out: RgbaRemap[] = [];
+
+    const blockSizesQw = view.getArrayOfNumbers(0x0, 32, Uint8Array);
+    const blockSizes = [];
+    for (let i = 0; i < blockSizesQw.length; i++) {
+        if (blockSizesQw[i] === 0) break;
+        blockSizes.push(blockSizesQw[i] * 16);
     }
 
-    const packets: RgbaRemapPacket[] = [];
+    function validate(a: RgbaRemap) {
+        // assert((a.dest & 0x3) === 0);
+        return a;
+    }
 
     let packetView = view.subview(0x20);
-    for (let i = 0; i < packetSizeListBytes.length; i++) {
-        const packetSizeBytes = packetSizeListBytes[i];
+    for (let i = 0; i < blockSizes.length; i++) {
+        const packetSizeBytes = blockSizes[i];
         if (packetSizeBytes === 0) break;
 
         const descriptor = {
@@ -167,29 +151,68 @@ export function readTieRgbaRemap(view: DataViewExt, header: TieClassHeader): Rgb
             if (ptr % size !== 0) ptr += size - (ptr % size);
         }
 
-        const block1 = descriptor.block1Size ? packetView.subview(ptr, descriptor.block1Size).getArrayOfNumbers(0, 0xFFFF, Uint16Array).map(v => v / 4) : null;
+        const block1_aaaa = descriptor.block1Size ? packetView.subview(ptr, descriptor.block1Size) : null;
         ptr += descriptor.block1Size;
-        const block2 = descriptor.block2Size ? packetView.subview(ptr, descriptor.block2Size).getArrayOfNumbers(0, 0xFFFF, Uint16Array) : null;
+        const block2_aabb = descriptor.block2Size ? packetView.subview(ptr, descriptor.block2Size) : null;
         ptr += descriptor.block2Size;
-        const block3 = descriptor.block3Size ? packetView.subview(ptr, descriptor.block3Size).getArrayOfNumbers(0, 0xFFFF, Uint16Array) : null;
+        const block3_unknown = descriptor.block3Size ? packetView.subview(ptr, descriptor.block3Size) : null;
         ptr += descriptor.block3Size;
-        const block4 = descriptor.block4Size ? packetView.subview(ptr, descriptor.block4Size).getArrayOfNumbers(0, 0xFFFF, Uint16Array) : null;
+        const block4_aaab = descriptor.block4Size ? packetView.subview(ptr, descriptor.block4Size) : null;
         ptr += descriptor.block4Size;
-        const block5 = descriptor.block5Size ? packetView.subview(ptr, descriptor.block5Size).getArrayOfNumbers(0, 0xFFFF, Uint16Array) : null;
+        const block5_aabc = descriptor.block5Size ? packetView.subview(ptr, descriptor.block5Size) : null;
         ptr += descriptor.block5Size;
-        const block6 = descriptor.block6Size ? packetView.subview(ptr, descriptor.block6Size).getArrayOfNumbers(0, 0xFFFF, Uint16Array) : null;
+        const block6_abcd = descriptor.block6Size ? packetView.subview(ptr, descriptor.block6Size) : null;
         ptr += descriptor.block6Size;
         alignTo(0x10)
-
-        packets.push({ packetSizeBytes, block1, block2, block3, block4, block5, block6 });
-
         assert(ptr === descriptor.totalSize);
         assert(ptr === packetSizeBytes);
+
+        // unsure about any of this
+
+        block1_aaaa?.subdivide(0, 0xFFFF, 4).forEach(view => {
+            const a = view.getUint16(0x0);
+            const dest = view.getUint16(0x2);
+            out.push(validate({ dest, src: [a, a, a, a] }));
+        });
+
+        block2_aabb?.subdivide(0, 0xFFFF, 4).forEach(view => {
+            const packed = view.getUint32(0x0);
+            const dest = packed & 0x3FFC;
+            const a = (packed >> 21) & 0x7FC;
+            const b = (packed >> 12) & 0x7FC;
+            out.push(validate({ dest, src: [a, a, b, b] }));
+        });
+
+        block4_aaab?.subdivide(0, 0xFFFF, 4).forEach(view => {
+            const packed = view.getUint32(0x0);
+            const dest = packed & 0x3FFC;
+            const a = (packed >> 21) & 0x7FC;
+            const b = (packed >> 12) & 0x7FC;
+            out.push(validate({ dest, src: [a, a, a, b] }));
+        });
+
+        block5_aabc?.subdivide(0, 0xFFFF, 8).forEach(view => {
+            const a = view.getUint16(0x0);
+            const b = view.getUint16(0x2);
+            const c = view.getUint16(0x4);
+            const dest = view.getUint16(0x6);
+            out.push(validate({ dest, src: [a, a, b, c] }));
+        });
+
+        block6_abcd?.subdivide(0, 0xFFFF, 8).forEach(view => {
+            const packed = view.getUint32(0x0);
+            const a = packed & 0x7FC;
+            const b = (packed >> 9) & 0x7FC;
+            const c = (packed >> 18) & 0x7FC;
+            const d = view.getUint16(0x4);
+            const dest = view.getUint16(0x6);
+            out.push(validate({ dest, src: [a, b, c, d] }));
+        });
 
         packetView = packetView.subview(packetSizeBytes);
     }
 
-    return packets;
+    return out;
 }
 
 export type TieClassHeader = {
@@ -325,7 +348,7 @@ const tieCommandSizes = {
 };
 
 export type TiePacketBody = ReturnType<typeof readTiePacketBody>;
-export function readTiePacketBody(gn: GN, view: DataViewExt, tiePacketHeader: TiePacketHeader, rgbaRemaps: RgbaRemapPacket | null, rgbaRemapBaseRegularVert: number, rgbaRemapBaseMorphingVert: number, adGifs: TieGifAds[], oClass: number, lod: number, packetIndex: number) {
+export function readTiePacketBody(gn: GN, view: DataViewExt, tiePacketHeader: TiePacketHeader, adGifs: TieGifAds[], oClass: number, lod: number, packetIndex: number) {
     /*
     struct TiePacketBody {
         // 0x0
@@ -350,7 +373,7 @@ export function readTiePacketBody(gn: GN, view: DataViewExt, tiePacketHeader: Ti
             uint8vec4 morphingRgbaIndices[tieVuHeader.morphingVertexCount];
         }
         // align 0x10
-        uint8 unknownFlags[until the (stripCount + 1)'th flag that is either 0x7, 0xFC, or 0xF6];
+        uint8 stripControlBytes[until the (stripCount + 1)'th flag that is either 0x7, 0xFC, or 0xF6];
     }
     */
 
@@ -403,30 +426,19 @@ export function readTiePacketBody(gn: GN, view: DataViewExt, tiePacketHeader: Ti
         alignTo(0x4);
         morphingRgbaIndices = view.subdivide(ptr, tieVuHeader.morphingVertexCount, 0x4).map(view => view.getUint8_Xyzw(0));
         ptr += tieVuHeader.morphingVertexCount * 0x4;
-    } else {
-        if (rgbaRemaps) { 
-            // disabled, this needs more reverse engineering work
-            // for (let i = 0; i < regularVerts.length; i++) {
-            //     assert(rgbaRemaps.block1 !== null);
-            //     const rgbaIndex = rgbaRemaps.block1[(rgbaRemapBaseRegularVert + i) * 2];
-            //     assert(rgbaIndex !== undefined);
-            //     regularRgbaIndices.push(rgbaIndex);
-            // }
-        }
     }
 
-    // I can calculate the length of this but not sure what it is
     alignTo(0x10);
-    const unknownFlags: number[] = [];
-    let unknownFlagsRemaining = tieVuHeader.stripCount + 1;
+    const stripControlBytes: number[] = [];
+    let stripCount = tieVuHeader.stripCount + 1;
     while (true) {
         const flag = view.getUint8(ptr++);
         if (flag == 0x7 || flag == 0xFC || flag == 0xF6) {
-            unknownFlagsRemaining--;
-            unknownFlags.push(flag);
-            if (unknownFlagsRemaining === 0) break;
+            stripCount--;
+            stripControlBytes.push(flag);
+            if (stripCount === 0) break;
         } else if (flag == 0x3) {
-            unknownFlags.push(flag);
+            stripControlBytes.push(flag);
         } else {
             assert(false);
         }
@@ -494,6 +506,7 @@ export function readTiePacketBody(gn: GN, view: DataViewExt, tiePacketHeader: Ti
         adGifSrcOffsets,
         tieVuHeader,
         tieStrips,
+        totalVertexCount: regularVertexCount + morphingVertexCount,
         regularVertexCount,
         regularVerts,
         morphingVerts,
@@ -501,7 +514,7 @@ export function readTiePacketBody(gn: GN, view: DataViewExt, tiePacketHeader: Ti
         morphingNormalIndices,
         regularRgbaIndices,
         morphingRgbaIndices,
-        unknownFlags,
+        stripControlBytes,
         commandBuffer: imaginaryGsBuffer.finish(),
     }
 }

--- a/src/RatchetAndClank/render-moby.ts
+++ b/src/RatchetAndClank/render-moby.ts
@@ -13,6 +13,7 @@ import { fillMatrix4x3, fillVec4 } from "../gfx/helpers/UniformBufferHelpers";
 import { MobyInstance } from "./bin-gameplay";
 import { Frustum } from "../Geometry";
 import { assert } from "../util";
+import { packRemap, TextureAtlases } from "./textures";
 
 export class MobyProgram extends DeviceProgram {
     public static a_Position = 0;
@@ -117,9 +118,9 @@ void main() {
     }
 
     if (u_RenderSettings.x == 0.0) { gl_FragColor = vec4(v_Rgba.rgb / 2.0, v_Rgba.a); return; }
-    ivec2 texRemap = getTexRemap(u_TextureRemaps.mobys, v_TextureIndex);
+    ivec2 texRemap = getTexRemap(v_TextureIndex);
     vec4 textureSample = ratchetSampler(texRemap, v_Clamp, v_ST);
-    gl_FragColor = commonFragmentShader(vec4(v_Rgba.rgb / 2.0, v_Rgba.a), textureSample, v_FogFactor);
+    gl_FragColor = commonFragmentShader(vec4(v_Rgba.rgb / 2.0, v_Rgba.a), textureSample, v_FogFactor, 0.01);
 }
 
 `;
@@ -132,7 +133,7 @@ export class MobyGeometry {
     private vertexBuffer: GfxBuffer | null = null;
     private vertexCount: number | null = null;
 
-    constructor(private cache: GfxRenderCache, public oClass: number, public moby: MobyClass, public lod: number, private textureIndices: number[]) {
+    constructor(private cache: GfxRenderCache, public oClass: number, public moby: MobyClass, public lod: number, private textureIndices: number[], private textureAtlases: TextureAtlases) {
         this.inputLayout = cache.createInputLayout({
             vertexAttributeDescriptors: [
                 // per vertex
@@ -327,7 +328,7 @@ export class MobyGeometry {
             vertexArrayBuffer[vertexPtr++] = angleScale * v.normalElevation;
             vertexArrayBuffer[vertexPtr++] = texcoordScale * v.s;
             vertexArrayBuffer[vertexPtr++] = texcoordScale * v.t;
-            vertexArrayBuffer[vertexPtr++] = v.textureIndex;
+            vertexArrayBuffer[vertexPtr++] = packRemap(this.textureAtlases.mobyTextureRemap[v.textureIndex]);
             vertexArrayBuffer[vertexPtr++] = v.clamp;
         }
 

--- a/src/RatchetAndClank/render-shrub.ts
+++ b/src/RatchetAndClank/render-shrub.ts
@@ -14,6 +14,7 @@ import { mat4, vec3 } from "gl-matrix";
 import { fillMatrix4x3, fillMatrix4x4, fillVec4 } from "../gfx/helpers/UniformBufferHelpers";
 import { ShrubInstance } from "./bin-gameplay";
 import { Frustum } from "../Geometry";
+import { packRemap, TextureAtlases } from "./textures";
 
 export class ShrubProgram extends DeviceProgram {
     public static a_Position = 0;
@@ -106,9 +107,9 @@ ${RatchetShaderLib.Sampler}
 
 void main() {
     if (u_RenderSettings.x == 0.0) { gl_FragColor = vec4(v_Rgba.rgb / 2.0, v_Rgba.a); return; }
-    ivec2 texRemap = getTexRemap(u_TextureRemaps.shrubs, v_TextureIndex);
+    ivec2 texRemap = getTexRemap(v_TextureIndex);
     vec4 textureSample = ratchetSampler(texRemap, v_Clamp, v_ST);
-    gl_FragColor = commonFragmentShader(v_Rgba, textureSample, v_FogFactor);
+    gl_FragColor = commonFragmentShader(v_Rgba, textureSample, v_FogFactor, 0.01);
 }
 
 `;
@@ -121,7 +122,7 @@ export class ShrubGeometry {
     private vertexBuffer: GfxBuffer;
     private vertexCount: number;
 
-    constructor(private cache: GfxRenderCache, public shrub: ShrubClass, private textureIndices: number[]) {
+    constructor(private cache: GfxRenderCache, public shrub: ShrubClass, private textureIndices: number[], private textureAtlases: TextureAtlases) {
         this.inputLayout = cache.createInputLayout({
             vertexAttributeDescriptors: [
                 // per vertex
@@ -258,7 +259,7 @@ export class ShrubGeometry {
                                 vertexArrayBuffer[vertexPtr++] = normalScale * normal.x;
                                 vertexArrayBuffer[vertexPtr++] = normalScale * normal.y;
                                 vertexArrayBuffer[vertexPtr++] = normalScale * normal.z;
-                                vertexArrayBuffer[vertexPtr++] = textureIndices[currentMaterial.texture];
+                                vertexArrayBuffer[vertexPtr++] = packRemap(this.textureAtlases.shrubTextureRemap[textureIndices[currentMaterial.texture]]);
                                 vertexArrayBuffer[vertexPtr++] = currentMaterial.clamp;
                                 vertexArrayBuffer[vertexPtr++] = texcoordScale * vertex.s;
                                 vertexArrayBuffer[vertexPtr++] = texcoordScale * vertex.t;

--- a/src/RatchetAndClank/render-sky.ts
+++ b/src/RatchetAndClank/render-sky.ts
@@ -66,10 +66,10 @@ void main() {
     float isTextured = u_ExtraData.x;
     if (isTextured == 1.0) {
         if (u_RenderSettings.x == 0.0) discard;
-        gl_FragColor = commonFragmentShader(v_Rgba, texture(SAMPLER_2D(u_Texture), v_ST), 0.0);
+        gl_FragColor = commonFragmentShader(v_Rgba, texture(SAMPLER_2D(u_Texture), v_ST), 0.0, 0.0);
     } else {
         if (u_RenderSettings.x == 0.0) { gl_FragColor = v_Rgba; return; }
-        gl_FragColor = commonFragmentShader(v_Rgba, vec4(1.0, 1.0, 1.0, 1.0), 0.0);
+        gl_FragColor = commonFragmentShader(v_Rgba, vec4(1.0, 1.0, 1.0, 1.0), 0.0, 0.0);
     }
 }
 `;

--- a/src/RatchetAndClank/render-tfrag.ts
+++ b/src/RatchetAndClank/render-tfrag.ts
@@ -1,16 +1,16 @@
 import { createBufferFromData } from "../gfx/helpers/BufferHelpers";
 import { GfxShaderLibrary } from "../gfx/helpers/GfxShaderLibrary";
-import { GfxBuffer, GfxBufferFrequencyHint, GfxBufferUsage, GfxDevice, GfxFormat, GfxInputLayout, GfxProgram, GfxSamplerBinding, GfxSamplerFormatKind, GfxTextureDimension, GfxVertexBufferFrequency } from "../gfx/platform/GfxPlatform";
+import { GfxBuffer, GfxBufferFrequencyHint, GfxBufferUsage, GfxCompareMode, GfxDevice, GfxFormat, GfxInputLayout, GfxProgram, GfxSamplerBinding, GfxSamplerFormatKind, GfxTextureDimension, GfxVertexBufferFrequency } from "../gfx/platform/GfxPlatform";
 import { GfxRenderCache } from "../gfx/render/GfxRenderCache";
 import { DeviceProgram } from "../Program";
 import { assert } from "../util";
 import { RatchetShaderLib } from "./shader-lib";
 import { Tfrag, TfragLight, TfragVertexInfo } from "./bin-core";
-import { PaletteTexture } from "./textures";
+import { packRemap, PaletteTexture, TextureAtlases } from "./textures";
 import { GfxRenderHelper } from "../gfx/render/GfxRenderHelper";
 import { GfxRenderInstList } from "../gfx/render/GfxRenderInstManager";
 import { noclipSpaceFromRatchetSpace } from "./utils";
-import { fillMatrix4x3, fillMatrix4x4 } from "../gfx/helpers/UniformBufferHelpers";
+import { fillMatrix4x3, fillVec4 } from "../gfx/helpers/UniformBufferHelpers";
 
 export class TfragProgram extends DeviceProgram {
     public static a_Position = 0;
@@ -34,6 +34,7 @@ ${RatchetShaderLib.SceneParams}
 
 layout(std140) uniform ub_TfragParams {
     Mat3x4 u_WorldFromLocal;
+    vec4 u_AlphaTest; // x = alpha test
 };
 
 layout(location = 0) uniform sampler2DArray u_Texture_16;
@@ -91,9 +92,9 @@ flat in int v_Clamp;
 
 void main() {
     if (u_RenderSettings.x == 0.0) { gl_FragColor = vec4(v_Rgba.rgb / 2.0, v_Rgba.a); return; }
-    ivec2 texRemap = getTexRemap(u_TextureRemaps.tfrags, v_TextureIndex);
+    ivec2 texRemap = getTexRemap(v_TextureIndex);
     vec4 textureSample = ratchetSampler(texRemap, v_Clamp, v_ST);
-    gl_FragColor = commonFragmentShader(v_Rgba, textureSample, v_FogFactor);
+    gl_FragColor = commonFragmentShader(v_Rgba, textureSample, v_FogFactor, u_AlphaTest.x);
 }
 `;
 
@@ -104,11 +105,13 @@ export class TfragGeometry {
 
     // array of 3 vertex buffers, one per lod
     private lods: ({
-        vertexBuffer: GfxBuffer,
-        vertexCount: number,
+        vertexBufferOpaque: GfxBuffer,
+        vertexCountOpaque: number,
+        vertexBufferTransparent: GfxBuffer,
+        vertexCountTransparent: number,
     } | null)[] = [null, null, null];
 
-    constructor(private cache: GfxRenderCache, private tfrags: Tfrag[], private tfragTextures: PaletteTexture[]) {
+    constructor(private cache: GfxRenderCache, private tfrags: Tfrag[], private textureAssets: PaletteTexture[], private textureAtlases: TextureAtlases) {
         this.inputLayout = cache.createInputLayout({
             vertexAttributeDescriptors: [
                 { location: TfragProgram.a_Position, format: GfxFormat.F32_RGB, bufferByteOffset: 0, bufferIndex: 0, },
@@ -128,12 +131,17 @@ export class TfragGeometry {
     public getOrCreateVertexBuffer(lod: number) {
         if (!this.lods[lod]) {
             const device = this.cache.device;
-            const vertexData = this.assemble(lod);
-            const vertexBuffer = createBufferFromData(device, GfxBufferUsage.Vertex, GfxBufferFrequencyHint.Static, vertexData.vertexArrayBuffer.buffer);
-            device.setResourceName(vertexBuffer, `Tfrag LOD ${lod} (VB)`);
+            const vertexDataOpaque = this.assemble(lod, false);
+            const vertexBufferOpaque = createBufferFromData(device, GfxBufferUsage.Vertex, GfxBufferFrequencyHint.Static, vertexDataOpaque.vertexArrayBuffer.buffer);
+            device.setResourceName(vertexBufferOpaque, `Tfrag LOD ${lod} Opaque VB`);
+            const vertexDataTransparent = this.assemble(lod, true);
+            const vertexBufferTransparent = createBufferFromData(device, GfxBufferUsage.Vertex, GfxBufferFrequencyHint.Static, vertexDataTransparent.vertexArrayBuffer.buffer);
+            device.setResourceName(vertexBufferTransparent, `Tfrag LOD ${lod} Transparent VB`);
             this.lods[lod] = {
-                vertexBuffer,
-                vertexCount: vertexData.vertexCount,
+                vertexBufferOpaque,
+                vertexCountOpaque: vertexDataOpaque.vertexCount,
+                vertexBufferTransparent,
+                vertexCountTransparent: vertexDataTransparent.vertexCount,
             };
         }
 
@@ -142,35 +150,72 @@ export class TfragGeometry {
         return lodData;
     }
 
-    private assemble(lod: number) {
+    private count(lod: number, transparentMode: boolean, trace: number[]) {
         const tfrags = this.tfrags;
-        const tfragTextures = this.tfragTextures;
-
-        const positionScale = 1 / 1024;
-        const texcoordScale = 1 / 4096;
-        const colorScale = 1 / 0x80;
+        const textureAssets = this.textureAssets;
 
         let vertexCount = 0;
 
         for (let i = 0; i < tfrags.length; i++) {
             const tfrag = tfrags[i];
             const tfragStrips = [tfrag.dataGroup5.lod0.strips, tfrag.dataGroup3.lod1.strips, tfrag.dataGroup1.lod2.strips];
+            const tfragTextures = tfrag.dataGroup2.textures;
+
             const strips = tfragStrips[lod];
             let stripPtr = 0;
+
+            let activeMaterialIsTransparent = false;
+
             stripLoop: while (true) {
                 const strip = strips[stripPtr];
                 assert(strip !== undefined);
+
                 switch (strip.endOfPacketFlag) {
                     case 0: break; // normal strip
                     case 0x80: break; // end of packet but not end of this tfrag
                     case 0xFF: break stripLoop; // end
                     default: throw new Error(`Unknown strip flag`);
                 }
-                vertexCount += 3 * (strip.vertexCount - 2);
+
+                let stripVertexCount = strip.vertexCount;
+                if (strip.hasAdGifFlag) {
+                    if (strip.adGifOffset === -1) {
+                        // do nothing
+                    } else if (strip.adGifOffset >= 0) {
+                        const localAdGifIndex = strip.adGifOffset / 0x5;
+                        assert(tfragTextures[localAdGifIndex] !== undefined);
+                        let activeMaterial = tfragTextures[localAdGifIndex].tex0.low;
+                        activeMaterialIsTransparent = textureAssets[activeMaterial].hasAlpha;
+                    } else {
+                        throw new Error(`invalid adGifOffset`);
+                    }
+                }
+
+                if (activeMaterialIsTransparent !== transparentMode) {
+                    // do not count
+                    stripPtr++;
+                    continue;
+                }
+
+                vertexCount += stripVertexCount * 3 - (2 * 3);
                 stripPtr++;
             }
+
         }
 
+        return vertexCount;
+    }
+
+    private assemble(lod: number, transparentMode: boolean) {
+        const tfrags = this.tfrags;
+        const textureAssets = this.textureAssets;
+
+        const positionScale = 1 / 1024;
+        const texcoordScale = 1 / 4096;
+        const colorScale = 1 / 0x80;
+
+        const trace :number[]= []
+        const vertexCount = this.count(lod, transparentMode,trace);
         const vertexArrayBuffer = new Float32Array(vertexCount * TfragProgram.elementsPerVertex);
         let vertexPtr = 0;
 
@@ -198,6 +243,7 @@ export class TfragGeometry {
             let stripIndicesPtr = 0;
 
             let activeMaterial = 0;
+            let activeMaterialIsTransparent = false;
             let activeClamp = 0;
 
             stripLoop: while (true) {
@@ -211,7 +257,7 @@ export class TfragGeometry {
                     default: throw new Error(`Unknown strip flag`);
                 }
 
-                let vertexCount = strip.vertexCount;
+                let stripVertexCount = strip.vertexCount;
                 if (strip.hasAdGifFlag) {
                     if (strip.adGifOffset === -1) {
                         // do nothing
@@ -219,13 +265,20 @@ export class TfragGeometry {
                         const localAdGifIndex = strip.adGifOffset / 0x5;
                         assert(tfragTextures[localAdGifIndex] !== undefined);
                         activeMaterial = tfragTextures[localAdGifIndex].tex0.low;
+                        activeMaterialIsTransparent = textureAssets[activeMaterial].hasAlpha;
                         activeClamp = tfragTextures[localAdGifIndex].clamp.low + (tfragTextures[localAdGifIndex].clamp.high << 2);
                     } else {
                         throw new Error(`invalid adGifOffset`);
                     }
                 }
 
-                for (let i = 0; i < vertexCount - 2; i++) {
+                if (activeMaterialIsTransparent !== transparentMode) {
+                    stripIndicesPtr += stripVertexCount;
+                    stripPtr++;
+                    continue;
+                }
+
+                for (let i = 0; i < stripVertexCount - 2; i++) {
                     const triangleIndices = [indices[stripIndicesPtr], indices[stripIndicesPtr + 1], indices[stripIndicesPtr + 2]];
                     for (let tri = 0; tri < 3; tri++) {
                         const vertexIndex = triangleIndices[tri];
@@ -245,7 +298,7 @@ export class TfragGeometry {
                         vertexArrayBuffer[vertexPtr++] = colorScale * rgba.g;
                         vertexArrayBuffer[vertexPtr++] = colorScale * rgba.b;
                         vertexArrayBuffer[vertexPtr++] = colorScale * rgba.a;
-                        vertexArrayBuffer[vertexPtr++] = activeMaterial;
+                        vertexArrayBuffer[vertexPtr++] = packRemap(this.textureAtlases.tfragTextureRemap[activeMaterial]);
                         vertexArrayBuffer[vertexPtr++] = activeClamp;
                         vertexArrayBuffer[vertexPtr++] = texcoordScale * this.fixTexcoord(vertInfo.s);
                         vertexArrayBuffer[vertexPtr++] = texcoordScale * this.fixTexcoord(vertInfo.t);
@@ -298,7 +351,8 @@ export class TfragGeometry {
     public destroy(device: GfxDevice): void {
         for (const lod of this.lods) {
             if (lod) {
-                device.destroyBuffer(lod.vertexBuffer);
+                device.destroyBuffer(lod.vertexBufferOpaque);
+                device.destroyBuffer(lod.vertexBufferTransparent);
             }
         }
     }
@@ -335,23 +389,40 @@ export class TfragRenderer {
 
         const vertexData = tfragGeometry.getOrCreateVertexBuffer(lodLevel);
 
-        const renderInst = this.renderHelper.renderInstManager.newRenderInst();
-        renderInst.setBindingLayouts(bindingLayouts);
-        renderInst.setGfxProgram(this.tfragProgram);
+        // to emulate TEST_1.AFAIL=FB_ONLY, render transparent parts twice, once with depth write and alpha test, and again with neither
+        const draws = [
+            { transparentGeometry: false, depthWrite: true, alphaTest: 0 },
+            { transparentGeometry: true, depthWrite: true, alphaTest: 0.75 },
+            { transparentGeometry: true, depthWrite: false, alphaTest: 0 },
+        ]
 
-        const tfragParams = renderInst.allocateUniformBufferF32(TfragProgram.ub_TfragParams, 12);
-        let offs = 0;
-        offs += fillMatrix4x3(tfragParams, offs, objectMatrix);
+        for (let i = 0; i < draws.length; i++) {
+            const draw = draws[i];
 
-        renderInst.setVertexInput(
-            tfragGeometry.inputLayout,
-            [
-                { buffer: vertexData.vertexBuffer, byteOffset: 0 },
-            ],
-            null,
-        );
-        renderInst.setSamplerBindingsFromTextureMappings(textureMappings);
-        renderInst.setDrawCount(vertexData.vertexCount, 0);
-        renderInstList.submitRenderInst(renderInst);
+            const vertexCount = draw.transparentGeometry ? vertexData.vertexCountTransparent : vertexData.vertexCountOpaque;
+            if (!vertexCount) continue;
+            const vertexBuffer = draw.transparentGeometry ? vertexData.vertexBufferTransparent : vertexData.vertexBufferOpaque;
+
+            const renderInst = this.renderHelper.renderInstManager.newRenderInst();
+            renderInst.setMegaStateFlags({ depthWrite: draw.depthWrite, depthCompare: GfxCompareMode.Greater });
+            renderInst.setBindingLayouts(bindingLayouts);
+            renderInst.setGfxProgram(this.tfragProgram);
+
+            const tfragParams = renderInst.allocateUniformBufferF32(TfragProgram.ub_TfragParams, 16);
+            let offs = 0;
+            offs += fillMatrix4x3(tfragParams, offs, objectMatrix);
+            offs += fillVec4(tfragParams, offs, draw.alphaTest, 0, 0, 0);
+
+            renderInst.setVertexInput(
+                tfragGeometry.inputLayout,
+                [
+                    { buffer: vertexBuffer, byteOffset: 0 },
+                ],
+                null,
+            );
+            renderInst.setSamplerBindingsFromTextureMappings(textureMappings);
+            renderInst.setDrawCount(vertexCount, 0);
+            renderInstList.submitRenderInst(renderInst);
+        }
     }
 }

--- a/src/RatchetAndClank/render-tfrag.ts
+++ b/src/RatchetAndClank/render-tfrag.ts
@@ -105,9 +105,8 @@ export class TfragGeometry {
 
     // array of 3 vertex buffers, one per lod
     private lods: ({
-        vertexBufferOpaque: GfxBuffer,
+        vertexBuffer: GfxBuffer,
         vertexCountOpaque: number,
-        vertexBufferTransparent: GfxBuffer,
         vertexCountTransparent: number,
     } | null)[] = [null, null, null];
 
@@ -131,17 +130,19 @@ export class TfragGeometry {
     public getOrCreateVertexBuffer(lod: number) {
         if (!this.lods[lod]) {
             const device = this.cache.device;
-            const vertexDataOpaque = this.assemble(lod, false);
-            const vertexBufferOpaque = createBufferFromData(device, GfxBufferUsage.Vertex, GfxBufferFrequencyHint.Static, vertexDataOpaque.vertexArrayBuffer.buffer);
-            device.setResourceName(vertexBufferOpaque, `Tfrag LOD ${lod} Opaque VB`);
-            const vertexDataTransparent = this.assemble(lod, true);
-            const vertexBufferTransparent = createBufferFromData(device, GfxBufferUsage.Vertex, GfxBufferFrequencyHint.Static, vertexDataTransparent.vertexArrayBuffer.buffer);
-            device.setResourceName(vertexBufferTransparent, `Tfrag LOD ${lod} Transparent VB`);
+            const vertexCountOpaque = this.count(lod, false);
+            const vertexCountTransparent = this.count(lod, true);
+            const vertexArrayBuffer = new Float32Array((vertexCountOpaque + vertexCountTransparent) * TfragProgram.elementsPerVertex);
+            this.assemble(lod, vertexArrayBuffer, 0, vertexCountOpaque, false);
+            this.assemble(lod, vertexArrayBuffer, vertexCountOpaque, vertexCountTransparent, true);
+
+            const vertexBuffer = createBufferFromData(device, GfxBufferUsage.Vertex, GfxBufferFrequencyHint.Static, vertexArrayBuffer.buffer);
+            device.setResourceName(vertexBuffer, `Tfrag LOD ${lod} VB`);
+
             this.lods[lod] = {
-                vertexBufferOpaque,
-                vertexCountOpaque: vertexDataOpaque.vertexCount,
-                vertexBufferTransparent,
-                vertexCountTransparent: vertexDataTransparent.vertexCount,
+                vertexBuffer,
+                vertexCountOpaque,
+                vertexCountTransparent,
             };
         }
 
@@ -150,7 +151,7 @@ export class TfragGeometry {
         return lodData;
     }
 
-    private count(lod: number, transparentMode: boolean, trace: number[]) {
+    private count(lod: number, transparentMode: boolean) {
         const tfrags = this.tfrags;
         const textureAssets = this.textureAssets;
 
@@ -206,7 +207,7 @@ export class TfragGeometry {
         return vertexCount;
     }
 
-    private assemble(lod: number, transparentMode: boolean) {
+    private assemble(lod: number, vertexArrayBuffer: Float32Array, baseVertex: number, expectedCount: number, transparentMode: boolean) {
         const tfrags = this.tfrags;
         const textureAssets = this.textureAssets;
 
@@ -214,10 +215,7 @@ export class TfragGeometry {
         const texcoordScale = 1 / 4096;
         const colorScale = 1 / 0x80;
 
-        const trace :number[]= []
-        const vertexCount = this.count(lod, transparentMode,trace);
-        const vertexArrayBuffer = new Float32Array(vertexCount * TfragProgram.elementsPerVertex);
-        let vertexPtr = 0;
+        let vertexPtr = baseVertex * TfragProgram.elementsPerVertex;
 
         for (let i = 0; i < tfrags.length; i++) {
             const tfrag = tfrags[i];
@@ -316,13 +314,7 @@ export class TfragGeometry {
 
         }
 
-        assert(vertexPtr === vertexCount * TfragProgram.elementsPerVertex);
-        assert(vertexPtr === vertexArrayBuffer.length);
-
-        return {
-            vertexArrayBuffer,
-            vertexCount,
-        };
+        assert(vertexPtr === (baseVertex + expectedCount) * TfragProgram.elementsPerVertex);
     }
 
     private fixTexcoord(n: number) {
@@ -351,8 +343,7 @@ export class TfragGeometry {
     public destroy(device: GfxDevice): void {
         for (const lod of this.lods) {
             if (lod) {
-                device.destroyBuffer(lod.vertexBufferOpaque);
-                device.destroyBuffer(lod.vertexBufferTransparent);
+                device.destroyBuffer(lod.vertexBuffer);
             }
         }
     }
@@ -391,24 +382,23 @@ export class TfragRenderer {
 
         // to emulate TEST_1.AFAIL=FB_ONLY, render transparent parts twice, once with depth write and alpha test, and again with neither
         const draws = [
-            { transparentGeometry: false, depthWrite: true, alphaTest: 0 },
-            { transparentGeometry: true, depthWrite: true, alphaTest: 0.75 },
-            { transparentGeometry: true, depthWrite: false, alphaTest: 0 },
+            { transparentOnly: false, depthWrite: true, alphaTest: 0.75 },
+            { transparentOnly: true, depthWrite: false, alphaTest: 0 },
         ]
 
         for (let i = 0; i < draws.length; i++) {
             const draw = draws[i];
 
-            const vertexCount = draw.transparentGeometry ? vertexData.vertexCountTransparent : vertexData.vertexCountOpaque;
+            const vertexCount = draw.transparentOnly ? vertexData.vertexCountTransparent : (vertexData.vertexCountOpaque + vertexData.vertexCountTransparent);
             if (!vertexCount) continue;
-            const vertexBuffer = draw.transparentGeometry ? vertexData.vertexBufferTransparent : vertexData.vertexBufferOpaque;
+            const startVertex = draw.transparentOnly ? vertexData.vertexCountOpaque : 0;
 
             const renderInst = this.renderHelper.renderInstManager.newRenderInst();
             renderInst.setMegaStateFlags({ depthWrite: draw.depthWrite, depthCompare: GfxCompareMode.Greater });
             renderInst.setBindingLayouts(bindingLayouts);
             renderInst.setGfxProgram(this.tfragProgram);
 
-            const tfragParams = renderInst.allocateUniformBufferF32(TfragProgram.ub_TfragParams, 16);
+            const tfragParams = renderInst.allocateUniformBufferF32(TfragProgram.ub_TfragParams, 0x16);
             let offs = 0;
             offs += fillMatrix4x3(tfragParams, offs, objectMatrix);
             offs += fillVec4(tfragParams, offs, draw.alphaTest, 0, 0, 0);
@@ -416,7 +406,7 @@ export class TfragRenderer {
             renderInst.setVertexInput(
                 tfragGeometry.inputLayout,
                 [
-                    { buffer: vertexBuffer, byteOffset: 0 },
+                    { buffer: vertexData.vertexBuffer, byteOffset: startVertex * TfragProgram.elementsPerVertex * 0x4 },
                 ],
                 null,
             );

--- a/src/RatchetAndClank/render-tie.ts
+++ b/src/RatchetAndClank/render-tie.ts
@@ -13,6 +13,7 @@ import { TieClass, TieVertexWithNormalAndRgba } from "./bin-core";
 import { TieInstance } from "./bin-gameplay";
 import { RatchetShaderLib } from "./shader-lib";
 import { GN, ImaginaryGsCommandType, MegaBuffer } from "./utils";
+import { packRemap, TextureAtlases } from "./textures";
 
 export class TieProgram extends DeviceProgram {
     public static a_Position = 0;
@@ -112,9 +113,9 @@ flat in int v_Clamp;
 
 void main() {
     if (u_RenderSettings.x == 0.0) { gl_FragColor = vec4(v_Rgba.rgb / 2.0, v_Rgba.a); return; }
-    ivec2 texRemap = getTexRemap(u_TextureRemaps.ties, v_TextureIndex);
+    ivec2 texRemap = getTexRemap(v_TextureIndex);
     vec4 textureSample = ratchetSampler(texRemap, v_Clamp, v_ST);
-    gl_FragColor = commonFragmentShader(v_Rgba, textureSample, v_FogFactor);
+    gl_FragColor = commonFragmentShader(v_Rgba, textureSample, v_FogFactor, 0.01);
 }
 `;
 
@@ -126,7 +127,7 @@ export class TieGeometry {
     private vertexBuffer: GfxBuffer;
     private vertexCount: number;
 
-    constructor(private cache: GfxRenderCache, private tieOClass: number, private tie: TieClass, private lodLevel: number, private textureIndices: number[]) {
+    constructor(private cache: GfxRenderCache, private tieOClass: number, private tie: TieClass, private lodLevel: number, private textureIndices: number[], private textureAtlases: TextureAtlases) {
         this.inputLayout = cache.createInputLayout({
             vertexAttributeDescriptors: [
                 // per vertex
@@ -250,7 +251,7 @@ export class TieGeometry {
                                 vertexArrayBuffer[vertexPtr++] = positionScale * vertex.x;
                                 vertexArrayBuffer[vertexPtr++] = positionScale * vertex.y;
                                 vertexArrayBuffer[vertexPtr++] = positionScale * vertex.z;
-                                vertexArrayBuffer[vertexPtr++] = textureIndices[currentMaterial.texture];
+                                vertexArrayBuffer[vertexPtr++] = packRemap(this.textureAtlases.tieTextureRemap[textureIndices[currentMaterial.texture]]);
                                 vertexArrayBuffer[vertexPtr++] = currentMaterial.clamp;
                                 vertexArrayBuffer[vertexPtr++] = rgbaIndex;
                                 vertexArrayBuffer[vertexPtr++] = texcoordScale * fixedTexcoord.s;

--- a/src/RatchetAndClank/scenes.ts
+++ b/src/RatchetAndClank/scenes.ts
@@ -180,16 +180,20 @@ class RatchetAndClankScene implements SceneGfx {
         const existing = this.geometries.tfrag;
         if (existing) return existing;
 
+        if (!this.textures.textureAtlases) return null;
+
         const { tfrags, tfragTextures } = this.levelResources;
         if (!tfrags || !tfragTextures) return null;
 
-        this.geometries.tfrag = new TfragGeometry(this.renderHelper.renderCache, tfrags, tfragTextures);
+        this.geometries.tfrag = new TfragGeometry(this.renderHelper.renderCache, tfrags, tfragTextures, this.textures.textureAtlases);
         return this.geometries.tfrag;
     }
 
     getOrCreateTieGeometry(oClass: number): (TieGeometry | null)[] | null {
         const existing = this.geometries.ties.get(oClass);
         if (existing) return existing;
+
+        if (!this.textures.textureAtlases) return null;
 
         const tieClass = this.levelResources.tieClasses?.get(oClass);
         if (!tieClass) return null;
@@ -199,7 +203,7 @@ class RatchetAndClankScene implements SceneGfx {
         const tieGeometry: (TieGeometry | null)[] = [null, null, null];
         for (let i = 0; i < 3; i++) {
             if (tieClass.packets[i].length === 0) continue; // no mesh for this lod
-            tieGeometry[i] = new TieGeometry(this.renderHelper.renderCache, oClass, tieClass, i, tieTextureIndices);
+            tieGeometry[i] = new TieGeometry(this.renderHelper.renderCache, oClass, tieClass, i, tieTextureIndices, this.textures.textureAtlases);
         }
         this.geometries.ties.set(oClass, tieGeometry);
         return tieGeometry;
@@ -208,6 +212,8 @@ class RatchetAndClankScene implements SceneGfx {
     getOrCreateMobyGeometry(oClass: number): (MobyGeometry | null)[] | null {
         const existing = this.geometries.mobys.get(oClass);
         if (existing) return existing;
+
+        if (!this.textures.textureAtlases) return null;
 
         const mobyClass = this.levelResources.mobyClasses?.get(oClass);
         if (!mobyClass) return null;
@@ -218,7 +224,7 @@ class RatchetAndClankScene implements SceneGfx {
         const mobyGeometry: (MobyGeometry | null)[] = [null, null];
         for (let i = 0; i < 2; i++) {
             if (!mobyClass.mesh.packetsByLod[i].length) continue;
-            mobyGeometry[i] = new MobyGeometry(this.renderHelper.renderCache, oClass, mobyClass, i, mobyTextureIndices);
+            mobyGeometry[i] = new MobyGeometry(this.renderHelper.renderCache, oClass, mobyClass, i, mobyTextureIndices, this.textures.textureAtlases);
         }
 
         this.geometries.mobys.set(oClass, mobyGeometry);
@@ -229,12 +235,14 @@ class RatchetAndClankScene implements SceneGfx {
         const existing = this.geometries.shrubs.get(oClass);
         if (existing) return existing;
 
+        if (!this.textures.textureAtlases) return null;
+
         const shrubClass = this.levelResources.shrubClasses?.get(oClass);
         if (!shrubClass) return null;
         const shrubTextureIndices = this.levelResources.shrubClassTextureIndices?.get(oClass);
         if (!shrubTextureIndices) return null;
 
-        const shrubGeometry = new ShrubGeometry(this.renderHelper.renderCache, shrubClass, shrubTextureIndices);
+        const shrubGeometry = new ShrubGeometry(this.renderHelper.renderCache, shrubClass, shrubTextureIndices, this.textures.textureAtlases);
         this.geometries.shrubs.set(oClass, shrubGeometry);
         return shrubGeometry;
     }
@@ -392,24 +400,6 @@ class RatchetAndClankScene implements SceneGfx {
                 offs += fillVec4(data, offs, 0, 0, 0, 0);
                 offs += fillVec4(data, offs, 0, 0, 0, 0);
                 offs += fillVec4(data, offs, 0, 0, 0, 0);
-            }
-        }
-
-        // texture remaps (4 * 32 * 4 floats) (two entries packed into each float)
-        const { textureAtlases } = this.textures;
-        const remapArrays = textureAtlases ? [textureAtlases.tfragTextureRemap, textureAtlases.tieTextureRemap, textureAtlases.mobyTextureRemap, textureAtlases.shrubTextureRemap] : [[], [], [], []];
-
-        const packRemap = (remap: typeof remapArrays[0][0]) => {
-            const bucket = remap ? Math.log2(remap.sizeBucket) - 4 : 0;
-            const slice = remap ? remap.index : 0;
-            return (slice << 3) | (bucket & 0x07);
-        };
-
-        for (const remapArray of remapArrays) {
-            for (let i = 0; i < 256; i += 2) {
-                const packed0 = packRemap(remapArray[i + 0]);
-                const packed1 = packRemap(remapArray[i + 1]);
-                data[offs++] = bitsAsFloat32(packed1 << 16 | packed0);
             }
         }
     }

--- a/src/RatchetAndClank/scenes.ts
+++ b/src/RatchetAndClank/scenes.ts
@@ -23,7 +23,6 @@ import { CollisionGeometry, CollisionRenderer } from "./render-collision";
 import { IS_DEVELOPMENT } from "../BuildVersion";
 import { GfxDynamicBufferCache } from "../gfx/render/GfxRenderCache";
 import { MobyGeometry, MobyRenderer } from "./render-moby";
-import { bitsAsFloat32 } from "../MathHelpers";
 
 const pathBase = (gn: GN) => `RatchetAndClank${gn}`;
 
@@ -417,7 +416,7 @@ class RatchetAndClankScene implements SceneGfx {
         // setup
         const template = this.renderHelper.pushTemplateRenderInst();
         template.setMegaStateFlags({
-            cullMode: GfxCullMode.None, // ps2 don't do backface culling
+            cullMode: GfxCullMode.None, // the game has backface culling only on objects within a specific per-object distance from the camera
             attachmentsState: [{
                 channelWriteMask: GfxChannelWriteMask.AllChannels,
                 rgbBlendState: {

--- a/src/RatchetAndClank/shader-lib.ts
+++ b/src/RatchetAndClank/shader-lib.ts
@@ -35,14 +35,6 @@ struct DirectionLight {
     vec4 colorB;
 };
 
-// size 4*32*4
-struct TextureRemaps {
-    vec4 tfrags[32];
-    vec4 ties[32];
-    vec4 mobys[32];
-    vec4 shrubs[32];
-};
-
 layout(std140) uniform ub_SceneParams {
     Mat4x4 u_ClipFromWorld;
     CameraData u_CameraData;
@@ -51,7 +43,6 @@ layout(std140) uniform ub_SceneParams {
     vec4 u_BackgroundColor;
     FogParams u_FogParams;
     DirectionLight u_DirectionLights[16];
-    TextureRemaps u_TextureRemaps;
 };
 
     `,
@@ -123,7 +114,7 @@ ${GfxShaderLibrary.MonochromeNTSCLinear}
 
 const float SATURATION_ADJUST = 1.15;
 
-vec4 commonFragmentShader(vec4 rgba, vec4 textureSample, float fogFactor) {
+vec4 commonFragmentShader(vec4 rgba, vec4 textureSample, float fogFactor, float alphaTest) {
     // texture color is multiplied with vertex color immediately
     rgba *= textureSample;
 
@@ -136,8 +127,7 @@ vec4 commonFragmentShader(vec4 rgba, vec4 textureSample, float fogFactor) {
     rgba = vec4(rgb, rgba.a);
 
     // alpha test
-    // this should be configured per object but I can't find the data
-    if (rgba.a < 0.01) discard;
+    if (rgba.a < alphaTest) discard;
 
     // with saturation filter (not authentic but looks washed out without it)
     rgba.rgb = mix(vec3(MonochromeNTSCLinear(rgba.rgb)), rgba.rgb, SATURATION_ADJUST);
@@ -147,12 +137,8 @@ vec4 commonFragmentShader(vec4 rgba, vec4 textureSample, float fogFactor) {
 
     `,
     Sampler: `
-ivec2 getTexRemap(in vec4 remapArray[32], in int index) {
-    uint v32 = floatBitsToUint(remapArray[index >> 3][(index >> 1) & 0x03]);
-    uint v16 = (v32 >> ((index & 0x01) * 16)) & 0xFFFFu;
-    uint bucket = (v16 & 0x07u);
-    uint slice = (v16 >> 3u);
-    return ivec2(bucket, slice);
+ivec2 getTexRemap(in int index) {
+    return ivec2(uint(index) & 0x7u, uint(index) >> 0x3u);
 }
 
 /*

--- a/src/RatchetAndClank/textures.ts
+++ b/src/RatchetAndClank/textures.ts
@@ -285,6 +285,13 @@ function assignTexturesToSizeBucket(buckets: TexturesBySize, textures: PaletteTe
     return remap;
 }
 
+
+export function packRemap(remap: { sizeBucket: number, index: number }) {
+    const bucket = remap ? Math.log2(remap.sizeBucket) - 4 : 0;
+    const slice = remap ? remap.index : 0;
+    return (slice << 3) | (bucket & 0x07);
+};
+
 export interface TextureAtlases {
     gfxTextures: { [size in 16 | 32 | 64 | 128 | 256]: GfxTexture },
     tfragTextureRemap: { sizeBucket: number, index: number }[],


### PR DESCRIPTION
 * Packing the texture remap data into floats wasn't working on Android. I've moved the final texture ids into the vertex buffer so no mapping in the shader is required.
 * Improve transparency ordering in tfrags. Split opaque and transparent, render transparent twice, once with depth write+alpha test, and again without. This emulates the ps2's TEST_1.AFAIL=FB_ONLY behavior. Mostly this fixes the artifacts on vines and grass hanging off ledges.
 * Small progress on rac2

## Pull Request Checklist

Please check one of the boxes below:
- [ ] Generative AI was used in the creation of this PR (for any part, including but not limited to coding, reverse engineering, or debugging). I have read [AI Contributions Policy](https://github.com/magcius/noclip.website/blob/main/README.md#ai-contributions-policy). All comments and documentation are human-authored.
- [x] Generative AI was not used in the creation of this PR.
