### PR TITLE
Update maps.ts

### DIFF
--- a/src/KirbyAirRide/maps.ts
+++ b/src/KirbyAirRide/maps.ts
@@ -260,8 +260,8 @@ export const maps = [
     new KirbyMapDesc("GrZeroyon1", "Drag Race 3"),
     new KirbyMapDesc("GrZeroyon4", "Drag Race 4"),
 
-    new KirbyMapDesc("GrColosseum1", "Dustup Derby 1"),
-    new KirbyMapDesc("GrColosseum3", "Dustup Derby 2"),
+    new KirbyMapDesc("GrColosseum1", "Destruction Derby 1"),
+    new KirbyMapDesc("GrColosseum3", "Destruction Derby 2"),
 
     new KirbyMapDesc("GrPasture1", "Kirby Melee 1"),
     new KirbyMapDesc("GrColosseum5", "Kirby Melee 2"),

--- a/src/KirbyAirRide/maps.ts
+++ b/src/KirbyAirRide/maps.ts
@@ -262,11 +262,10 @@ export const maps = [
 
     new KirbyMapDesc("GrColosseum1", "Destruction Derby 1"),
     new KirbyMapDesc("GrColosseum3", "Destruction Derby 2"),
+    new KirbyMapDesc("GrDedede1", "Destruction Derby 3"),
 
     new KirbyMapDesc("GrPasture1", "Kirby Melee 1"),
     new KirbyMapDesc("GrColosseum5", "Kirby Melee 2"),
-
-    new KirbyMapDesc("GrDedede1", "VS. King Dedede"),
 
     "Test",
     new KirbyMapDesc("GrTest6", "Test6Model"),


### PR DESCRIPTION
Changed "Dustup Derby" to "Destruction Derby," which is the actual name used in the original _Kirby Air Ride_.

## Pull Request Checklist

Please check one of the boxes below:
- [ ] Generative AI was used in the creation of this PR (for any part, including but not limited to coding, reverse engineering, or debugging). I have read [AI Contributions Policy](https://github.com/magcius/noclip.website/blob/main/README.md#ai-contributions-policy). All comments and documentation are human-authored.
- [x] Generative AI was not used in the creation of this PR.
