### PR TITLE
Migrate to wasm-pack instead of manually calling wasm-bindgen and wasm-opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then, use the following commands to set up your environment (only needed every s
   cargo bin --install
   ```
 
-Finally, to build and run the project, use `pnpm start`. This will start a live-reloading environment and uses filesystem watchers to auto-build the project.
+Finally, to build and run the project, use `pnpm start`. This will start a live-reloading environment and uses filesystem watchers to auto-build the project. To include live-reloading for Rust code as well, use `pnpm start --watch`.
 
 For any questions related to development, see the [Official noclip.website Discord Server](https://discord.gg/bkJmKKv)'s #development channel. A number of developers from the community are present there and can help answer questions if you run into any additional issues getting set up.
 

--- a/package.json
+++ b/package.json
@@ -56,19 +56,19 @@
         "rsbuild.config.ts",
         "tsconfig.json"
       ],
-      "dependencies": ["build:wasm-release"]
+      "dependencies": ["build:cargo-build-release"]
     },
     "start": {
       "command": "rsbuild dev",
       "dependencies": [
-        "build:wasm-debug"
+        "build:cargo-build-debug"
       ],
       "service": true,
       "cascade": false,
       "files": []
     },
     "build:cargo-build-debug": {
-      "command": "cd rust && cargo build --target wasm32-unknown-unknown",
+      "command": "cd rust && cargo bin wasm-pack target/wasm32-unknown-unknown/debug/noclip_rust_support.wasm --dev --out-dir ./pkg --out-name index --target web",
       "files": [
         "rust/Cargo.toml",
         "rust/src/**/*.rs",
@@ -80,7 +80,7 @@
       ]
     },
     "build:cargo-build-release": {
-      "command": "cd rust && cargo build --release --target wasm32-unknown-unknown",
+      "command": "cd rust && cargo bin wasm-pack target/wasm32-unknown-unknown/debug/noclip_rust_support.wasm --release --out-dir ./pkg --out-name index --target web",
       "files": [
         "rust/Cargo.toml",
         "rust/src/**/*.rs",
@@ -91,44 +91,6 @@
         "rust/target/wasm32-unknown-unknown/release/noclip_rust_support.wasm"
       ]
     },
-    "build:wasm-debug": {
-      "command": "cd rust && cargo bin wasm-bindgen-cli target/wasm32-unknown-unknown/debug/noclip_rust_support.wasm --out-dir ./pkg --out-name index --target web",
-      "files": [
-        "rust/target/wasm32-unknown-unknown/debug/noclip_rust_support.wasm"
-      ],
-      "output": [
-        "rust/pkg/*"
-      ],
-      "dependencies": [
-        "build:cargo-build-debug"
-      ],
-      "clean": false
-    },
-    "build:rust-wasm-opt": {
-      "command": "cd rust && cargo bin wasm-opt target/wasm32-unknown-unknown/release/noclip_rust_support.wasm -Os --enable-bulk-memory -g --output target/wasm32-unknown-unknown/release/noclip-rust-support.opt.wasm",
-      "files": [
-        "rust/target/wasm32-unknown-unknown/release/noclip_rust_support.wasm"
-      ],
-      "output": [
-        "rust/target/wasm32-unknown-unknown/release/noclip-rust-support.opt.wasm"
-      ],
-      "dependencies": [
-        "build:cargo-build-release"
-      ]
-    },
-    "build:wasm-release": {
-      "command": "cd rust && cargo bin wasm-bindgen-cli target/wasm32-unknown-unknown/release/noclip-rust-support.opt.wasm --out-dir ./pkg --out-name index --target web",
-      "files": [
-        "rust/target/wasm32-unknown-unknown/release/noclip-rust-support.opt.wasm"
-      ],
-      "output": [
-        "rust/pkg/*"
-      ],
-      "dependencies": [
-        "build:rust-wasm-opt"
-      ]
-    }
-  },
   "browserslist": [
     "last 2 Chrome versions"
   ],

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "scripts": {
     "start": "wireit",
     "build": "wireit",
-    "build:wasm-debug": "wireit",
-    "build:wasm-release": "wireit",
+    "build:cargo-build-debug": "wireit",
+    "build:cargo-build-release": "wireit",
     "build:ZeldaWindWaker": "tsx src/ZeldaWindWaker/tools/zww_extractor.ts",
     "build:ZeldaTwilightPrincess": "tsx src/ZeldaTwilightPrincess/tools/ztp_extractor.ts",
     "build:DonkeyKong64": "tsx src/DonkeyKong64/tools/extractor.ts",
@@ -61,14 +61,16 @@
     "start": {
       "command": "rsbuild dev",
       "dependencies": [
-        "build:cargo-build-debug"
+        {
+          "script": "build:cargo-build-debug",
+          "cascade": false
+        }
       ],
       "service": true,
-      "cascade": false,
       "files": []
     },
     "build:cargo-build-debug": {
-      "command": "cd rust && cargo bin wasm-pack target/wasm32-unknown-unknown/debug/noclip_rust_support.wasm --dev --out-dir ./pkg --out-name index --target web",
+      "command": "cd rust && cargo bin wasm-pack build --dev --out-dir ./pkg --out-name index --target web",
       "files": [
         "rust/Cargo.toml",
         "rust/src/**/*.rs",
@@ -76,11 +78,15 @@
         "rust/noclip-macros/src/**/*.rs"
       ],
       "output": [
-        "rust/target/wasm32-unknown-unknown/debug/noclip_rust_support.wasm"
-      ]
+        "rust/pkg/index.js",
+        "rust/pkg/index.d.ts",
+        "rust/pkg/index_bg.wasm",
+        "rust/pkg/index_bg.wasm.d.ts"
+      ],
+      "clean": false
     },
     "build:cargo-build-release": {
-      "command": "cd rust && cargo bin wasm-pack target/wasm32-unknown-unknown/debug/noclip_rust_support.wasm --release --out-dir ./pkg --out-name index --target web",
+      "command": "cd rust && cargo bin wasm-pack build --release --out-dir ./pkg --out-name index --target web",
       "files": [
         "rust/Cargo.toml",
         "rust/src/**/*.rs",
@@ -88,9 +94,14 @@
         "rust/noclip-macros/src/**/*.rs"
       ],
       "output": [
-        "rust/target/wasm32-unknown-unknown/release/noclip_rust_support.wasm"
-      ]
-    },
+        "rust/pkg/index.js",
+        "rust/pkg/index.d.ts",
+        "rust/pkg/index_bg.wasm",
+        "rust/pkg/index_bg.wasm.d.ts"
+      ],
+      "clean": false
+    }
+  },
   "browserslist": [
     "last 2 Chrome versions"
   ],

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -406,6 +406,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,11 +555,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -752,6 +777,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "polymorph"
@@ -974,6 +1005,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,35 +1176,22 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1175,31 +1199,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,13 +20,13 @@ console_error_panic_hook = "0.1.7"
 deku = { version = "0.19.1", features = ["logging"] }
 env_logger = "0.10.1"
 inflate = "0.4.5"
-js-sys = "0.3.60"
+js-sys = "0.3.103"
 polymorph = { git = "https://github.com/wgreenberg/polymorph", features = ["sheepfile-reader"], default-features = false }
 log = "0.4.21"
 lz4_flex = { version = "0.10.0", default-features = false, features = ["safe-decode", "checked-decode"] }
 lzma-rs = { version = "0.3.0", features = ["raw_decoder"] }
 naga = { git = "https://github.com/magcius/wgpu", branch = "issue-4349", features = ["glsl-in", "wgsl-out"] }
-wasm-bindgen = "=0.2.100"
+wasm-bindgen = "=0.2.126"
 web-sys = { version = "0.3.48", features = ["console"] }
 nalgebra-glm = "0.19.0"
 rand = "0.8.5"
@@ -41,4 +41,4 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test
 
 [package.metadata.bin]
 wasm-bindgen-cli = { version = "0.2.100", locked = true, bins = ["wasm-bindgen"] }
-wasm-opt = { version = "0.116.1" }
+wasm-pack = { version = "0.15.0" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,7 +27,7 @@ lz4_flex = { version = "0.10.0", default-features = false, features = ["safe-dec
 lzma-rs = { version = "0.3.0", features = ["raw_decoder"] }
 naga = { git = "https://github.com/magcius/wgpu", branch = "issue-4349", features = ["glsl-in", "wgsl-out"] }
 wasm-bindgen = "=0.2.126"
-web-sys = { version = "0.3.48", features = ["console"] }
+web-sys = { version = "0.3.103", features = ["console"] }
 nalgebra-glm = "0.19.0"
 rand = "0.8.5"
 getrandom = { version = "0.2.15", features = ["js"] }
@@ -40,5 +40,4 @@ tegra_swizzle = "0.4.0"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
 
 [package.metadata.bin]
-wasm-bindgen-cli = { version = "0.2.100", locked = true, bins = ["wasm-bindgen"] }
 wasm-pack = { version = "0.15.0" }


### PR DESCRIPTION
[Migrate off manually calling wasm-bindgen-cli and wasm-opt.](https://github.com/magcius/noclip.website/commit/e70477ff5ebf6de5defe9925f7db921132a56fc4) 

I originally migrated the original toolchain (wasm-bindgen-cli + wasm-opt
from cargo), but wasm-opt hasn't had an update since 0.116.1 (2024-03)
since it was moved to the binaryen project, which is now at 0.130. The
recommended toolchain has become [wasm-pack](https://github.com/wasm-bindgen/wasm-pack).
See https://blog.rust-lang.org/inside-rust/2025/07/21/sunsetting-the-rustwasm-github-org/.

This resolves the issue on Arch BTW, where... *something* happens on GCC
16 while attempting to compile wasm-opt. See https://github.com/WebAssembly/binaryen/pull/8559.

This commit also greatly simplifies the build steps, because wasm-pack
will pick to run wasm-opt depending on the build variant.

## Pull Request Checklist

Please check one of the boxes below:
- [ ] Generative AI was used in the creation of this PR (for any part, including but not limited to coding, reverse engineering, or debugging). I have read [AI Contributions Policy](https://github.com/magcius/noclip.website/blob/main/README.md#ai-contributions-policy). All comments and documentation are human-authored.
- [x] Generative AI was not used in the creation of this PR.

