### PR TITLE
extend DK64 to expose Render Hacks like other games

### DIFF
--- a/src/DonkeyKong64/scenes.ts
+++ b/src/DonkeyKong64/scenes.ts
@@ -1,18 +1,19 @@
 
 import * as Viewer from '../viewer.js';
 import * as BYML from '../byml.js';
+import * as UI from '../ui.js';
 
 import { GfxDevice, GfxCullMode, GfxProgram, GfxMegaStateDescriptor, makeTextureDescriptor2D, GfxFormat, GfxSampler, GfxTexture, GfxTexFilterMode, GfxMipFilterMode, GfxBindingLayoutDescriptor, GfxBlendMode, GfxBlendFactor, GfxBuffer, GfxInputLayout, GfxBufferUsage, GfxBufferFrequencyHint, GfxVertexAttributeDescriptor, GfxInputLayoutBufferDescriptor, GfxVertexBufferFrequency, GfxVertexBufferDescriptor, GfxIndexBufferDescriptor } from '../gfx/platform/GfxPlatform.js';
 import { SceneContext } from '../SceneBase.js';
 import { makeBackbufferDescSimple, standardFullClearRenderPassDescriptor } from '../gfx/helpers/RenderGraphHelpers.js';
 import { F3DEX_Program } from '../BanjoKazooie/render.js';
-import { translateBlendMode, RSP_Geometry, translateCullMode } from '../zelview/f3dzex.js';
 import { nArray, align, assert } from '../util.js';
 import { DeviceProgram } from '../Program.js';
 import { mat4, vec3 } from 'gl-matrix';
 import { GfxRenderCache } from '../gfx/render/GfxRenderCache.js';
 import { TextureMapping, FakeTextureHolder } from '../TextureHolder.js';
-import { DrawCall, RSPState, runDL_F3DEX2, RSPOutput } from './f3dex2.js';
+import { DrawCall, RSP_Geometry, RSPState, runDL_F3DEX2, RSPOutput } from './f3dex2.js';
+import { translateBlendMode, translateCullMode } from '../PokemonSnap/f3dex2.js';
 import { GfxRenderInstList, GfxRenderInstManager } from '../gfx/render/GfxRenderInstManager.js';
 import { computeViewMatrixSkybox, computeViewMatrix, CameraController } from '../Camera.js';
 import { fillMatrix4x3, fillMatrix4x2, fillVec4, fillMatrix4x4 } from '../gfx/helpers/UniformBufferHelpers.js';
@@ -89,7 +90,7 @@ class DrawCallInstance {
             }
         }
 
-        this.megaStateFlags = translateBlendMode(this.drawCall.DP_OtherModeL);
+        this.megaStateFlags = translateBlendMode(this.drawCall.SP_GeometryMode, this.drawCall.DP_OtherModeL);
         this.setBackfaceCullingEnabled(true);
         this.createProgram();
     }
@@ -442,6 +443,49 @@ class DK64Renderer implements Viewer.SceneGfx {
 
     public adjustCameraController(c: CameraController) {
         c.setSceneMoveSpeedMult(30/60);
+    }
+
+    public createPanels(): UI.Panel[] {
+        const renderHacksPanel = new UI.Panel();
+        renderHacksPanel.customHeaderBackgroundColor = UI.COOL_BLUE_COLOR;
+        renderHacksPanel.setTitle(UI.RENDER_HACKS_ICON, 'Render Hacks');
+
+        const enableCullingCheckbox = new UI.Checkbox('Enable Culling', true);
+        enableCullingCheckbox.onchanged = () => {
+            for (const meshRenderer of this.meshRenderers)
+                meshRenderer.setBackfaceCullingEnabled(enableCullingCheckbox.checked);
+        };
+        renderHacksPanel.contents.appendChild(enableCullingCheckbox.elem);
+
+        const enableVertexColorsCheckbox = new UI.Checkbox('Enable Vertex Colors', true);
+        enableVertexColorsCheckbox.onchanged = () => {
+            for (const meshRenderer of this.meshRenderers)
+                meshRenderer.setVertexColorsEnabled(enableVertexColorsCheckbox.checked);
+        };
+        renderHacksPanel.contents.appendChild(enableVertexColorsCheckbox.elem);
+
+        const enableTextures = new UI.Checkbox('Enable Textures', true);
+        enableTextures.onchanged = () => {
+            for (const meshRenderer of this.meshRenderers)
+                meshRenderer.setTexturesEnabled(enableTextures.checked);
+        };
+        renderHacksPanel.contents.appendChild(enableTextures.elem);
+
+        const enableMonochromeVertexColors = new UI.Checkbox('Grayscale Vertex Colors', false);
+        enableMonochromeVertexColors.onchanged = () => {
+            for (const meshRenderer of this.meshRenderers)
+                meshRenderer.setMonochromeVertexColorsEnabled(enableMonochromeVertexColors.checked);
+        };
+        renderHacksPanel.contents.appendChild(enableMonochromeVertexColors.elem);
+
+        const enableAlphaVisualizer = new UI.Checkbox('Visualize Vertex Alpha', false);
+        enableAlphaVisualizer.onchanged = () => {
+            for (const meshRenderer of this.meshRenderers)
+                meshRenderer.setAlphaVisualizerEnabled(enableAlphaVisualizer.checked);
+        };
+        renderHacksPanel.contents.appendChild(enableAlphaVisualizer.elem);
+
+        return [renderHacksPanel];
     }
 
     private prepareToRender(device: GfxDevice, viewerInput: Viewer.ViewerRenderInput): void {


### PR DESCRIPTION
This includes Culling (new for DK64), Vertex Colors, Textures, Grayscale Vertex Colors, and Vertex Alpha

Inspired by https://x.com/MarioBrothBlog/status/2079266512603316489 , which could have used this.

## Pull Request Checklist

Please check one of the boxes below:
- [X] Generative AI was used in the creation of this PR (for any part, including but not limited to coding, reverse engineering, or debugging). I have read [AI Contributions Policy](https://github.com/magcius/noclip.website/blob/main/README.md#ai-contributions-policy). All comments and documentation are human-authored.
- [ ] Generative AI was not used in the creation of this PR.
