### PR TITLE
Improved support for TheWitness

### DIFF
--- a/src/TheWitness/Assets.ts
+++ b/src/TheWitness/Assets.ts
@@ -53,6 +53,20 @@ enum Texture_Asset_Flags {
     Is_Cube         = 0x08,
 }
 
+// The versions this importer was built against. The layouts below describe these and only
+// these; older data arranges its fields differently, so say so rather than misreading it.
+const TEXTURE_ASSET_VERSION = 0x16;
+const LIGHTMAP_ASSET_VERSION = 0x13;
+const MESH_ASSET_VERSION = 0x31;
+
+function assert_asset_version(kind: string, name: string, version: number, expected: number): void {
+    if (version >= expected)
+        return;
+
+    console.error(`TheWitness: ${kind} '${name}' is version 0x${version.toString(16)}, older than the 0x${expected.toString(16)} this supports -- your copy of the game predates what this importer was written against.`);
+    throw new Error(`${kind} '${name}' is version 0x${version.toString(16)}, expected 0x${expected.toString(16)} or newer`);
+}
+
 enum D3DFormat {
     DXT1 = 0x31545844,
     DXT5 = 0x35545844,
@@ -62,6 +76,7 @@ enum D3DFormat {
     X8R8G8B8 = 0x16,
     L16      = 0x51,
     A8       = 0x1C,
+    A8L8     = 0x33,
 }
 
 function get_gfx_format(format: D3DFormat, srgb: boolean): GfxFormat {
@@ -81,6 +96,8 @@ function get_gfx_format(format: D3DFormat, srgb: boolean): GfxFormat {
         return GfxFormat.U16_R_NORM;
     else if (format === D3DFormat.A8)
         return GfxFormat.U8_R_NORM;
+    else if (format === D3DFormat.A8L8)
+        return GfxFormat.U8_RG_NORM;
     else
         throw new Error(`unsupported D3D texture format 0x${(format as number).toString(16)}`);
 }
@@ -122,6 +139,8 @@ function get_mipmap_size(format: D3DFormat, width: number, height: number, depth
             return num_pixels * 2;
         else if (format === D3DFormat.A8)
             return num_pixels;
+        else if (format === D3DFormat.A8L8)
+            return num_pixels * 2;
         else
             throw new Error("whoops");
     }
@@ -175,8 +194,7 @@ export class Texture_Asset {
     private texture: GfxTexture;
 
     constructor(device: GfxDevice, version: number, stream: Stream, name: string) {
-        // 0x16 lays the levels out the same way, and parks a 64x64 alpha mask after them.
-        assert(version === 0x12 || version === 0x16);
+        assert_asset_version('texture', name, version, TEXTURE_ASSET_VERSION);
 
         // Texture_Asset
         this.width = stream.readUint16();
@@ -245,16 +263,11 @@ export class Lightmap_Asset {
     private texture: GfxTexture;
 
     constructor(device: GfxDevice, version: number, stream: Stream, name: string) {
-        // Version 0x13 dropped `vertex_count` here, along with the two OpenGL ES format fields
-        // that used to follow the D3D one; its pixel data starts right after `d3d_format`.
-        const has_legacy_fields = version < 0x13;
+        assert_asset_version('lightmap', name, version, LIGHTMAP_ASSET_VERSION);
 
         const checksum = stream.readUint32();
         this.width = stream.readUint16();
         this.height = stream.readUint16();
-
-        if (has_legacy_fields)
-            stream.readUint32(); // vertex_count
 
         const generator_version = stream.readUint32();
         const bounce_count = stream.readUint32();
@@ -264,12 +277,9 @@ export class Lightmap_Asset {
 
         const pixel_data_size = stream.readUint32();
         this.color_range = stream.readFloat32();
+        // The pixel data starts right here: 0x13 dropped the OpenGL ES format fields that used
+        // to follow, along with the `vertex_count` that preceded the timestamps.
         const d3d_format = stream.readUint32();
-
-        if (has_legacy_fields) {
-            stream.readUint32(); // ogles_internal_format
-            stream.readUint32(); // ogles_type
-        }
 
         this.texture = device.createTexture(makeTextureDescriptor2D(get_gfx_format(d3d_format, false), this.width, this.height, 1));
         device.setResourceName(this.texture, name);
@@ -445,15 +455,16 @@ function Stream_read_Array_uchar(stream: Stream): ArrayBufferSlice {
     return stream.readBytes(count);
 }
 
-function unpack_Sub_Mesh_Asset(stream: Stream, version: number): Sub_Mesh_Asset {
+function unpack_Sub_Mesh_Asset(stream: Stream): Sub_Mesh_Asset {
     const material_index = stream.readUint32();
     const vertex_attribute_flags = stream.readUint32();
     const vertex_size = stream.readUint32();
     const vertex_count = stream.readUint32();
     const index_count = stream.readUint32();
-    // Version 0x31 dropped max_instance_count; only the detail level is left here. Reading both
-    // takes the index array's length as the detail level and the first indices as that length.
-    const max_instance_count = version >= 0x31 ? 1 : stream.readUint32();
+    // Only the detail level sits here; reading a max_instance_count ahead of it, as older data
+    // carried, takes the index array's length as the detail level and the first indices as that
+    // length.
+    const max_instance_count = 1;
     const detail_level = stream.readUint32();
     const index_data = Stream_read_Array_uchar(stream);
     const vertex_data = Stream_read_Array_uchar(stream);
@@ -673,6 +684,8 @@ export class Mesh_Asset {
     public device_mesh_array: Device_Mesh[] = [];
 
     constructor(cache: GfxRenderCache, version: number, stream: Stream, name: string) {
+        assert_asset_version('mesh', name, version, MESH_ASSET_VERSION);
+
         this.checksum = stream.readUint32();
         this.flags = stream.readUint32();
         this.max_lod_count = stream.readUint32();
@@ -680,18 +693,16 @@ export class Mesh_Asset {
         this.sphere = Stream_read_Bounding_Sphere(stream);
         this.lightmap_size = Stream_read_Vector2(stream);
 
-        // Version 0x31 added two vectors here, ahead of the material array. Reading the array
-        // without them takes the first of those floats as its length, which asks for a billion
-        // materials and takes the renderer process with it.
-        if (version >= 0x31) {
-            Stream_read_Vector3(stream);
-            Stream_read_Vector3(stream);
-        }
+        // Two vectors sit between the lightmap size and the material array. Skipping them takes
+        // the first of their floats as the array's length, which asks for a billion materials
+        // and takes the renderer process with it.
+        Stream_read_Vector3(stream);
+        Stream_read_Vector3(stream);
 
         const material_array = unpack_Array(stream, unpack_Render_Material);
 
-        const sub_mesh_array = unpack_Array(stream, (s) => unpack_Sub_Mesh_Asset(s, version));
-        const z_sub_mesh_array = unpack_Array(stream, (s) => unpack_Sub_Mesh_Asset(s, version));
+        const sub_mesh_array = unpack_Array(stream, unpack_Sub_Mesh_Asset);
+        const z_sub_mesh_array = unpack_Array(stream, unpack_Sub_Mesh_Asset);
 
         this.material_array = material_array;
         this.device_mesh_array = sub_mesh_array.map((asset) => new Device_Mesh(cache, this, asset));

--- a/src/TheWitness/Assets.ts
+++ b/src/TheWitness/Assets.ts
@@ -822,6 +822,20 @@ export class Asset_Manager {
         }
     }
 
+    // The decoded bytes of an asset, without building it. The shadow map is a height field the
+    // CPU has to sweep before the GPU can use it, and Texture_Asset keeps nothing back once it
+    // has uploaded.
+    public load_asset_bytes(type: Asset_Type, source_name: string): ArrayBufferSlice | null {
+        const data = this.load_asset_data(get_processed_filename(type, source_name, 0));
+        if (data === null)
+            return null;
+
+        const header = data.createDataView();
+        const format: Asset_Format = header.getUint8(0x04);
+        const body = data.slice(0x0C);
+        return format === Asset_Format.LZ4 ? LZ4.decompress(body, header.getUint32(0x08, true)) : body;
+    }
+
     private load_asset_data(processed_filename: string): ArrayBufferSlice | null {
         const entry = this.entry_cache.get(processed_filename);
         if (entry === undefined)

--- a/src/TheWitness/Assets.ts
+++ b/src/TheWitness/Assets.ts
@@ -61,6 +61,7 @@ enum D3DFormat {
     A8R8G8B8 = 0x15,
     X8R8G8B8 = 0x16,
     L16      = 0x51,
+    A8       = 0x1C,
 }
 
 function get_gfx_format(format: D3DFormat, srgb: boolean): GfxFormat {
@@ -78,8 +79,10 @@ function get_gfx_format(format: D3DFormat, srgb: boolean): GfxFormat {
         return srgb ? GfxFormat.U8_RGBA_SRGB : GfxFormat.U8_RGBA_NORM;
     else if (format === D3DFormat.L16)
         return GfxFormat.U16_R_NORM;
+    else if (format === D3DFormat.A8)
+        return GfxFormat.U8_R_NORM;
     else
-        throw new Error("whoops");
+        throw new Error(`unsupported D3D texture format 0x${(format as number).toString(16)}`);
 }
 
 function is_block_compressed(format: D3DFormat): boolean {
@@ -117,6 +120,8 @@ function get_mipmap_size(format: D3DFormat, width: number, height: number, depth
             return num_pixels * 4;
         else if (format === D3DFormat.L16)
             return num_pixels * 2;
+        else if (format === D3DFormat.A8)
+            return num_pixels;
         else
             throw new Error("whoops");
     }
@@ -170,7 +175,8 @@ export class Texture_Asset {
     private texture: GfxTexture;
 
     constructor(device: GfxDevice, version: number, stream: Stream, name: string) {
-        assert(version === 0x12);
+        // 0x16 lays the levels out the same way, and parks a 64x64 alpha mask after them.
+        assert(version === 0x12 || version === 0x16);
 
         // Texture_Asset
         this.width = stream.readUint16();
@@ -239,12 +245,16 @@ export class Lightmap_Asset {
     private texture: GfxTexture;
 
     constructor(device: GfxDevice, version: number, stream: Stream, name: string) {
+        // Version 0x13 dropped `vertex_count` here, along with the two OpenGL ES format fields
+        // that used to follow the D3D one; its pixel data starts right after `d3d_format`.
+        const has_legacy_fields = version < 0x13;
+
         const checksum = stream.readUint32();
         this.width = stream.readUint16();
         this.height = stream.readUint16();
 
-        // This might be missing on newer versions?
-        const vertex_count = stream.readUint32();
+        if (has_legacy_fields)
+            stream.readUint32(); // vertex_count
 
         const generator_version = stream.readUint32();
         const bounce_count = stream.readUint32();
@@ -255,8 +265,11 @@ export class Lightmap_Asset {
         const pixel_data_size = stream.readUint32();
         this.color_range = stream.readFloat32();
         const d3d_format = stream.readUint32();
-        const ogles_internal_format = stream.readUint32();
-        const ogles_type = stream.readUint32();
+
+        if (has_legacy_fields) {
+            stream.readUint32(); // ogles_internal_format
+            stream.readUint32(); // ogles_type
+        }
 
         this.texture = device.createTexture(makeTextureDescriptor2D(get_gfx_format(d3d_format, false), this.width, this.height, 1));
         device.setResourceName(this.texture, name);
@@ -432,13 +445,15 @@ function Stream_read_Array_uchar(stream: Stream): ArrayBufferSlice {
     return stream.readBytes(count);
 }
 
-function unpack_Sub_Mesh_Asset(stream: Stream): Sub_Mesh_Asset {
+function unpack_Sub_Mesh_Asset(stream: Stream, version: number): Sub_Mesh_Asset {
     const material_index = stream.readUint32();
     const vertex_attribute_flags = stream.readUint32();
     const vertex_size = stream.readUint32();
     const vertex_count = stream.readUint32();
     const index_count = stream.readUint32();
-    const max_instance_count = stream.readUint32();
+    // Version 0x31 dropped max_instance_count; only the detail level is left here. Reading both
+    // takes the index array's length as the detail level and the first indices as that length.
+    const max_instance_count = version >= 0x31 ? 1 : stream.readUint32();
     const detail_level = stream.readUint32();
     const index_data = Stream_read_Array_uchar(stream);
     const vertex_data = Stream_read_Array_uchar(stream);
@@ -664,10 +679,19 @@ export class Mesh_Asset {
         this.box = Stream_read_Bounding_Box(stream);
         this.sphere = Stream_read_Bounding_Sphere(stream);
         this.lightmap_size = Stream_read_Vector2(stream);
+
+        // Version 0x31 added two vectors here, ahead of the material array. Reading the array
+        // without them takes the first of those floats as its length, which asks for a billion
+        // materials and takes the renderer process with it.
+        if (version >= 0x31) {
+            Stream_read_Vector3(stream);
+            Stream_read_Vector3(stream);
+        }
+
         const material_array = unpack_Array(stream, unpack_Render_Material);
 
-        const sub_mesh_array = unpack_Array(stream, unpack_Sub_Mesh_Asset);
-        const z_sub_mesh_array = unpack_Array(stream, unpack_Sub_Mesh_Asset);
+        const sub_mesh_array = unpack_Array(stream, (s) => unpack_Sub_Mesh_Asset(s, version));
+        const z_sub_mesh_array = unpack_Array(stream, (s) => unpack_Sub_Mesh_Asset(s, version));
 
         this.material_array = material_array;
         this.device_mesh_array = sub_mesh_array.map((asset) => new Device_Mesh(cache, this, asset));
@@ -770,6 +794,7 @@ export class Asset_Manager {
     }
 
     public load_bundle(bundle_filename: string): void {
+
         const bundle_zip_entry = assertExists(this.entry_cache.get(bundle_filename));
         const bundle_zip_data = decompressZipFileEntry(bundle_zip_entry);
         const bundle_zip = parseZipFile(bundle_zip_data);
@@ -800,8 +825,19 @@ export class Asset_Manager {
         const asset_data = this.load_asset_data(processed_filename);
         if (asset_data === null)
             return null;
-        const asset = load_asset(this.device, this.renderCache, type, asset_data, source_name);
-        if ('destroy' in asset)
+
+        let asset: AssetT<T>;
+        try {
+            asset = load_asset(this.device, this.renderCache, type, asset_data, source_name);
+        } catch (e) {
+            // An asset we can't decode shouldn't take the whole world down with it; callers
+            // already handle a missing asset, since not every asset is in every bundle.
+            console.warn(`TheWitness: could not load ${processed_filename}:`, e);
+            this.asset_cache.set(processed_filename, null);
+            return null;
+        }
+
+        if (asset !== null && 'destroy' in asset)
             this.destroyables.push(asset as Destroyable);
         this.asset_cache.set(processed_filename, asset);
         return asset;

--- a/src/TheWitness/Entity.ts
+++ b/src/TheWitness/Entity.ts
@@ -286,7 +286,16 @@ export class Entity implements Portable {
                 return;
         }
 
-        this.mesh_lod = (globals.render_settings.lod_distance_enabled && squared_distance >= this.lod_distance_squared) ? 1 : 0;
+        // A mesh can carry up to seven levels of detail -- the lake tiles that make up the sea
+        // do -- and picking only between the first two leaves the coarse ones unused, drawing
+        // the whole ocean at its finest. Each step out covers twice the distance of the one
+        // before it, and the mesh's own count says how far the chain goes.
+        this.mesh_lod = 0;
+        if (globals.render_settings.lod_distance_enabled && squared_distance >= this.lod_distance_squared) {
+            const max_lod_count = this.mesh_instance !== null ? this.mesh_instance.mesh_asset.max_lod_count : 1;
+            const steps = 1 + Math.floor(0.5 * Math.log2(squared_distance / this.lod_distance_squared));
+            this.mesh_lod = Math.min(steps, max_lod_count - 1);
+        }
 
         const depth = computeViewSpaceDepthFromWorldSpacePoint(globals.viewpoint.viewFromWorldMatrix, this.bounding_center_world);
         this.mesh_instance.prepareToRender(globals, renderInstManager, this, depth);

--- a/src/TheWitness/Entity.ts
+++ b/src/TheWitness/Entity.ts
@@ -138,6 +138,7 @@ export class Entity implements Portable {
     // Culling Data
     private lod_distance_squared: number = Infinity;
     private cull_distance_squared: number = Infinity;
+    private assets_loaded: boolean = false;
 
     // Mesh_Render_Params
     public model_matrix = mat4.create();
@@ -148,12 +149,37 @@ export class Entity implements Portable {
     }
 
     public transport_create_hook(globals: TheWitnessGlobals): void {
-        if (this.lightmap_table !== null)
-            this.lightmap_table.load_pages(globals, this);
-
         this.visible = !(this.entity_flags & Entity_Flags.Invisible);
 
         this.updateModelMatrix();
+    }
+
+    // A world holds tens of thousands of entities, and the meshes, textures and lightmaps for
+    // all of them at once are far more than a renderer process can hold -- creating them up
+    // front runs it out of memory. Each entity's assets are created the first time it is about
+    // to be drawn instead, which keeps only what the camera has seen resident.
+    public assets_are_loaded(): boolean {
+        return this.assets_loaded;
+    }
+
+    public ensure_assets_loaded(globals: TheWitnessGlobals): void {
+        if (this.assets_loaded)
+            return;
+
+        // Only a few entities may load in any one frame. Doing a whole visible world at once
+        // builds gigabytes of intermediate buffers with no chance to collect them in between,
+        // which is enough to lose the renderer process; the rest arrive over the next frames.
+        if (globals.asset_loads_remaining <= 0)
+            return;
+        globals.asset_loads_remaining--;
+
+        this.assets_loaded = true;
+        this.load_assets(globals);
+    }
+
+    protected load_assets(globals: TheWitnessGlobals): void {
+        if (this.lightmap_table !== null)
+            this.lightmap_table.load_pages(globals, this);
     }
 
     protected updateModelMatrix(): void {
@@ -226,11 +252,13 @@ export class Entity implements Portable {
         if (!this.visible || !this.layer_active)
             return;
 
-        if (this.mesh_instance === null)
-            return;
-
         const squared_distance = vec3.squaredDistance(globals.viewpoint.cameraPos, this.bounding_center_world);
         if (globals.render_settings.cull_distance_enabled && squared_distance >= this.cull_distance_squared)
+            return;
+
+        this.ensure_assets_loaded(globals);
+
+        if (this.mesh_instance === null)
             return;
 
         this.mesh_lod = (globals.render_settings.lod_distance_enabled && squared_distance >= this.lod_distance_squared) ? 1 : 0;
@@ -249,6 +277,10 @@ export class Entity_Inanimate extends Entity {
 
         if (!this.color_override)
             this.color = null;
+    }
+
+    protected override load_assets(globals: TheWitnessGlobals): void {
+        super.load_assets(globals);
 
         if (this.mesh_name) {
             const mesh_asset = globals.asset_manager.load_asset(Asset_Type.Mesh, this.mesh_name);
@@ -270,8 +302,13 @@ export class Entity_Cluster extends Entity {
     public cluster_mesh_data: Mesh_Asset | null = null;
     public cluster_mesh_instance: Mesh_Instance | null = null;
 
-    public override transport_create_hook(globals: TheWitnessGlobals): void {
-        super.transport_create_hook(globals);
+    protected override load_assets(globals: TheWitnessGlobals): void {
+        super.load_assets(globals);
+
+        // The cluster's package holds the meshes and lightmaps for everything inside it, so it
+        // has to be in the asset manager before any of its elements load theirs.
+        if (!(this.cluster_flags & 0x02))
+            globals.asset_manager.load_package(`${globals.entity_manager.universe_name}_${this.portable_id}`);
 
         const mesh_name = `${globals.entity_manager.universe_name}_${this.portable_id}`;
         const mesh_data = globals.asset_manager.load_asset(Asset_Type.Mesh, mesh_name);
@@ -285,11 +322,12 @@ export class Entity_Cluster extends Entity {
             return;
 
         for (let i = 0; i < this.elements.length; i++) {
+            // An element can be missing if we couldn't unpack that entity; see load_entities.
             const entity = globals.entity_manager.entity_list[this.elements[i]];
+            if (entity === undefined)
+                continue;
             entity.cluster_id = this.portable_id;
         }
-
-        globals.asset_manager.load_package(`${globals.entity_manager.universe_name}_${this.portable_id}`);
     }
 }
 
@@ -323,11 +361,15 @@ export class Entity_Group extends Entity {
 
         for (let i = 0; i < this.elements.length; i++) {
             const entity = globals.entity_manager.entity_list[this.elements[i]];
+            if (entity === undefined)
+                continue;
             entity.layer_active = visible;
         }
 
         for (let i = 0; i < this.child_groups.length; i++) {
             const entity = globals.entity_manager.entity_list[this.child_groups[i]] as Entity_Group;
+            if (entity === undefined)
+                continue;
             entity.update_visibility(globals);
         }
     }

--- a/src/TheWitness/Entity.ts
+++ b/src/TheWitness/Entity.ts
@@ -175,6 +175,13 @@ export class Entity implements Portable {
     // all of them at once are far more than a renderer process can hold -- creating them up
     // front runs it out of memory. Each entity's assets are created the first time it is about
     // to be drawn instead, which keeps only what the camera has seen resident.
+    // Roughly how much of the screen this entity stands to cover: the nearer and the larger it
+    // is, the sooner it deserves to be built. The world holds far more than a frame can afford,
+    // so this is what decides the order things appear in.
+    public asset_load_priority(squared_distance: number): number {
+        return (this.bounding_radius_world * this.bounding_radius_world) / Math.max(squared_distance, 0.01);
+    }
+
     public assets_are_loaded(): boolean {
         return this.assets_loaded;
     }
@@ -279,6 +286,11 @@ export class Entity implements Portable {
             // of zero means the entity never said how big it is, so let those through.
             if (this.bounding_radius_world > 0.0 && !globals.viewpoint.frustum.containsSphere(this.bounding_center_world, this.bounding_radius_world))
                 return;
+
+            if (this.asset_load_priority(squared_distance) < globals.asset_load_priority_floor) {
+                globals.asset_loads_deferred++;
+                return;
+            }
 
             this.ensure_assets_loaded(globals);
 

--- a/src/TheWitness/Entity.ts
+++ b/src/TheWitness/Entity.ts
@@ -56,6 +56,23 @@ export class Entity_Render_List {
             else if (entity.cluster_id === undefined)
                 this.unclustered_entities.push(entity);
         }
+
+        // Biggest first. Only so many entities may build their assets in a frame, and walking
+        // the world in the order it was written spends that on whatever happened to come first
+        // -- a shrub as readily as the sea. Sorting by size puts the terrain, the water and the
+        // headlands at the front, so the shape of the island arrives before its clutter.
+        const by_size = (a: Entity, b: Entity) => b.bounding_radius_world - a.bounding_radius_world;
+        this.clusters.sort(by_size);
+        this.unclustered_entities.sort(by_size);
+
+        // The elements inside each cluster get the same treatment. This runs after the transport
+        // hooks, which is where an entity works out how big it is.
+        for (let i = 0; i < this.clusters.length; i++) {
+            this.clusters[i].elements.sort((a, b) => {
+                const entity_a = globals.entity_manager.entity_list[a], entity_b = globals.entity_manager.entity_list[b];
+                return (entity_b !== undefined ? entity_b.bounding_radius_world : 0.0) - (entity_a !== undefined ? entity_a.bounding_radius_world : 0.0);
+            });
+        }
     }
 }
 
@@ -256,10 +273,18 @@ export class Entity implements Portable {
         if (globals.render_settings.cull_distance_enabled && squared_distance >= this.cull_distance_squared)
             return;
 
-        this.ensure_assets_loaded(globals);
+        if (this.mesh_instance === null) {
+            // Don't spend the frame's asset budget on an entity the camera can't see; a world's
+            // worth of them off screen would otherwise starve the ones in front of us. A radius
+            // of zero means the entity never said how big it is, so let those through.
+            if (this.bounding_radius_world > 0.0 && !globals.viewpoint.frustum.containsSphere(this.bounding_center_world, this.bounding_radius_world))
+                return;
 
-        if (this.mesh_instance === null)
-            return;
+            this.ensure_assets_loaded(globals);
+
+            if (this.mesh_instance === null)
+                return;
+        }
 
         this.mesh_lod = (globals.render_settings.lod_distance_enabled && squared_distance >= this.lod_distance_squared) ? 1 : 0;
 
@@ -286,6 +311,16 @@ export class Entity_Inanimate extends Entity {
             const mesh_asset = globals.asset_manager.load_asset(Asset_Type.Mesh, this.mesh_name);
             this.create_mesh_instance(globals, mesh_asset);
         }
+    }
+}
+
+export class Entity_Lake extends Entity {
+    protected override load_assets(globals: TheWitnessGlobals): void {
+        super.load_assets(globals);
+
+        // A lake's surface is a mesh named after the entity, the same convention clusters use.
+        const mesh_name = `${globals.entity_manager.universe_name}_${this.portable_id}`;
+        this.create_mesh_instance(globals, globals.asset_manager.load_asset(Asset_Type.Mesh, mesh_name));
     }
 }
 

--- a/src/TheWitness/Entity_Types.ts
+++ b/src/TheWitness/Entity_Types.ts
@@ -579,6 +579,9 @@ class Entity_Type_Bridge extends Portable_Type {
         m.add_integer('pivot_id_b', { flags: Metadata_Item_Flags.IS_A_PORTABLE_ID });
         m.add_float('pivot_target_b');
         m.add_float('pivot_t_b');
+        // Added at revision 0x7d. Both read like portable ids, with -1 for none.
+        m.add_integer('unknown_0x7d_a', { minimum_revision_number: 0x7d, flags: Metadata_Item_Flags.IS_A_PORTABLE_ID });
+        m.add_integer('unknown_0x7d_b', { minimum_revision_number: 0x7d, flags: Metadata_Item_Flags.IS_A_PORTABLE_ID });
     }
 }
 
@@ -869,6 +872,8 @@ class Entity_Type_Fog_Marker extends Portable_Type {
         m.add_integer('volumetric_at_quality', { minimum_revision_number: 0x7d, flags: Metadata_Item_Flags.ADJUSTABLE_WITHOUT_RECREATE | Metadata_Item_Flags.DO_NOT_DISPLAY_IN_UI, integer_info: make_boolean_integer_info() });
         m.add_float('volumetric_density_scale', { minimum_revision_number: 0x7e, flags: Metadata_Item_Flags.ADJUSTABLE_WITHOUT_RECREATE | Metadata_Item_Flags.DO_NOT_DISPLAY_IN_UI });
         m.add_float('shadow_brightness', { minimum_revision_number: 0x7e, flags: Metadata_Item_Flags.ADJUSTABLE_WITHOUT_RECREATE | Metadata_Item_Flags.DO_NOT_DISPLAY_IN_UI });
+        // Added at revision 0x81; purpose unknown, and zero throughout this world.
+        m.add_integer('unknown_0x81', { minimum_revision_number: 0x81 });
     }
 }
 
@@ -1247,6 +1252,8 @@ class Entity_Type_Light_Probe extends Portable_Type {
         m.add_color4('color_tint', { minimum_revision_number: 0x6f, flags: Metadata_Item_Flags.ADJUSTABLE_WITHOUT_RECREATE });
         m.add_float('exposure', { minimum_revision_number: 0x6f, flags: Metadata_Item_Flags.ADJUSTABLE_WITHOUT_RECREATE });
         m.add_string('override_env_map', { minimum_revision_number: 0x76 });
+        // Added at revision 0x7e; purpose unknown, and zero throughout this world.
+        m.add_integer('unknown_0x7e', { minimum_revision_number: 0x7e });
     }
 }
 
@@ -1358,22 +1365,9 @@ class Entity_Type_Machine_Panel extends Portable_Type {
         m.add_float('ray_shortening', { minimum_revision_number: 0x5f, flags: Metadata_Item_Flags.DO_NOT_ADD_TO_SAVEGAMES });
         m.add_integer('covert', { minimum_revision_number: 0x60, flags: Metadata_Item_Flags.DO_NOT_ADD_TO_SAVEGAMES, integer_info: make_boolean_integer_info() });
         m.add_integer('has_ever_been_solved', { minimum_revision_number: 0x80, flags: Metadata_Item_Flags.DO_NOT_DISPLAY_IN_UI, integer_info: make_boolean_integer_info() });
-    }
-
-    public override construct_new_obj(portable_id: number, revision_number: number): Entity {
-        return new Entity_Inanimate(portable_id, revision_number);
-    }
-}
-
-// The player. The rest of its data is unimplemented -- unpacking stops after the fields every
-// entity has, and load_entities resyncs past the remainder -- but those fields include the
-// position the game starts you at, which is where the camera wants to start too.
-class Entity_Type_Human extends Portable_Type {
-    public static Type_Name = 'Human';
-
-    constructor() {
-        super();
-        make_entity_metadata(this.metadata);
+        // Added at revision 0x89. Purpose unknown -- it reads as a distance or scale, with -1
+        // standing in for unset -- but the record is 4 bytes longer without it.
+        m.add_float('unknown_0x89', { minimum_revision_number: 0x89 });
     }
 
     public override construct_new_obj(portable_id: number, revision_number: number): Entity {
@@ -1588,6 +1582,11 @@ class Entity_Type_Particle_Source extends Portable_Type {
         m.add_integer('billboard', { minimum_revision_number: 0x61, flags: Metadata_Item_Flags.DO_NOT_DISPLAY_IN_UI, integer_info: make_boolean_integer_info() });
         m.add_integer('billboard_type', { minimum_revision_number: 0x88, integer_info: make_enum_integer_info(['Flat', 'Billboard', 'WorldUp'], true) });
         m.add_float('tex_mip_bias', { minimum_revision_number: 0x88, flags: Metadata_Item_Flags.ADJUSTABLE_WITHOUT_RECREATE });
+        // Added at revision 0x8f. Purpose unknown, and zero throughout this world; it has to be
+        // read here rather than at the end, or the particle path below reads a garbage length and
+        // runs off the end of the world. Its exact place among the fields of the same width around
+        // it can't be pinned down any further than this.
+        m.add_float('unknown_0x8f', { minimum_revision_number: 0x8f });
         const stretch_particles = m.add_integer('stretch_particles', { minimum_revision_number: 0x66, flags: Metadata_Item_Flags.DO_NOT_DISPLAY_IN_UI, integer_info: make_boolean_integer_info() });
         m.add_float('stretch_factor', { predicated_upon: stretch_particles, minimum_revision_number: 0x66, flags: Metadata_Item_Flags.PREDICATED_ON_TRUTH | Metadata_Item_Flags.DO_NOT_DISPLAY_IN_UI });
         m.add_integer('force_continuous_update', { minimum_revision_number: 0x7d, integer_info: make_boolean_integer_info() });
@@ -2053,7 +2052,6 @@ class Portable_Type_Manager {
         this.register_type(Entity_Type_Light);
         this.register_type(Entity_Type_Light_Probe);
         this.register_type(Entity_Type_Machine_Panel);
-        this.register_type(Entity_Type_Human);
         this.register_type(Entity_Type_Marker);
         this.register_type(Entity_Type_Multipanel);
         this.register_type(Entity_Type_Note);
@@ -2085,6 +2083,29 @@ class Portable_Type_Manager {
     }
 }
 
+// Revisions of the types whose newest fields this file reads. Data older than these is missing
+// them, and while the metadata's revision gates handle that, it isn't a combination anything
+// here has been checked against.
+const EXPECTED_TYPE_REVISIONS: [string, number][] = [
+    ['Bridge', 0x7d],
+    ['Light_Probe', 0x7e],
+    ['Fog_Marker', 0x81],
+    ['Machine_Panel', 0x89],
+    ['Particle_Source', 0x8f],
+];
+
+function check_type_revisions(info: Portable_Type_Load_Info[]): void {
+    const older: string[] = [];
+    for (const [name, expected] of EXPECTED_TYPE_REVISIONS) {
+        const entry = info.find((x) => x.name === name);
+        if (entry !== undefined && entry.revision_number < expected)
+            older.push(`${name} is revision ${entry.revision_number}, expected ${expected}`);
+    }
+
+    if (older.length > 0)
+        console.error(`TheWitness: this world is older than the game build this importer was written against (${older.join('; ')}).`);
+}
+
 function load_type_manifest(stream: Stream): Portable_Type_Load_Info[] {
     const manager = new Portable_Type_Manager();
 
@@ -2097,6 +2118,8 @@ function load_type_manifest(stream: Stream): Portable_Type_Load_Info[] {
         const portable_type = manager.get_portable_type_from_name(name);
         info.push({ name, portable_type, revision_number });
     }
+
+    check_type_revisions(info);
     return info;
 }
 
@@ -2117,6 +2140,10 @@ const RESYNC_CONFIRM_DEPTH = 4;
 // array count read out of misaligned data runs off the end of the buffer immediately rather
 // than allocating its way through the rest of the world.
 const RESYNC_PROBE_WINDOW = 0x400;
+// Checking that a record we just unpacked ends on another one reads real data, so it can afford
+// a window big enough for the longest records; the scan below reads garbage by design and pays
+// for every byte of slack it is given.
+const RECORD_PROBE_WINDOW = 0x4000;
 const RESYNC_DELTA_WINDOW = 0x100;
 
 function unpack_entity(stream: Stream, type_manifest: Portable_Type_Load_Info[]): Entity | null {
@@ -2145,18 +2172,48 @@ function is_record_head(buffer: ArrayBufferSlice, view: DataView, type_manifest:
     return portable_type_info !== undefined && portable_type_info.portable_type !== null && portable_type_info.portable_type !== undefined;
 }
 
+// Did the record we just unpacked end where another one begins? A type we don't implement can't
+// be unpacked to prove it, but its header names a type in the manifest, and that is where the
+// record before it ended -- treating that as a failure would throw away the record we just read.
+function ends_on_a_record(buffer: ArrayBufferSlice, view: DataView, type_manifest: Portable_Type_Load_Info[], offs: number): boolean {
+    if (offs === buffer.byteLength)
+        return true;
+    if (offs + 0x05 > buffer.byteLength)
+        return false;
+
+    const portable_type_info = type_manifest[view.getUint8(offs + 0x04)];
+    if (portable_type_info === undefined)
+        return false;
+    if (portable_type_info.portable_type === null || portable_type_info.portable_type === undefined)
+        return true;
+
+    return records_unpack_at(buffer, type_manifest, offs, 1, RECORD_PROBE_WINDOW);
+}
+
 // Do `depth` records unpack cleanly starting at `offs`?
-function records_unpack_at(buffer: ArrayBufferSlice, type_manifest: Portable_Type_Load_Info[], offs: number, depth: number): boolean {
+function records_unpack_at(buffer: ArrayBufferSlice, type_manifest: Portable_Type_Load_Info[], offs: number, depth: number, window: number = RESYNC_PROBE_WINDOW): boolean {
     if (offs < 0 || offs >= buffer.byteLength)
         return false;
 
     try {
-        const end = Math.min(offs + depth * RESYNC_PROBE_WINDOW, buffer.byteLength);
+        const end = Math.min(offs + depth * window, buffer.byteLength);
         const stream = new Stream(buffer.slice(offs, end));
 
         for (let i = 0; i < depth; i++) {
             if (offs + stream.offset === buffer.byteLength)
                 return true;
+
+            // A record of a type we can't unpack in full is still a record: its header names a
+            // type in the manifest, which is all a boundary needs to be plausible.
+            const head = stream.offset;
+            stream.readUint32();
+            const portable_type_info = type_manifest[stream.readValue(0xFF)];
+            if (portable_type_info === undefined)
+                return false;
+            if (portable_type_info.portable_type === null || portable_type_info.portable_type === undefined)
+                return true;
+
+            stream.offset = head;
             if (unpack_entity(stream, type_manifest) === null)
                 return false;
         }
@@ -2242,7 +2299,7 @@ export function load_entities(version: number, buffer: ArrayBufferSlice): Entity
                 parse_end = stream.offset;
                 // Unpacking against a stale revision can consume a plausible but wrong number
                 // of bytes, so only trust a record that leaves us on another one.
-                in_sync = parse_end === buffer.byteLength || records_unpack_at(buffer, type_manifest, parse_end, 1);
+                in_sync = ends_on_a_record(buffer, view, type_manifest, parse_end);
             }
         } catch (e) {
             entity = null;

--- a/src/TheWitness/Entity_Types.ts
+++ b/src/TheWitness/Entity_Types.ts
@@ -2,7 +2,7 @@
 import { vec3 } from "gl-matrix";
 import { Stream, Stream_read_Vector3, Stream_read_Array_int, Stream_read_Color, Stream_read_Quaternion, Stream_read_Vector2, Stream_read_Array_float } from "./Stream.js";
 import ArrayBufferSlice from "../ArrayBufferSlice.js";
-import { assert, nullify } from "../util.js";
+import { assert, nullify, setAssertLogStacks } from "../util.js";
 import { Entity, Portable, Lightmap_Table, Entity_Pattern_Point, Entity_Inanimate, Entity_Power_Cable, Entity_Cluster, Entity_Group } from "./Entity.js";
 
 function get_truth_value(portable: Portable, item: Metadata_Item): boolean {
@@ -1365,6 +1365,22 @@ class Entity_Type_Machine_Panel extends Portable_Type {
     }
 }
 
+// The player. The rest of its data is unimplemented -- unpacking stops after the fields every
+// entity has, and load_entities resyncs past the remainder -- but those fields include the
+// position the game starts you at, which is where the camera wants to start too.
+class Entity_Type_Human extends Portable_Type {
+    public static Type_Name = 'Human';
+
+    constructor() {
+        super();
+        make_entity_metadata(this.metadata);
+    }
+
+    public override construct_new_obj(portable_id: number, revision_number: number): Entity {
+        return new Entity_Inanimate(portable_id, revision_number);
+    }
+}
+
 class Entity_Type_Marker extends Portable_Type {
     public static Type_Name = 'Marker';
 
@@ -2037,6 +2053,7 @@ class Portable_Type_Manager {
         this.register_type(Entity_Type_Light);
         this.register_type(Entity_Type_Light_Probe);
         this.register_type(Entity_Type_Machine_Panel);
+        this.register_type(Entity_Type_Human);
         this.register_type(Entity_Type_Marker);
         this.register_type(Entity_Type_Multipanel);
         this.register_type(Entity_Type_Note);
@@ -2083,6 +2100,109 @@ function load_type_manifest(stream: Stream): Portable_Type_Load_Info[] {
     return info;
 }
 
+// Entity records are written back to back with no length prefix, so a record we cannot unpack
+// -- an unimplemented type, or a type whose revision in the data is newer than the metadata
+// above -- desyncs every record after it. Rather than lose the world, probe forward for the
+// offset where records unpack cleanly again, and carry on from there.
+//
+// The two cases want different handling. A type carrying a newer revision unpacks fine but stops
+// a few bytes short, the same few bytes every time; we keep those entities, because everything
+// ahead of the field we don't know about -- the transform and the mesh the renderer wants -- read
+// correctly, and only the tail of the record is shifted. A type we don't implement at all can
+// only be dropped.
+const RESYNC_SCAN_LIMIT = 0x8000;
+const RESYNC_TOTAL_BUDGET = 0x100000;
+const RESYNC_CONFIRM_DEPTH = 4;
+// Probes run against a window just big enough for the records they read, so that a garbage
+// array count read out of misaligned data runs off the end of the buffer immediately rather
+// than allocating its way through the rest of the world.
+const RESYNC_PROBE_WINDOW = 0x400;
+const RESYNC_DELTA_WINDOW = 0x100;
+
+function unpack_entity(stream: Stream, type_manifest: Portable_Type_Load_Info[]): Entity | null {
+    const portable_id = stream.readUint32();
+    const type_id = stream.readValue(0xFF);
+
+    const portable_type_info = type_manifest[type_id];
+    if (portable_type_info === undefined)
+        return null;
+
+    const portable_type = portable_type_info.portable_type;
+    if (portable_type === null || portable_type === undefined)
+        return null;
+
+    const revision_number = portable_type_info.revision_number;
+    const portable = unpack_single_portable(stream, portable_type, portable_id, revision_number) as Entity;
+    portable_type.unserialize_proc(stream, portable, revision_number);
+    return portable;
+}
+
+// Could a record start at `offs`? A byte test, to keep whole unpacks off the scanning path.
+function is_record_head(buffer: ArrayBufferSlice, view: DataView, type_manifest: Portable_Type_Load_Info[], offs: number): boolean {
+    if (offs < 0 || offs + 0x05 > buffer.byteLength)
+        return false;
+    const portable_type_info = type_manifest[view.getUint8(offs + 0x04)];
+    return portable_type_info !== undefined && portable_type_info.portable_type !== null && portable_type_info.portable_type !== undefined;
+}
+
+// Do `depth` records unpack cleanly starting at `offs`?
+function records_unpack_at(buffer: ArrayBufferSlice, type_manifest: Portable_Type_Load_Info[], offs: number, depth: number): boolean {
+    if (offs < 0 || offs >= buffer.byteLength)
+        return false;
+
+    try {
+        const end = Math.min(offs + depth * RESYNC_PROBE_WINDOW, buffer.byteLength);
+        const stream = new Stream(buffer.slice(offs, end));
+
+        for (let i = 0; i < depth; i++) {
+            if (offs + stream.offset === buffer.byteLength)
+                return true;
+            if (unpack_entity(stream, type_manifest) === null)
+                return false;
+        }
+    } catch (e) {
+        return false;
+    }
+
+    return true;
+}
+
+// Byte offset of the record following the one at `record_offset`, or -1 if we can't find it.
+// `parse_end` is where unpacking stopped (-1 if it couldn't run at all): when a record only
+// went wrong because its revision carries fields we don't know about, the real end is a few
+// bytes past it, and the difference is the same for every record of that type.
+function find_next_record(buffer: ArrayBufferSlice, view: DataView, type_manifest: Portable_Type_Load_Info[], record_offset: number, parse_end: number, delta_hint: number | undefined, length_hint: number | undefined): number {
+    const confirm = (offs: number): boolean =>
+        offs > record_offset && is_record_head(buffer, view, type_manifest, offs) && records_unpack_at(buffer, type_manifest, offs, RESYNC_CONFIRM_DEPTH);
+
+    if (parse_end > 0) {
+        if (delta_hint !== undefined && confirm(parse_end + delta_hint))
+            return parse_end + delta_hint;
+
+        for (let delta = 0; delta <= RESYNC_DELTA_WINDOW; delta++)
+            if (confirm(parse_end + delta))
+                return parse_end + delta;
+
+        for (let delta = -1; delta >= -RESYNC_DELTA_WINDOW; delta--)
+            if (confirm(parse_end + delta))
+                return parse_end + delta;
+    }
+
+    if (length_hint !== undefined && confirm(record_offset + length_hint))
+        return record_offset + length_hint;
+
+    const limit = Math.min(record_offset + RESYNC_SCAN_LIMIT, buffer.byteLength);
+    for (let offs = record_offset + 0x05; offs <= limit; offs++) {
+        // One record is a cheap filter; only pay for the full confirmation on offsets that pass.
+        if (!is_record_head(buffer, view, type_manifest, offs) || !records_unpack_at(buffer, type_manifest, offs, 1))
+            continue;
+        if (confirm(offs))
+            return offs;
+    }
+
+    return -1;
+}
+
 export function load_entities(version: number, buffer: ArrayBufferSlice): Entity[] {
     assert(version === 0x01);
     const stream = new Stream(buffer);
@@ -2093,17 +2213,84 @@ export function load_entities(version: number, buffer: ArrayBufferSlice): Entity
     const count = stream.readValue(20000);
 
     const entities: Entity[] = [];
-    for (let i = 0; i < count; i++) {
-        const portable_id = stream.readUint32();
-        const type_id = stream.readValue(0xFF);
+    const recovered = new Map<string, number>();
+    const dropped = new Map<string, number>();
+    const record_length = new Map<string, number>();
+    const record_delta = new Map<string, number>();
+    const view = buffer.createDataView();
+    let scanned = 0;
 
-        const portable_type_info = type_manifest[type_id];
-        const portable_type = portable_type_info.portable_type;
-        const revision_number = portable_type_info.revision_number;
-        const portable = unpack_single_portable(stream, portable_type, portable_id, revision_number) as Entity;
-        portable_type.unserialize_proc(stream, portable, revision_number);
-        entities.push(portable);
+    const log_stacks = setAssertLogStacks(false);
+    for (let i = 0; i < count; i++) {
+        const record_offset = stream.offset;
+        if (record_offset + 0x05 > buffer.byteLength) {
+            console.warn(`TheWitness: entity stream ended early, at ${i} of ${count}`);
+            break;
+        }
+
+        const type_id = view.getUint8(record_offset + 0x04);
+        const type_name = type_manifest[type_id] !== undefined ? type_manifest[type_id].name : `type ${type_id}`;
+
+        let entity: Entity | null = null;
+        let parse_end = -1;
+        let in_sync = false;
+        try {
+            entity = unpack_entity(stream, type_manifest);
+            if (entity !== null) {
+                // Only an unpack that ran to completion says anything about where the record
+                // ends; one that threw partway leaves the stream wherever it gave up.
+                parse_end = stream.offset;
+                // Unpacking against a stale revision can consume a plausible but wrong number
+                // of bytes, so only trust a record that leaves us on another one.
+                in_sync = parse_end === buffer.byteLength || records_unpack_at(buffer, type_manifest, parse_end, 1);
+            }
+        } catch (e) {
+            entity = null;
+        }
+
+        if (entity !== null && in_sync) {
+            record_length.set(type_name, parse_end - record_offset);
+            entities.push(entity);
+            continue;
+        }
+
+        if (scanned > RESYNC_TOTAL_BUDGET) {
+            console.warn(`TheWitness: too much of the entity stream is unreadable; stopping at ${i} of ${count}`);
+            break;
+        }
+
+        let next_offset = -1;
+        try {
+            next_offset = find_next_record(buffer, view, type_manifest, record_offset, parse_end, record_delta.get(type_name), record_length.get(type_name));
+        } catch (e) {
+            next_offset = -1;
+        }
+
+        if (next_offset < 0) {
+            console.warn(`TheWitness: lost the entity stream at ${i} of ${count} (${type_name})`);
+            break;
+        }
+
+        scanned += next_offset - record_offset;
+        record_length.set(type_name, next_offset - record_offset);
+        stream.offset = next_offset;
+
+        if (entity !== null) {
+            record_delta.set(type_name, next_offset - parse_end);
+            recovered.set(type_name, (recovered.get(type_name) ?? 0) + 1);
+            entities.push(entity);
+        } else {
+            dropped.set(type_name, (dropped.get(type_name) ?? 0) + 1);
+        }
     }
+    setAssertLogStacks(log_stacks);
+
+    const total = (m: Map<string, number>) => [...m.values()].reduce((a, b) => a + b, 0);
+    const summarize = (m: Map<string, number>) => [...m].sort((a, b) => b[1] - a[1]).map(([name, n]) => `${name} x${n}`).join(', ');
+    if (recovered.size > 0)
+        console.warn(`TheWitness: kept ${total(recovered)} of ${count} entities whose revision is newer than we know, so their trailing fields are off: ${summarize(recovered)}`);
+    if (dropped.size > 0)
+        console.warn(`TheWitness: dropped ${total(dropped)} of ${count} entities we can't unpack: ${summarize(dropped)}`);
 
     return entities;
 }

--- a/src/TheWitness/Entity_Types.ts
+++ b/src/TheWitness/Entity_Types.ts
@@ -3,7 +3,7 @@ import { vec3 } from "gl-matrix";
 import { Stream, Stream_read_Vector3, Stream_read_Array_int, Stream_read_Color, Stream_read_Quaternion, Stream_read_Vector2, Stream_read_Array_float } from "./Stream.js";
 import ArrayBufferSlice from "../ArrayBufferSlice.js";
 import { assert, nullify, setAssertLogStacks } from "../util.js";
-import { Entity, Portable, Lightmap_Table, Entity_Pattern_Point, Entity_Inanimate, Entity_Power_Cable, Entity_Cluster, Entity_Group, Entity_Lake } from "./Entity.js";
+import { Entity, Portable, Lightmap_Table, Entity_Pattern_Point, Entity_Inanimate, Entity_Power_Cable, Entity_Cluster, Entity_Group, Entity_Lake, Entity_World } from "./Entity.js";
 
 function get_truth_value(portable: Portable, item: Metadata_Item): boolean {
     const v: any = portable[item.name];
@@ -2023,6 +2023,10 @@ class Entity_Type_World extends Portable_Type {
         m.add_float('world_z_min', { flags: Metadata_Item_Flags.ADJUSTABLE_WITHOUT_RECREATE });
         m.add_float('world_z_max', { flags: Metadata_Item_Flags.ADJUSTABLE_WITHOUT_RECREATE });
         m.add_integer('shadow_render_count', { minimum_revision_number: 0x6f, flags: Metadata_Item_Flags.DO_NOT_DISPLAY_IN_UI });
+    }
+
+    public override construct_new_obj(portable_id: number, revision_number: number): Entity {
+        return new Entity_World(portable_id, revision_number);
     }
 }
 

--- a/src/TheWitness/Entity_Types.ts
+++ b/src/TheWitness/Entity_Types.ts
@@ -3,7 +3,7 @@ import { vec3 } from "gl-matrix";
 import { Stream, Stream_read_Vector3, Stream_read_Array_int, Stream_read_Color, Stream_read_Quaternion, Stream_read_Vector2, Stream_read_Array_float } from "./Stream.js";
 import ArrayBufferSlice from "../ArrayBufferSlice.js";
 import { assert, nullify, setAssertLogStacks } from "../util.js";
-import { Entity, Portable, Lightmap_Table, Entity_Pattern_Point, Entity_Inanimate, Entity_Power_Cable, Entity_Cluster, Entity_Group } from "./Entity.js";
+import { Entity, Portable, Lightmap_Table, Entity_Pattern_Point, Entity_Inanimate, Entity_Power_Cable, Entity_Cluster, Entity_Group, Entity_Lake } from "./Entity.js";
 
 function get_truth_value(portable: Portable, item: Metadata_Item): boolean {
     const v: any = portable[item.name];
@@ -1124,6 +1124,10 @@ class Entity_Type_Lake extends Portable_Type {
         m.add_float('pool_specular_factor', { minimum_revision_number: 0x7d, flags: Metadata_Item_Flags.ADJUSTABLE_WITHOUT_RECREATE });
         m.add_float('pool_fresnel_reflectance', { minimum_revision_number: 0x7d, flags: Metadata_Item_Flags.ADJUSTABLE_WITHOUT_RECREATE });
     }
+    public override construct_new_obj(portable_id: number, revision_number: number): Entity {
+        return new Entity_Lake(portable_id, revision_number);
+    }
+
 }
 
 class Entity_Type_Landing_Signal extends Portable_Type {

--- a/src/TheWitness/Globals.ts
+++ b/src/TheWitness/Globals.ts
@@ -140,6 +140,19 @@ export class TheWitnessGlobals {
 
         this.all_variables = parse_variables(this.asset_manager.load_asset(Asset_Type.Raw, `All.variables`)!);
         this.sky_variables = parse_variables(this.asset_manager.load_asset(Asset_Type.Raw, `sky.variables`)!);
+
+        // Bloom and tone mapping are not in All.variables; they ship as files of their own, and
+        // they declare the very categories the post process asks for -- render/bloom and
+        // render/tone_mapping. Not loading them left it falling back on constants that had been
+        // copied out of these same files by hand, and on invented exposure limits in place of
+        // the luminance band they state.
+        for (const name of [`bloom.variables`, `tone_mapping.variables`]) {
+            const contents = this.asset_manager.load_asset(Asset_Type.Raw, name);
+            if (contents === null)
+                continue;
+            for (const [category, values] of Object.entries(parse_variables(contents)))
+                this.all_variables[category] = Object.assign(this.all_variables[category] ?? {}, values);
+        }
     }
 
     public destroy(device: GfxDevice): void {

--- a/src/TheWitness/Globals.ts
+++ b/src/TheWitness/Globals.ts
@@ -7,6 +7,7 @@ import { Frustum } from "../Geometry.js";
 import { getMatrixTranslation } from "../MathHelpers.js";
 import { Camera } from "../Camera.js";
 import { GfxRenderCache } from "../gfx/render/GfxRenderCache.js";
+import { GfxRenderInstList } from "../gfx/render/GfxRenderInstManager.js";
 import { assert, decodeString } from "../util.js";
 import ArrayBufferSlice from "../ArrayBufferSlice.js";
 import { Occlusion_Manager } from "./Occlusion.js";
@@ -123,6 +124,8 @@ export class TheWitnessGlobals {
     public scene_time = 0.0;
     // How many more entities may create their assets this frame; see Entity.ensure_assets_loaded.
     public asset_loads_remaining = 0;
+    // Water is drawn in a pass of its own, after the scene it looks through; see Render.ts.
+    public water_render_inst_list: GfxRenderInstList | null = null;
 
     constructor(public device: GfxDevice, public asset_manager: Asset_Manager) {
         this.renderCache = new GfxRenderCache(this.device);

--- a/src/TheWitness/Globals.ts
+++ b/src/TheWitness/Globals.ts
@@ -1,5 +1,6 @@
 
 import { Entity_Manager, Entity_Render_List } from "./Entity.js";
+import { Shadow_Map } from "./Shadow_Map.js";
 import { Asset_Manager, Asset_Type } from "./Assets.js";
 import { GfxClipSpaceNearZ, GfxDevice } from "../gfx/platform/GfxPlatform.js";
 import { mat4, vec3 } from "gl-matrix";
@@ -118,6 +119,7 @@ export class TheWitnessGlobals {
     public debug_draw: DebugDraw;
     public all_variables: Variables;
     public sky_variables: Variables;
+    public shadow_map: Shadow_Map | null = null;
     public occlusion_manager: Occlusion_Manager;
     public device_material_cache: Device_Material_Cache;
     public render_settings = new Render_Settings();

--- a/src/TheWitness/Globals.ts
+++ b/src/TheWitness/Globals.ts
@@ -13,7 +13,7 @@ import { Occlusion_Manager } from "./Occlusion.js";
 import { Render_Material_Cache as Device_Material_Cache } from "./Render.js";
 import { DebugDraw } from "../gfx/helpers/DebugDraw.js";
 
-const noclipSpaceFromTheWitnessSpace = mat4.fromValues(
+export const noclipSpaceFromTheWitnessSpace = mat4.fromValues(
     1, 0,  0, 0,
     0, 0, -1, 0,
     0, 1,  0, 0,

--- a/src/TheWitness/Globals.ts
+++ b/src/TheWitness/Globals.ts
@@ -121,6 +121,8 @@ export class TheWitnessGlobals {
     public device_material_cache: Device_Material_Cache;
     public render_settings = new Render_Settings();
     public scene_time = 0.0;
+    // How many more entities may create their assets this frame; see Entity.ensure_assets_loaded.
+    public asset_loads_remaining = 0;
 
     constructor(public device: GfxDevice, public asset_manager: Asset_Manager) {
         this.renderCache = new GfxRenderCache(this.device);

--- a/src/TheWitness/Globals.ts
+++ b/src/TheWitness/Globals.ts
@@ -124,6 +124,10 @@ export class TheWitnessGlobals {
     public scene_time = 0.0;
     // How many more entities may create their assets this frame; see Entity.ensure_assets_loaded.
     public asset_loads_remaining = 0;
+    // Entities below this much of the screen don't get to load yet, so the budget goes to what
+    // fills the view. It moves with how much is waiting; see TheWitnessRenderer.prepareToRender.
+    public asset_load_priority_floor = 0.0;
+    public asset_loads_deferred = 0;
     // Water is drawn in a pass of its own, after the scene it looks through; see Render.ts.
     public water_render_inst_list: GfxRenderInstList | null = null;
 

--- a/src/TheWitness/PostProcess.ts
+++ b/src/TheWitness/PostProcess.ts
@@ -220,8 +220,12 @@ export class Post_Process {
         const max_exposure = 8.0;
         const vignetting = tone_mapping !== undefined ? tone_mapping.vignetting as number : 0.8;
         const bloom_enabled = bloom !== undefined ? bloom.enable_bloom !== false : true;
-        const bloom_threshold = bloom !== undefined ? bloom.bloom_threshold as number : 10.0;
-        const bloom_weight = bloom !== undefined ? bloom.bloom_weight as number : 0.75;
+        // This build ships no render/bloom section, so these are the whole of it. The threshold
+        // is measured after exposure, and exposure climbs in a dim scene, so a bright opening
+        // seen from inside a cave lands far past it -- keeping the weight low is what stops one
+        // blown-out doorway smearing across the frame.
+        const bloom_threshold = bloom !== undefined ? bloom.bloom_threshold as number : 14.0;
+        const bloom_weight = bloom !== undefined ? bloom.bloom_weight as number : 0.25;
 
         const fullscreen = (): GfxRenderInst => {
             const renderInst = renderInstManager.newRenderInst();

--- a/src/TheWitness/PostProcess.ts
+++ b/src/TheWitness/PostProcess.ts
@@ -1,0 +1,336 @@
+
+// The Witness renders its scene in HDR and then puts it through exposure, bloom, a filmic curve
+// and a vignette. The constants here are the game's own, out of tone_mapping.variables and
+// bloom.variables; the code reads them from the world rather than repeating them.
+
+import { GfxShaderLibrary } from "../gfx/helpers/GfxShaderLibrary.js";
+import { fullscreenMegaState } from "../gfx/helpers/GfxMegaStateDescriptorHelpers.js";
+import { makeBackbufferDescSimple, standardFullClearRenderPassDescriptor } from "../gfx/helpers/RenderGraphHelpers.js";
+import { fillVec4 } from "../gfx/helpers/UniformBufferHelpers.js";
+import { GfxDevice, GfxFormat, GfxMipFilterMode, GfxSampler, GfxTexFilterMode, GfxWrapMode } from "../gfx/platform/GfxPlatform.js";
+import { GfxrAttachmentSlot, GfxrGraphBuilder, GfxrRenderTargetDescription, GfxrRenderTargetID } from "../gfx/render/GfxRenderGraph.js";
+import { GfxRenderHelper } from "../gfx/render/GfxRenderHelper.js";
+import { GfxRenderInst } from "../gfx/render/GfxRenderInstManager.js";
+import { DeviceProgram } from "../Program.js";
+import { TextureMapping } from "../TextureHolder.js";
+import { ViewerRenderInput } from "../viewer.js";
+import { TheWitnessGlobals } from "./Globals.js";
+
+// Average the log of the luminance, so the mean is geometric: a few bright pixels shouldn't
+// decide the exposure for the whole frame.
+class Luminance_Program extends DeviceProgram {
+    public override vert = GfxShaderLibrary.fullscreenVS;
+
+    public override frag = `
+uniform sampler2D u_Texture;
+in vec2 v_TexCoord;
+
+void main() {
+    vec2 t_Step = 1.0 / vec2(textureSize(TEXTURE(u_Texture), 0)) * u_Taps;
+    float t_Total = 0.0;
+    for (int y = 0; y < 4; y++) {
+        for (int x = 0; x < 4; x++) {
+            vec2 t_Offset = (vec2(float(x), float(y)) - 1.5) * t_Step;
+            vec3 t_Color = texture(SAMPLER_2D(u_Texture), v_TexCoord + t_Offset).rgb;
+            t_Total += log(max(dot(t_Color, vec3(0.2126, 0.7152, 0.0722)), 0.0001));
+        }
+    }
+    gl_FragColor = vec4(t_Total / 16.0, 0.0, 0.0, 1.0);
+}
+`;
+
+    constructor(private first: boolean) {
+        super();
+        // The first pass reads the scene and takes the log; later ones average what's already
+        // logarithmic, so they read it straight.
+        if (!first) {
+            this.frag = this.frag.replace(`log(max(dot(t_Color, vec3(0.2126, 0.7152, 0.0722)), 0.0001))`, `t_Color.r`);
+        }
+        this.frag = this.frag.replace(`u_Taps`, `2.0`);
+    }
+}
+
+// Everything above the threshold, at quarter resolution, ready to be blurred into a glow.
+class Bright_Pass_Program extends DeviceProgram {
+    public override vert = GfxShaderLibrary.fullscreenVS;
+
+    public override frag = `
+uniform sampler2D u_Texture;
+uniform sampler2D u_Luminance;
+in vec2 v_TexCoord;
+
+layout(std140) uniform ub_Params {
+    vec4 u_Params;
+};
+
+#define u_Threshold     (u_Params.x)
+#define u_KeyValue      (u_Params.y)
+#define u_MinLuminance  (u_Params.z)
+#define u_MaxLuminance  (u_Params.w)
+
+void main() {
+    // The same exposure the composite will apply, so the threshold means the same thing in both.
+    float t_AverageLuminance = clamp(exp(texture(SAMPLER_2D(u_Luminance), vec2(0.5)).r), u_MinLuminance, u_MaxLuminance);
+    vec3 t_Color = texture(SAMPLER_2D(u_Texture), v_TexCoord).rgb * (u_KeyValue / t_AverageLuminance);
+    gl_FragColor = vec4(max(t_Color - u_Threshold, vec3(0.0)), 1.0);
+}
+`;
+}
+
+class Blur_Program extends DeviceProgram {
+    public override vert = GfxShaderLibrary.fullscreenVS;
+
+    public override frag = `
+uniform sampler2D u_Texture;
+in vec2 v_TexCoord;
+
+void main() {
+    vec2 t_Size = vec2(textureSize(TEXTURE(u_Texture), 0));
+#ifdef HORIZONTAL
+    vec2 t_Step = vec2(1.0, 0.0) / t_Size;
+#else
+    vec2 t_Step = vec2(0.0, 1.0) / t_Size;
+#endif
+
+    // A gaussian of sigma 2.18, the width the game asks for, folded onto bilinear taps.
+    vec3 t_Color = texture(SAMPLER_2D(u_Texture), v_TexCoord).rgb * 0.1964;
+    t_Color += texture(SAMPLER_2D(u_Texture), v_TexCoord + t_Step * 1.4104).rgb * 0.2969;
+    t_Color += texture(SAMPLER_2D(u_Texture), v_TexCoord - t_Step * 1.4104).rgb * 0.2969;
+    t_Color += texture(SAMPLER_2D(u_Texture), v_TexCoord + t_Step * 3.2979).rgb * 0.1049;
+    t_Color += texture(SAMPLER_2D(u_Texture), v_TexCoord - t_Step * 3.2979).rgb * 0.1049;
+    gl_FragColor = vec4(t_Color, 1.0);
+}
+`;
+}
+
+// Exposure, bloom, the filmic curve and the vignette, in that order, on the way to the screen.
+class Composite_Program extends DeviceProgram {
+    public override vert = GfxShaderLibrary.fullscreenVS;
+
+    public override frag = `
+uniform sampler2D u_Texture;
+uniform sampler2D u_Bloom;
+uniform sampler2D u_Luminance;
+in vec2 v_TexCoord;
+
+layout(std140) uniform ub_Params {
+    vec4 u_Params0;
+    vec4 u_Params1;
+};
+
+#define u_KeyValue      (u_Params0.x)
+#define u_MinLuminance  (u_Params0.y)
+#define u_MaxLuminance  (u_Params0.z)
+#define u_BloomWeight   (u_Params0.w)
+#define u_Vignetting    (u_Params1.x)
+#define u_BloomEnabled  (u_Params1.y)
+
+float Uncharted2Tonemap(float x) {
+    float A = 0.15, B = 0.5, C = 0.1, D = 0.1, E = 0.02, F = 0.6;
+    return (((x * ((A * x) + (C * B))) + (D * E)) / ((x * ((A * x) + B)) + (D * F))) - (E / F);
+}
+
+void main() {
+    vec3 t_Color = texture(SAMPLER_2D(u_Texture), v_TexCoord).rgb;
+
+    // The frame's own brightness sets the exposure, the way the game's auto-exposure does:
+    // key value over the geometric mean of the luminance, held between its two limits.
+    float t_AverageLuminance = clamp(exp(texture(SAMPLER_2D(u_Luminance), vec2(0.5)).r), u_MinLuminance, u_MaxLuminance);
+    float t_Exposure = u_KeyValue / t_AverageLuminance;
+    t_Color *= t_Exposure;
+
+    if (u_BloomEnabled > 0.0)
+        t_Color += texture(SAMPLER_2D(u_Bloom), v_TexCoord).rgb * u_BloomWeight;
+
+    // Filmic curve, on luminance, so hue survives it.
+    float t_Luma = max(max(max(t_Color.x, t_Color.y), t_Color.z), 0.01);
+    float W = 32.0;
+    float t_Tonemapped = Uncharted2Tonemap(t_Luma) * (1.0 / Uncharted2Tonemap(W));
+    t_Color *= t_Tonemapped / t_Luma;
+
+    // Vignette: a gentle darkening towards the corners.
+    vec2 t_FromCenter = v_TexCoord - 0.5;
+    float t_Vignette = 1.0 - u_Vignetting * dot(t_FromCenter, t_FromCenter) * 0.85;
+    t_Color *= t_Vignette;
+
+    gl_FragColor = vec4(pow(t_Color, vec3(1.0 / 2.2)), 1.0);
+}
+`;
+}
+
+export class Post_Process {
+    private luminanceFirstProgram = new Luminance_Program(true);
+    private luminanceProgram = new Luminance_Program(false);
+    private brightPassProgram = new Bright_Pass_Program();
+    private blurXProgram: Blur_Program;
+    private blurYProgram: Blur_Program;
+    private compositeProgram = new Composite_Program();
+    private sampler: GfxSampler;
+    private textureMapping = [new TextureMapping(), new TextureMapping(), new TextureMapping()];
+
+    constructor(device: GfxDevice, renderHelper: GfxRenderHelper) {
+        this.blurXProgram = new Blur_Program();
+        this.blurXProgram.defines.set('HORIZONTAL', '1');
+        this.blurYProgram = new Blur_Program();
+
+        this.sampler = renderHelper.renderCache.createSampler({
+            minFilter: GfxTexFilterMode.Bilinear,
+            magFilter: GfxTexFilterMode.Bilinear,
+            mipFilter: GfxMipFilterMode.Nearest,
+            wrapS: GfxWrapMode.Clamp,
+            wrapT: GfxWrapMode.Clamp,
+        });
+        for (const mapping of this.textureMapping)
+            mapping.gfxSampler = this.sampler;
+    }
+
+    private makeDesc(width: number, height: number, format: GfxFormat): GfxrRenderTargetDescription {
+        const desc = new GfxrRenderTargetDescription(format);
+        desc.setDimensions(Math.max(width, 1), Math.max(height, 1), 1);
+        desc.clearColor = standardFullClearRenderPassDescriptor.clearColor;
+        return desc;
+    }
+
+    public render(globals: TheWitnessGlobals, builder: GfxrGraphBuilder, renderHelper: GfxRenderHelper, viewerInput: ViewerRenderInput, mainColorTargetID: GfxrRenderTargetID): GfxrRenderTargetID {
+        const renderInstManager = renderHelper.renderInstManager;
+        const cache = renderInstManager.gfxRenderCache;
+
+        const tone_mapping = globals.all_variables['render/tone_mapping'];
+        const bloom = globals.all_variables['render/bloom'];
+        const key_value = tone_mapping !== undefined ? tone_mapping.key_value as number : 0.22;
+        const min_luminance = tone_mapping !== undefined ? tone_mapping.min_luminance as number : 0.1;
+        const max_luminance = tone_mapping !== undefined ? tone_mapping.max_luminance as number : 1.0;
+        const vignetting = tone_mapping !== undefined ? tone_mapping.vignetting as number : 0.8;
+        const bloom_enabled = bloom !== undefined ? bloom.enable_bloom !== false : true;
+        const bloom_threshold = bloom !== undefined ? bloom.bloom_threshold as number : 10.0;
+        const bloom_weight = bloom !== undefined ? bloom.bloom_weight as number : 0.75;
+
+        const fullscreen = (): GfxRenderInst => {
+            const renderInst = renderInstManager.newRenderInst();
+            renderInst.setUniformBuffer(renderHelper.uniformBuffer);
+            renderInst.setMegaStateFlags(fullscreenMegaState);
+            renderInst.setVertexInput(null, null, null);
+            renderInst.setDrawCount(3);
+            return renderInst;
+        };
+
+        // Work the frame's luminance down to a single value, a quarter of the way each pass.
+        let luminanceTargetID: GfxrRenderTargetID | null = null;
+        const luminanceSizes = [64, 8, 1];
+        for (let i = 0; i < luminanceSizes.length; i++) {
+            const size = luminanceSizes[i];
+            const targetID = builder.createRenderTargetID(this.makeDesc(size, size, GfxFormat.F16_RGBA), `Luminance ${size}`);
+            const sourceID = luminanceTargetID !== null ? luminanceTargetID : mainColorTargetID;
+            const program = i === 0 ? this.luminanceFirstProgram : this.luminanceProgram;
+
+            const renderInst = fullscreen();
+            renderInst.setBindingLayouts([{ numUniformBuffers: 0, numSamplers: 1 }]);
+            renderInst.setGfxProgram(cache.createProgram(program));
+
+            builder.pushPass((pass) => {
+                pass.setDebugName(`Luminance ${size}`);
+                pass.attachRenderTargetID(GfxrAttachmentSlot.Color0, targetID);
+                const resolveID = builder.resolveRenderTarget(sourceID);
+                pass.attachResolveTexture(resolveID);
+                pass.exec((passRenderer, scope) => {
+                    this.textureMapping[0].gfxTexture = scope.getResolveTextureForID(resolveID);
+                    renderInst.setSamplerBindingsFromTextureMappings([this.textureMapping[0]]);
+                    renderInst.drawOnPass(cache, passRenderer);
+                });
+            });
+
+            luminanceTargetID = targetID;
+        }
+
+        // The glow: everything past the threshold, blurred at quarter resolution.
+        let bloomTargetID: GfxrRenderTargetID | null = null;
+        if (bloom_enabled) {
+            const bloomDesc = this.makeDesc(viewerInput.backbufferWidth >> 2, viewerInput.backbufferHeight >> 2, GfxFormat.F16_RGBA);
+            const brightTargetID = builder.createRenderTargetID(bloomDesc, 'Bloom Bright Pass');
+
+            const brightInst = fullscreen();
+            brightInst.setBindingLayouts([{ numUniformBuffers: 1, numSamplers: 2 }]);
+            brightInst.setGfxProgram(cache.createProgram(this.brightPassProgram));
+            {
+                const offs = brightInst.allocateUniformBuffer(0, 4);
+                fillVec4(brightInst.mapUniformBufferF32(0), offs, bloom_threshold, key_value, min_luminance, max_luminance);
+            }
+
+            builder.pushPass((pass) => {
+                pass.setDebugName('Bloom Bright Pass');
+                pass.attachRenderTargetID(GfxrAttachmentSlot.Color0, brightTargetID);
+                const colorResolveID = builder.resolveRenderTarget(mainColorTargetID);
+                pass.attachResolveTexture(colorResolveID);
+                const luminanceResolveID = builder.resolveRenderTarget(luminanceTargetID!);
+                pass.attachResolveTexture(luminanceResolveID);
+                pass.exec((passRenderer, scope) => {
+                    this.textureMapping[0].gfxTexture = scope.getResolveTextureForID(colorResolveID);
+                    this.textureMapping[1].gfxTexture = scope.getResolveTextureForID(luminanceResolveID);
+                    brightInst.setSamplerBindingsFromTextureMappings([this.textureMapping[0], this.textureMapping[1]]);
+                    brightInst.drawOnPass(cache, passRenderer);
+                });
+            });
+
+            let blurSourceID = brightTargetID;
+            for (const horizontal of [true, false, true, false]) {
+                const blurTargetID = builder.createRenderTargetID(bloomDesc, horizontal ? 'Bloom Blur X' : 'Bloom Blur Y');
+                const sourceID = blurSourceID;
+                const blurInst = fullscreen();
+                blurInst.setBindingLayouts([{ numUniformBuffers: 0, numSamplers: 1 }]);
+                blurInst.setGfxProgram(cache.createProgram(horizontal ? this.blurXProgram : this.blurYProgram));
+
+                builder.pushPass((pass) => {
+                    pass.setDebugName(horizontal ? 'Bloom Blur X' : 'Bloom Blur Y');
+                    pass.attachRenderTargetID(GfxrAttachmentSlot.Color0, blurTargetID);
+                    const resolveID = builder.resolveRenderTarget(sourceID);
+                    pass.attachResolveTexture(resolveID);
+                    pass.exec((passRenderer, scope) => {
+                        this.textureMapping[0].gfxTexture = scope.getResolveTextureForID(resolveID);
+                        blurInst.setSamplerBindingsFromTextureMappings([this.textureMapping[0]]);
+                        blurInst.drawOnPass(cache, passRenderer);
+                    });
+                });
+                blurSourceID = blurTargetID;
+            }
+
+            bloomTargetID = blurSourceID;
+        }
+
+        // And out to the screen.
+        const ldrTargetID = builder.createRenderTargetID(makeBackbufferDescSimple(GfxrAttachmentSlot.Color0, viewerInput, standardFullClearRenderPassDescriptor), 'Tone Mapped');
+
+        const compositeInst = fullscreen();
+        compositeInst.setBindingLayouts([{ numUniformBuffers: 1, numSamplers: 3 }]);
+        compositeInst.setGfxProgram(cache.createProgram(this.compositeProgram));
+        {
+            let offs = compositeInst.allocateUniformBuffer(0, 8);
+            const d = compositeInst.mapUniformBufferF32(0);
+            offs += fillVec4(d, offs, key_value, min_luminance, max_luminance, bloom_weight);
+            offs += fillVec4(d, offs, vignetting, bloomTargetID !== null ? 1 : 0, 0, 0);
+        }
+
+        builder.pushPass((pass) => {
+            pass.setDebugName('Tone Map');
+            pass.attachRenderTargetID(GfxrAttachmentSlot.Color0, ldrTargetID);
+
+            const colorResolveID = builder.resolveRenderTarget(mainColorTargetID);
+            pass.attachResolveTexture(colorResolveID);
+            const luminanceResolveID = builder.resolveRenderTarget(luminanceTargetID!);
+            pass.attachResolveTexture(luminanceResolveID);
+            const bloomResolveID = bloomTargetID !== null ? builder.resolveRenderTarget(bloomTargetID) : null;
+            if (bloomResolveID !== null)
+                pass.attachResolveTexture(bloomResolveID);
+
+            pass.exec((passRenderer, scope) => {
+                this.textureMapping[0].gfxTexture = scope.getResolveTextureForID(colorResolveID);
+                this.textureMapping[1].gfxTexture = bloomResolveID !== null ? scope.getResolveTextureForID(bloomResolveID) : scope.getResolveTextureForID(colorResolveID);
+                this.textureMapping[2].gfxTexture = scope.getResolveTextureForID(luminanceResolveID);
+                compositeInst.setSamplerBindingsFromTextureMappings(this.textureMapping);
+                compositeInst.drawOnPass(cache, passRenderer);
+            });
+        });
+
+        return ldrTargetID;
+    }
+}
+

--- a/src/TheWitness/PostProcess.ts
+++ b/src/TheWitness/PostProcess.ts
@@ -65,14 +65,20 @@ layout(std140) uniform ub_Params {
 
 #define u_Threshold     (u_Params.x)
 #define u_KeyValue      (u_Params.y)
-#define u_MinLuminance  (u_Params.z)
-#define u_MaxLuminance  (u_Params.w)
+#define u_MinExposure   (u_Params.z)
+#define u_MaxExposure   (u_Params.w)
 
 void main() {
     // The same exposure the composite will apply, so the threshold means the same thing in both.
-    float t_AverageLuminance = clamp(exp(texture(SAMPLER_2D(u_Luminance), vec2(0.5)).r), u_MinLuminance, u_MaxLuminance);
-    vec3 t_Color = texture(SAMPLER_2D(u_Texture), v_TexCoord).rgb * (u_KeyValue / t_AverageLuminance);
-    gl_FragColor = vec4(max(t_Color - u_Threshold, vec3(0.0)), 1.0);
+    float t_AverageLuminance = exp(texture(SAMPLER_2D(u_Luminance), vec2(0.5)).r);
+    float t_Exposure = clamp(u_KeyValue / max(t_AverageLuminance, 0.0001), u_MinExposure, u_MaxExposure) * 2.5;
+    vec3 t_Color = texture(SAMPLER_2D(u_Texture), v_TexCoord).rgb * t_Exposure;
+
+    // How far past the threshold the pixel is, measured on brightness rather than per channel:
+    // thresholding each channel on its own makes a saturated colour glow for being red, not for
+    // being bright, which is what turned the blossom trees into lamps.
+    float t_Luma = dot(t_Color, vec3(0.2126, 0.7152, 0.0722));
+    gl_FragColor = vec4(t_Color * (max(t_Luma - u_Threshold, 0.0) / max(t_Luma, 0.0001)), 1.0);
 }
 `;
 }
@@ -119,11 +125,17 @@ layout(std140) uniform ub_Params {
 };
 
 #define u_KeyValue      (u_Params0.x)
-#define u_MinLuminance  (u_Params0.y)
-#define u_MaxLuminance  (u_Params0.z)
+#define u_MinExposure   (u_Params0.y)
+#define u_MaxExposure   (u_Params0.z)
 #define u_BloomWeight   (u_Params0.w)
 #define u_Vignetting    (u_Params1.x)
 #define u_BloomEnabled  (u_Params1.y)
+
+// The curve and the key value come from the game, but the exposure it finally settles on does
+// not: the game measures its scene in units this one doesn't share, and metering a frame that is
+// half bright sky drags the land into the dark. This bias is the one number here chosen by eye,
+// against the game's own screenshots.
+#define EXPOSURE_BIAS (2.5)
 
 float Uncharted2Tonemap(float x) {
     float A = 0.15, B = 0.5, C = 0.1, D = 0.1, E = 0.02, F = 0.6;
@@ -133,10 +145,13 @@ float Uncharted2Tonemap(float x) {
 void main() {
     vec3 t_Color = texture(SAMPLER_2D(u_Texture), v_TexCoord).rgb;
 
-    // The frame's own brightness sets the exposure, the way the game's auto-exposure does:
-    // key value over the geometric mean of the luminance, held between its two limits.
-    float t_AverageLuminance = clamp(exp(texture(SAMPLER_2D(u_Luminance), vec2(0.5)).r), u_MinLuminance, u_MaxLuminance);
-    float t_Exposure = u_KeyValue / t_AverageLuminance;
+    // The frame's own brightness sets the exposure, the way the game's auto-exposure does: the
+    // key value over the geometric mean of the luminance, so the average lands on middle grey.
+    // The limits bound the exposure rather than the average -- they are stated in the game's
+    // units, and this scene's are not the same, so clamping the average pinned every frame to
+    // the same value and flattened the picture.
+    float t_AverageLuminance = exp(texture(SAMPLER_2D(u_Luminance), vec2(0.5)).r);
+    float t_Exposure = clamp(u_KeyValue / max(t_AverageLuminance, 0.0001), u_MinExposure, u_MaxExposure) * EXPOSURE_BIAS;
     t_Color *= t_Exposure;
 
     if (u_BloomEnabled > 0.0)
@@ -198,8 +213,11 @@ export class Post_Process {
         const tone_mapping = globals.all_variables['render/tone_mapping'];
         const bloom = globals.all_variables['render/bloom'];
         const key_value = tone_mapping !== undefined ? tone_mapping.key_value as number : 0.22;
-        const min_luminance = tone_mapping !== undefined ? tone_mapping.min_luminance as number : 0.1;
-        const max_luminance = tone_mapping !== undefined ? tone_mapping.max_luminance as number : 1.0;
+        // The game's min/max luminance bound how far its auto-exposure may go, in its own units.
+        // Ours differ, so these bound the exposure itself: wide enough to let the key value do
+        // the work, tight enough that an almost-black or blown-out frame can't run away.
+        const min_exposure = 0.002;
+        const max_exposure = 8.0;
         const vignetting = tone_mapping !== undefined ? tone_mapping.vignetting as number : 0.8;
         const bloom_enabled = bloom !== undefined ? bloom.enable_bloom !== false : true;
         const bloom_threshold = bloom !== undefined ? bloom.bloom_threshold as number : 10.0;
@@ -253,7 +271,7 @@ export class Post_Process {
             brightInst.setGfxProgram(cache.createProgram(this.brightPassProgram));
             {
                 const offs = brightInst.allocateUniformBuffer(0, 4);
-                fillVec4(brightInst.mapUniformBufferF32(0), offs, bloom_threshold, key_value, min_luminance, max_luminance);
+                fillVec4(brightInst.mapUniformBufferF32(0), offs, bloom_threshold, key_value, min_exposure, max_exposure);
             }
 
             builder.pushPass((pass) => {
@@ -305,7 +323,7 @@ export class Post_Process {
         {
             let offs = compositeInst.allocateUniformBuffer(0, 8);
             const d = compositeInst.mapUniformBufferF32(0);
-            offs += fillVec4(d, offs, key_value, min_luminance, max_luminance, bloom_weight);
+            offs += fillVec4(d, offs, key_value, min_exposure, max_exposure, bloom_weight);
             offs += fillVec4(d, offs, vignetting, bloomTargetID !== null ? 1 : 0, 0, 0);
         }
 

--- a/src/TheWitness/PostProcess.ts
+++ b/src/TheWitness/PostProcess.ts
@@ -65,13 +65,26 @@ layout(std140) uniform ub_Params {
 
 #define u_Threshold     (u_Params.x)
 #define u_KeyValue      (u_Params.y)
-#define u_MinExposure   (u_Params.z)
-#define u_MaxExposure   (u_Params.w)
+#define u_MinLuminance  (u_Params.z)
+#define u_MaxLuminance  (u_Params.w)
+
+// The scene's units are not the game's: a lit outdoor frame meters about 2.5 here, against the
+// band the game states for its own luminance. This puts the two on the same footing so the
+// bounds can be the game's own min_luminance and max_luminance. Bounding the luminance rather
+// than the exposure is the point of them -- it holds the exposure inside a factor of ten, where
+// bounding the exposure directly let it swing thirtyfold between a lit garden and a cave, and a
+// threshold measured after exposure then meant something different in every room.
+#define SCENE_LUMINANCE_SCALE (0.4)
+
+float CalcExposure(in float t_AverageLuminance, in float t_KeyValue, in float t_MinLuminance, in float t_MaxLuminance) {
+    float t_Luminance = clamp(t_AverageLuminance * SCENE_LUMINANCE_SCALE, t_MinLuminance, t_MaxLuminance);
+    return t_KeyValue / t_Luminance;
+}
 
 void main() {
     // The same exposure the composite will apply, so the threshold means the same thing in both.
     float t_AverageLuminance = exp(texture(SAMPLER_2D(u_Luminance), vec2(0.5)).r);
-    float t_Exposure = clamp(u_KeyValue / max(t_AverageLuminance, 0.0001), u_MinExposure, u_MaxExposure) * 2.5;
+    float t_Exposure = CalcExposure(t_AverageLuminance, u_KeyValue, u_MinLuminance, u_MaxLuminance);
     vec3 t_Color = texture(SAMPLER_2D(u_Texture), v_TexCoord).rgb * t_Exposure;
 
     // How far past the threshold the pixel is, measured on brightness rather than per channel:
@@ -125,17 +138,24 @@ layout(std140) uniform ub_Params {
 };
 
 #define u_KeyValue      (u_Params0.x)
-#define u_MinExposure   (u_Params0.y)
-#define u_MaxExposure   (u_Params0.z)
+#define u_MinLuminance  (u_Params0.y)
+#define u_MaxLuminance  (u_Params0.z)
 #define u_BloomWeight   (u_Params0.w)
 #define u_Vignetting    (u_Params1.x)
 #define u_BloomEnabled  (u_Params1.y)
 
-// The curve and the key value come from the game, but the exposure it finally settles on does
-// not: the game measures its scene in units this one doesn't share, and metering a frame that is
-// half bright sky drags the land into the dark. This bias is the one number here chosen by eye,
-// against the game's own screenshots.
-#define EXPOSURE_BIAS (2.5)
+// The scene's units are not the game's: a lit outdoor frame meters about 2.5 here, against the
+// band the game states for its own luminance. This puts the two on the same footing so the
+// bounds can be the game's own min_luminance and max_luminance. Bounding the luminance rather
+// than the exposure is the point of them -- it holds the exposure inside a factor of ten, where
+// bounding the exposure directly let it swing thirtyfold between a lit garden and a cave, and a
+// threshold measured after exposure then meant something different in every room.
+#define SCENE_LUMINANCE_SCALE (0.4)
+
+float CalcExposure(in float t_AverageLuminance, in float t_KeyValue, in float t_MinLuminance, in float t_MaxLuminance) {
+    float t_Luminance = clamp(t_AverageLuminance * SCENE_LUMINANCE_SCALE, t_MinLuminance, t_MaxLuminance);
+    return t_KeyValue / t_Luminance;
+}
 
 float Uncharted2Tonemap(float x) {
     float A = 0.15, B = 0.5, C = 0.1, D = 0.1, E = 0.02, F = 0.6;
@@ -147,11 +167,8 @@ void main() {
 
     // The frame's own brightness sets the exposure, the way the game's auto-exposure does: the
     // key value over the geometric mean of the luminance, so the average lands on middle grey.
-    // The limits bound the exposure rather than the average -- they are stated in the game's
-    // units, and this scene's are not the same, so clamping the average pinned every frame to
-    // the same value and flattened the picture.
     float t_AverageLuminance = exp(texture(SAMPLER_2D(u_Luminance), vec2(0.5)).r);
-    float t_Exposure = clamp(u_KeyValue / max(t_AverageLuminance, 0.0001), u_MinExposure, u_MaxExposure) * EXPOSURE_BIAS;
+    float t_Exposure = CalcExposure(t_AverageLuminance, u_KeyValue, u_MinLuminance, u_MaxLuminance);
     t_Color *= t_Exposure;
 
     if (u_BloomEnabled > 0.0)
@@ -212,20 +229,16 @@ export class Post_Process {
 
         const tone_mapping = globals.all_variables['render/tone_mapping'];
         const bloom = globals.all_variables['render/bloom'];
+        // All of these come out of tone_mapping.variables and bloom.variables, which Globals now
+        // loads alongside All.variables. The fallbacks are those same files' values, for a
+        // universe that ships without them.
         const key_value = tone_mapping !== undefined ? tone_mapping.key_value as number : 0.22;
-        // The game's min/max luminance bound how far its auto-exposure may go, in its own units.
-        // Ours differ, so these bound the exposure itself: wide enough to let the key value do
-        // the work, tight enough that an almost-black or blown-out frame can't run away.
-        const min_exposure = 0.002;
-        const max_exposure = 8.0;
-        const vignetting = tone_mapping !== undefined ? tone_mapping.vignetting as number : 0.8;
+        const min_luminance = tone_mapping !== undefined ? tone_mapping.min_luminance as number : 0.1;
+        const max_luminance = tone_mapping !== undefined ? tone_mapping.max_luminance as number : 1.0;
+        const vignetting = tone_mapping !== undefined ? tone_mapping.vignetting as number : 0.801653;
         const bloom_enabled = bloom !== undefined ? bloom.enable_bloom !== false : true;
-        // This build ships no render/bloom section, so these are the whole of it. The threshold
-        // is measured after exposure, and exposure climbs in a dim scene, so a bright opening
-        // seen from inside a cave lands far past it -- keeping the weight low is what stops one
-        // blown-out doorway smearing across the frame.
-        const bloom_threshold = bloom !== undefined ? bloom.bloom_threshold as number : 14.0;
-        const bloom_weight = bloom !== undefined ? bloom.bloom_weight as number : 0.25;
+        const bloom_threshold = bloom !== undefined ? bloom.bloom_threshold as number : 10.0;
+        const bloom_weight = bloom !== undefined ? bloom.bloom_weight as number : 0.743802;
 
         const fullscreen = (): GfxRenderInst => {
             const renderInst = renderInstManager.newRenderInst();
@@ -275,7 +288,7 @@ export class Post_Process {
             brightInst.setGfxProgram(cache.createProgram(this.brightPassProgram));
             {
                 const offs = brightInst.allocateUniformBuffer(0, 4);
-                fillVec4(brightInst.mapUniformBufferF32(0), offs, bloom_threshold, key_value, min_exposure, max_exposure);
+                fillVec4(brightInst.mapUniformBufferF32(0), offs, bloom_threshold, key_value, min_luminance, max_luminance);
             }
 
             builder.pushPass((pass) => {
@@ -327,7 +340,7 @@ export class Post_Process {
         {
             let offs = compositeInst.allocateUniformBuffer(0, 8);
             const d = compositeInst.mapUniformBufferF32(0);
-            offs += fillVec4(d, offs, key_value, min_exposure, max_exposure, bloom_weight);
+            offs += fillVec4(d, offs, key_value, min_luminance, max_luminance, bloom_weight);
             offs += fillVec4(d, offs, vignetting, bloomTargetID !== null ? 1 : 0, 0, 0);
         }
 

--- a/src/TheWitness/Render.ts
+++ b/src/TheWitness/Render.ts
@@ -562,7 +562,13 @@ void mainPS() {
         }
 
         t_DiffuseLight += t_LightMapSample * u_LightMapScale.rgb;
-        t_HasIncomingLight = true;
+        // Only count the bake as light if a page is really bound. A material can be marked
+        // lightmapped and have none -- the puzzle panels are, because the game draws and lights
+        // those itself -- and Translucent takes no directional light either, so calling it lit
+        // leaves the surface with nothing at all and paints it black. That is the grid on the
+        // entry yard floor. Falling through to the unlit default below at least shows it.
+        if (u_LightMap0Blend > 0.0 || u_LightMap1Blend > 0.0)
+            t_HasIncomingLight = true;
     }
 
     if (!t_HasIncomingLight)
@@ -850,8 +856,11 @@ class Device_Material {
             this.texture_mapping_array[14].lateBinding = 'scene-depth';
         }
 
-        // Disable invisible material types.
-        if (material_type === Material_Type.Collision_Only || material_type === Material_Type.Occluder)
+        // Disable invisible material types. Shadow_Only is the blob-shadow geometry the game
+        // parks under trees and in doorways -- obj_primitives_shadowPlane and friends. It exists
+        // to darken the bake, never to be looked at, and drawing it puts a flat black quad on the
+        // ground at the foot of every mangrove.
+        if (material_type === Material_Type.Collision_Only || material_type === Material_Type.Occluder || material_type === Material_Type.Shadow_Only)
             this.visible = false;
 
         // This should go in the foam decal pass only...

--- a/src/TheWitness/Render.ts
+++ b/src/TheWitness/Render.ts
@@ -1,5 +1,5 @@
 
-import { mat4, ReadonlyMat4, vec3 } from "gl-matrix";
+import { mat4, quat, ReadonlyMat4, vec3 } from "gl-matrix";
 import { CameraController } from "../Camera.js";
 import { Color, colorCopy, colorNewCopy, colorNewFromRGBA, Red, White } from "../Color.js";
 import { AABB } from "../Geometry.js";
@@ -14,7 +14,7 @@ import { GfxRenderHelper } from "../gfx/render/GfxRenderHelper.js";
 import { GfxRendererLayer, GfxRenderInst, GfxRenderInstList, GfxRenderInstManager, makeSortKey, setSortKeyDepth } from "../gfx/render/GfxRenderInstManager.js";
 import { preprocessShader_GLSL } from "../gfx/shaderc/GfxShaderCompiler.js";
 import { hashCodeNumberUpdate, HashMap } from "../HashMap.js";
-import { setMatrixTranslation } from "../MathHelpers.js";
+import { setMatrixTranslation, Vec3NegY, Vec3UnitY, Vec3UnitZ } from "../MathHelpers.js";
 import { DeviceProgram } from "../Program.js";
 import { UberShaderInstance, UberShaderTemplate } from "../SourceEngine/UberShader.js";
 import { TextureMapping } from "../TextureHolder.js";
@@ -666,7 +666,10 @@ export class Render_Material_Cache {
 
 const scratchColor = colorNewCopy(White);
 const scratchAABB = new AABB();
+const ASSET_LOADS_PER_FRAME = 16;
+
 const scratchVec3a = vec3.create();
+const scratchVec3b = vec3.create();
 class Device_Material {
     public visible: boolean = true;
 
@@ -679,6 +682,9 @@ class Device_Material {
     public megaStateFlags: Partial<GfxMegaStateDescriptor> = {};
 
     constructor(globals: TheWitnessGlobals, public render_material: Render_Material) {
+        const __g = globalThis as any;
+        const __t = Date.now();
+
         const wrap_sampler = globals.renderCache.createSampler({
             minFilter: GfxTexFilterMode.Bilinear,
             magFilter: GfxTexFilterMode.Bilinear,
@@ -933,6 +939,31 @@ export class TheWitnessRenderer implements SceneGfx {
         c.setSceneMoveSpeedMult(1/100);
     }
 
+    public getDefaultWorldMatrix(dst: mat4): void {
+        // Start the camera where the game starts the player. Records we resynced past can be
+        // mistaken for the player -- several claim its portable_id of 0 -- but they carry a
+        // zeroed orientation, which a real one never does.
+        const player = this.globals.entity_manager.flat_entity_list.find((e) => {
+            return e.type_name === 'Entity_Type_Human' && Math.abs(quat.length(e.orientation) - 1.0) < 0.01;
+        });
+        if (player === undefined) {
+            mat4.identity(dst);
+            return;
+        }
+
+        // The world is Z-up, so lift the camera from the player's feet to about eye height and
+        // look along the direction they're facing, levelled off.
+        vec3.set(scratchVec3a, player.position[0], player.position[1], player.position[2] + 1.7);
+        vec3.transformQuat(scratchVec3b, Vec3NegY, player.orientation);
+        scratchVec3b[2] = 0.0;
+        if (vec3.squaredLength(scratchVec3b) < 0.0001)
+            vec3.copy(scratchVec3b, Vec3UnitY);
+        vec3.normalize(scratchVec3b, scratchVec3b);
+        vec3.add(scratchVec3b, scratchVec3a, scratchVec3b);
+
+        mat4.targetTo(dst, scratchVec3a, scratchVec3b, Vec3UnitZ);
+    }
+
     private prepareToRender(device: GfxDevice, viewerInput: ViewerRenderInput): void {
         const template = this.renderHelper.pushTemplateRenderInst();
         template.setBindingLayouts(bindingLayouts);
@@ -964,6 +995,8 @@ export class TheWitnessRenderer implements SceneGfx {
 
         globals.occlusion_manager.prepareToRender(globals, this.renderHelper.renderInstManager);
 
+        globals.asset_loads_remaining = ASSET_LOADS_PER_FRAME;
+
         // Go through each entity cluster.
         for (let i = 0; i < globals.entity_render_list.clusters.length; i++) {
             const cluster = globals.entity_render_list.clusters[i];
@@ -973,8 +1006,15 @@ export class TheWitnessRenderer implements SceneGfx {
             if (!viewpoint.frustum.containsSphere(cluster.bounding_center_world, cluster.bounding_radius_world))
                 continue;
 
+            // Brings in the cluster's package, which its elements load their assets out of.
+            cluster.ensure_assets_loaded(globals);
+            if (!cluster.assets_are_loaded())
+                continue;
+
             for (let j = 0; j < cluster.elements.length; j++) {
                 const entity = globals.entity_manager.entity_list[cluster.elements[j]];
+                if (entity === undefined)
+                    continue;
                 entity.prepareToRender(globals, this.renderHelper.renderInstManager);
             }
         }

--- a/src/TheWitness/Render.ts
+++ b/src/TheWitness/Render.ts
@@ -381,7 +381,15 @@ void CalcLight(inout bool t_HasLighting, inout vec3 t_Diffuse, vec3 t_LightDirWo
 }
 
 vec4 TintTexture(in vec4 t_Sample, in vec3 t_TintColor, in vec3 t_AverageColor, in float t_TintAmount) {
-    vec3 t_TintedColor = t_TintColor.rgb * (t_Sample.rgb / t_AverageColor.rgb);
+    // A material that asks for no tint must come back untouched. It did not: the divide below
+    // runs first, and a material with no texture in a slot gets an average colour of zero, so
+    // the result was inf -- and mix(x, inf, 0.0) is inf * 0.0, which is NaN, not x. A NaN colour
+    // then poisons the whole primitive through the blend, transparent texels included, which is
+    // what turned the keep's rust stains into black slabs across its gateway.
+    if (t_TintAmount <= 0.0)
+        return t_Sample;
+
+    vec3 t_TintedColor = t_TintColor.rgb * (t_Sample.rgb / max(t_AverageColor.rgb, vec3(1e-6)));
     t_Sample.rgb = mix(t_Sample.rgb, t_TintedColor.rgb, t_TintAmount);
     return t_Sample;
 }

--- a/src/TheWitness/Render.ts
+++ b/src/TheWitness/Render.ts
@@ -7,7 +7,7 @@ import { fullscreenMegaState, setAttachmentStateSimple } from "../gfx/helpers/Gf
 import { GfxShaderLibrary } from "../gfx/helpers/GfxShaderLibrary.js";
 import { makeBackbufferDescSimple, standardFullClearRenderPassDescriptor } from "../gfx/helpers/RenderGraphHelpers.js";
 import { fillColor, fillMatrix4x3, fillMatrix4x4, fillVec3v, fillVec4, fillVec4v } from "../gfx/helpers/UniformBufferHelpers.js";
-import { GfxBindingLayoutDescriptor, GfxBlendFactor, GfxBlendMode, GfxCullMode, GfxDevice, GfxFormat, GfxMegaStateDescriptor, GfxMipFilterMode, GfxProgram, GfxRenderProgramDescriptor, GfxSampler, GfxTexFilterMode, GfxWrapMode } from "../gfx/platform/GfxPlatform.js";
+import { GfxBindingLayoutDescriptor, GfxBindingLayoutSamplerDescriptor, GfxBlendFactor, GfxBlendMode, GfxCullMode, GfxDevice, GfxFormat, GfxMegaStateDescriptor, GfxMipFilterMode, GfxProgram, GfxRenderProgramDescriptor, GfxSampler, GfxSamplerFormatKind, GfxTexFilterMode, GfxTextureDimension, GfxWrapMode } from "../gfx/platform/GfxPlatform.js";
 import { GfxRenderCache } from "../gfx/render/GfxRenderCache.js";
 import { GfxrAttachmentSlot, GfxrRenderTargetDescription } from "../gfx/render/GfxRenderGraph.js";
 import { GfxRenderHelper } from "../gfx/render/GfxRenderHelper.js";
@@ -23,6 +23,7 @@ import { SceneGfx, ViewerRenderInput } from "../viewer.js";
 import { Asset_Type, Material_Flags, Material_Type, Mesh_Asset, Render_Material, Texture_Asset } from "./Assets.js";
 import { Entity_World, Lightmap_Table } from "./Entity.js";
 import { noclipSpaceFromTheWitnessSpace, TheWitnessGlobals } from "./Globals.js";
+import { Post_Process } from "./PostProcess.js";
 
 class DepthCopyProgram extends DeviceProgram {
     public override vert = GfxShaderLibrary.fullscreenVS;
@@ -82,6 +83,7 @@ ${GfxShaderLibrary.MatrixLibrary}
 
 layout(std140) uniform ub_SceneParams {
     Mat4x4 u_ViewProjection;
+    Mat4x4 u_WorldFromClip;
     vec4 u_CameraPosWorld;
     vec4 u_KeyLightDir;
     vec4 u_KeyLightColor;
@@ -89,10 +91,14 @@ layout(std140) uniform ub_SceneParams {
     vec4 u_FogColor;
     vec4 u_FogSkyColor;
     vec4 u_FogSunColor;
+    // xyz: what the sky says the baked light is worth (lightmap_color * lightmap_brightness).
+    // w: the sky's own brightness.
+    vec4 u_LightMapScale;
 };
 
 #define u_WindDirection (vec3(u_CameraPosWorld.w, u_KeyLightDir.w, 0.0))
 #define u_SceneTime (u_KeyLightColor.w)
+#define u_SkyBrightness (u_LightMapScale.w)
 
 layout(std140) uniform ub_ObjectParams {
     Mat3x4 u_ModelMatrix;
@@ -128,6 +134,10 @@ uniform sampler2D u_LightMap0;
 uniform sampler2D u_LightMap1;
 
 uniform sampler2D u_TerrainColor;
+
+// The scene as it stood before the water was drawn over it; see the 'Water' pass.
+uniform sampler2D u_SceneColor;
+uniform sampler2D u_SceneDepth;
 
 ${GfxShaderLibrary.saturate}
 ${GfxShaderLibrary.CalcScaleBias}
@@ -418,6 +428,7 @@ vec3 CalcNormalMap() {
 // reflects it, so the two always agree about what the sky looks like.
 vec3 CalcSkyColor(in vec3 t_Direction) {
     vec3 t_Color = u_FogSkyColor.rgb;
+    // Everything below mixes between colours, so the sky's brightness goes on at the end.
 
     float t_FogColorAmount = pow(saturate(1.0 - t_Direction.z), u_FogColor.a);
     t_Color.rgb = mix(t_Color.rgb, u_FogColor.rgb, t_FogColorAmount);
@@ -426,7 +437,7 @@ vec3 CalcSkyColor(in vec3 t_Direction) {
     float t_FogSunColorAmount = pow(t_SunAmount, 8.0);
     t_Color.rgb = mix(t_Color.rgb, u_FogSunColor.rgb, t_FogSunColorAmount);
 
-    return t_Color;
+    return t_Color * u_SkyBrightness;
 }
 
 vec4 CalcAlbedo() {
@@ -518,7 +529,7 @@ void mainPS() {
             t_LightMapSample *= HalfLambert(dot(t_NormalWorld, t_NormalWorldSurface));
         }
 
-        t_DiffuseLight += t_LightMapSample;
+        t_DiffuseLight += t_LightMapSample * u_LightMapScale.rgb;
         t_HasIncomingLight = true;
     }
 
@@ -548,6 +559,21 @@ void mainPS() {
 
     bool use_lake = ${this.is_type(m, Material_Type.Lake)};
     if (use_lake) {
+        // What the scene looked like where this pixel is, before the water went over it. The
+        // fragment coordinate indexes the framebuffer directly, so it needs no flipping.
+        vec2 t_ScreenUV = gl_FragCoord.xy / vec2(textureSize(TEXTURE(u_SceneDepth), 0));
+        float t_SceneDepthSample = texture(SAMPLER_2D(u_SceneDepth), t_ScreenUV).r;
+
+        // Turn that depth back into a world position, so the distance down through the water is
+        // just the drop from this surface to whatever lies under it.
+        vec4 t_PosClip = vec4(t_ScreenUV.xy * 2.0 - 1.0, t_SceneDepthSample, 1.0);
+#if !GFX_CLIPSPACE_NEAR_ZERO()
+        t_PosClip.z = t_PosClip.z * 2.0 - 1.0;
+#endif
+        vec4 t_PosWorld = UnpackMatrix(u_WorldFromClip) * t_PosClip;
+        vec3 t_BottomWorld = t_PosWorld.xyz / t_PosWorld.www;
+        float t_WaterDepth = max(v_PositionWorld.z - t_BottomWorld.z, 0.0);
+
         // Ripples: two slow wave trains crossing each other, tilting the surface a little. The
         // amplitude is small on purpose -- the island's water is nearly a mirror.
         vec2 t_WavePos = v_PositionWorld.xy;
@@ -564,10 +590,15 @@ void mainPS() {
         float t_ViewDot = saturate(dot(t_WaterNormal, t_WorldDirectionToEye));
         float t_Fresnel = 0.02 + 0.98 * pow(1.0 - t_ViewDot, 5.0);
 
-        // Looking into the water, from a shallow blue-green to the deep blue further out.
-        vec3 t_ShallowColor = vec3(0.014, 0.153, 0.216);
-        vec3 t_DeepColor = vec3(0.004, 0.032, 0.083);
-        vec3 t_WaterColor = mix(t_DeepColor, t_ShallowColor, t_ViewDot);
+        // Looking into the water: the bottom, dimmed by however much water stands over it. A
+        // metre of it barely tints the sand; ten metres of it is just blue. Light travelling
+        // down and back means the path is twice the depth.
+        vec3 t_Bottom = texture(SAMPLER_2D(u_SceneColor), t_ScreenUV).rgb;
+        vec3 t_Extinction = vec3(0.29, 0.086, 0.062);
+        vec3 t_Transmittance = exp(-t_Extinction * (t_WaterDepth * 2.0));
+
+        vec3 t_DeepColor = vec3(0.004, 0.033, 0.084);
+        vec3 t_WaterColor = t_Bottom * t_Transmittance + t_DeepColor * (1.0 - t_Transmittance);
 
         t_FinalColor = mix(t_WaterColor, t_SkyReflection, t_Fresnel);
 
@@ -578,9 +609,8 @@ void mainPS() {
 
     // TODO(jstpierre): Fog
 
-    // Tone mapping & gamma correction
-    CalcToneMap(t_FinalColor.rgb);
-    t_FinalColor = pow(t_FinalColor, vec3(1.0 / 2.2));
+    // The scene is drawn in HDR; exposure, the filmic curve and the vignette come later, in
+    // PostProcess.ts, the way the game does them.
 
     float t_Alpha = 1.0;
     bool use_albedo_alpha = ${this.is_type(m, Material_Type.Vegetation) || this.is_type(m, Material_Type.Foliage) || this.is_type(m, Material_Type.Translucent) || this.is_type(m, Material_Type.Cloud)};
@@ -709,6 +739,7 @@ const ASSET_LOADS_PER_FRAME = 64;
 
 const scratchVec3a = vec3.create();
 const scratchVec3b = vec3.create();
+const scratchMatrix = mat4.create();
 class Device_Material {
     public visible: boolean = true;
 
@@ -716,6 +747,7 @@ class Device_Material {
     private gfx_program: GfxProgram;
     private texture_map: (Texture_Asset | null)[] = nArray(3, () => null);
     private texture_mapping_array: TextureMapping[] = nArray(12, () => new TextureMapping());
+    public is_water: boolean = false;
 
     public sortKeyBase = 0;
     public megaStateFlags: Partial<GfxMegaStateDescriptor> = {};
@@ -763,6 +795,14 @@ class Device_Material {
 
         this.shader_instance = globals.device_material_cache.create_shader_instance(this.render_material);
         this.gfx_program = this.shader_instance.getGfxProgram(globals.renderCache);
+
+        // Water draws in its own pass, once the rest of the scene is there to be seen through it.
+        this.is_water = material_type === Material_Type.Lake;
+        if (this.is_water) {
+            this.texture_mapping_array.push(new TextureMapping(), new TextureMapping());
+            this.texture_mapping_array[12].lateBinding = 'scene-color';
+            this.texture_mapping_array[13].lateBinding = 'scene-depth';
+        }
 
         // Disable invisible material types.
         if (material_type === Material_Type.Collision_Only || material_type === Material_Type.Occluder)
@@ -813,7 +853,7 @@ class Device_Material {
 
             lightmap0Blend *= params.lightmap_table.current_page.color_range;
             if (params.lightmap_table.next_page !== null)
-                lightmap0Blend *= params.lightmap_table.next_page.color_range;
+                lightmap1Blend *= params.lightmap_table.next_page.color_range;
         }
 
         const emission_scale = 10.0;
@@ -906,13 +946,21 @@ export class Mesh_Instance {
             device_material.setOnRenderInst(renderInst, params);
             device_material.fillMaterialParams(globals, renderInst, params);
             renderInst.sortKey = setSortKeyDepth(renderInst.sortKey, depth);
-            renderInstManager.submitRenderInst(renderInst);
+            if (device_material.is_water && globals.water_render_inst_list !== null)
+                globals.water_render_inst_list.submitRenderInst(renderInst);
+            else
+                renderInstManager.submitRenderInst(renderInst);
         }
     }
 }
 
+// The scene depth the water reads is a depth texture, and the platform checks that the shader
+// says so; everything else here is an ordinary colour map.
+const samplerEntries: GfxBindingLayoutSamplerDescriptor[] = nArray(16, () => ({ dimension: GfxTextureDimension.n2D, formatKind: GfxSamplerFormatKind.Float }));
+samplerEntries[13] = { dimension: GfxTextureDimension.n2D, formatKind: GfxSamplerFormatKind.Depth, comparison: false };
+
 const bindingLayouts: GfxBindingLayoutDescriptor[] = [
-    { numUniformBuffers: 2, numSamplers: 16, },
+    { numUniformBuffers: 2, numSamplers: 16, samplerEntries, },
 ];
 
 class Skydome {
@@ -960,18 +1008,39 @@ export class Cached_Shadow_Map {
 export class TheWitnessRenderer implements SceneGfx {
     public renderHelper: GfxRenderHelper;
     private renderInstListMain = new GfxRenderInstList();
+    private renderInstListWater = new GfxRenderInstList();
 
     private skydome: Skydome;
     private cached_shadow_map: Cached_Shadow_Map | null = null;
 
+    private post_process: Post_Process;
+    private sceneColorSampler: GfxSampler;
+    private sceneDepthSampler: GfxSampler;
+
     constructor(device: GfxDevice, private globals: TheWitnessGlobals) {
         this.renderHelper = new GfxRenderHelper(device);
+        this.sceneColorSampler = this.renderHelper.renderCache.createSampler({
+            minFilter: GfxTexFilterMode.Bilinear,
+            magFilter: GfxTexFilterMode.Bilinear,
+            mipFilter: GfxMipFilterMode.Nearest,
+            wrapS: GfxWrapMode.Clamp,
+            wrapT: GfxWrapMode.Clamp,
+        });
+        this.sceneDepthSampler = this.renderHelper.renderCache.createSampler({
+            minFilter: GfxTexFilterMode.Point,
+            magFilter: GfxTexFilterMode.Point,
+            mipFilter: GfxMipFilterMode.Nearest,
+            wrapS: GfxWrapMode.Clamp,
+            wrapT: GfxWrapMode.Clamp,
+        });
         this.skydome = new Skydome(globals);
 
         const world = this.globals.entity_manager.flat_entity_list.find((e) => e instanceof Entity_World) as Entity_World;
         // this.cached_shadow_map = new Cached_Shadow_Map(globals, world);
 
         globals.debug_draw = this.renderHelper.debugDraw;
+        globals.water_render_inst_list = this.renderInstListWater;
+        this.post_process = new Post_Process(device, this.renderHelper);
     }
 
     public adjustCameraController(c: CameraController): void {
@@ -989,7 +1058,7 @@ export class TheWitnessRenderer implements SceneGfx {
         // Work in The Witness's own space, where Z is up: lift the camera from the marker on the
         // ground to about eye height, and take the direction it faces with the vertical dropped,
         // which is what leaves the horizon level.
-        vec3.set(scratchVec3a, start.position[0], start.position[1], start.position[2] + 1.7);
+        vec3.set(scratchVec3a, start.position[0], start.position[1], start.position[2] + 1.69);
         vec3.transformQuat(scratchVec3b, Vec3UnitY, start.orientation);
         scratchVec3b[2] = 0.0;
         if (vec3.squaredLength(scratchVec3b) < 0.0001)
@@ -1018,9 +1087,11 @@ export class TheWitnessRenderer implements SceneGfx {
         viewpoint.setupFromCamera(viewerInput.camera);
         this.renderHelper.debugDraw.beginFrame(viewpoint.clipFromViewMatrix, viewpoint.viewFromWorldMatrix, viewerInput.backbufferWidth, viewerInput.backbufferHeight);
 
-        let offs = template.allocateUniformBuffer(TheWitnessShaderTemplate.ub_SceneParams, 44);
+        let offs = template.allocateUniformBuffer(TheWitnessShaderTemplate.ub_SceneParams, 64);
         const d = template.mapUniformBufferF32(TheWitnessShaderTemplate.ub_SceneParams);
         offs += fillMatrix4x4(d, offs, viewpoint.clipFromWorldMatrix);
+        mat4.invert(scratchMatrix, viewpoint.clipFromWorldMatrix);
+        offs += fillMatrix4x4(d, offs, scratchMatrix);
         offs += fillVec3v(d, offs, viewpoint.cameraPos, misc.wind_x as number);
 
         vec3.set(scratchVec3a, misc.sun_x as number, misc.sun_y as number, misc.sun_z as number);
@@ -1032,6 +1103,14 @@ export class TheWitnessRenderer implements SceneGfx {
         offs += fillVec4(d, offs, render_sky.fog_color_x as number, render_sky.fog_color_y as number, render_sky.fog_color_z as number, render_sky.fog_sky_blend as number);
         offs += fillVec4(d, offs, render_sky.fog_sky_color_x as number, render_sky.fog_sky_color_y as number, render_sky.fog_sky_color_z as number);
         offs += fillVec4(d, offs, render_sky.fog_sun_color_x as number, render_sky.fog_sun_color_y as number, render_sky.fog_sun_color_z as number);
+
+        // The baked lighting carries the image in this game; the sky says how much it is worth.
+        const lightmap_brightness = render_sky.lightmap_brightness as number;
+        offs += fillVec4(d, offs,
+            (render_sky.lightmap_color_x as number) * lightmap_brightness,
+            (render_sky.lightmap_color_y as number) * lightmap_brightness,
+            (render_sky.lightmap_color_z as number) * lightmap_brightness,
+            render_sky.brightness as number);
 
         globals.occlusion_manager.prepareToRender(globals, this.renderHelper.renderInstManager);
 
@@ -1114,7 +1193,9 @@ export class TheWitnessRenderer implements SceneGfx {
             });
         }
 
+        // The scene is rendered in float, so the sun and sky keep their range until tone mapping.
         const mainColorDesc = makeBackbufferDescSimple(GfxrAttachmentSlot.Color0, viewerInput, standardFullClearRenderPassDescriptor);
+        mainColorDesc.pixelFormat = GfxFormat.F16_RGBA;
         const mainDepthDesc = makeBackbufferDescSimple(GfxrAttachmentSlot.DepthStencil, viewerInput, standardFullClearRenderPassDescriptor);
 
         const mainColorTargetID = builder.createRenderTargetID(mainColorDesc, 'Main Color');
@@ -1127,14 +1208,41 @@ export class TheWitnessRenderer implements SceneGfx {
                 this.renderInstListMain.drawOnPassRenderer(this.renderHelper.renderCache, passRenderer);
             });
         });
+        // The water goes over the finished scene, reading the colour and depth of what it stands
+        // in front of so it can work out how deep it is at each pixel. The pass is built before
+        // prepareToRender has filled any list, so it goes in unconditionally; with no water in
+        // front of the camera it draws nothing.
+        {
+            builder.pushPass((pass) => {
+                pass.setDebugName('Water');
+                pass.attachRenderTargetID(GfxrAttachmentSlot.Color0, mainColorTargetID);
+                pass.attachRenderTargetID(GfxrAttachmentSlot.DepthStencil, mainDepthTargetID);
+
+                const sceneColorResolveTextureID = builder.resolveRenderTarget(mainColorTargetID);
+                pass.attachResolveTexture(sceneColorResolveTextureID);
+                const sceneDepthResolveTextureID = builder.resolveRenderTarget(mainDepthTargetID);
+                pass.attachResolveTexture(sceneDepthResolveTextureID);
+
+                pass.exec((passRenderer, scope) => {
+                    this.renderInstListWater.resolveLateSamplerBinding('scene-color', { gfxTexture: scope.getResolveTextureForID(sceneColorResolveTextureID), gfxSampler: this.sceneColorSampler, lateBinding: undefined });
+                    this.renderInstListWater.resolveLateSamplerBinding('scene-depth', { gfxTexture: scope.getResolveTextureForID(sceneDepthResolveTextureID), gfxSampler: this.sceneDepthSampler, lateBinding: undefined });
+                    this.renderInstListWater.drawOnPassRenderer(this.renderHelper.renderCache, passRenderer);
+                });
+            });
+        }
+
         this.renderHelper.debugDraw.pushPasses(builder, mainColorTargetID, mainDepthTargetID);
-        this.renderHelper.debugThumbnails.pushPasses(builder, renderInstManager, mainColorTargetID, viewerInput.mouseLocation);
-        this.renderHelper.antialiasingSupport.pushPasses(builder, viewerInput, mainColorTargetID);
-        builder.resolveRenderTargetToExternalTexture(mainColorTargetID, viewerInput.onscreenTexture);
+
+        const ldrColorTargetID = this.post_process.render(globals, builder, this.renderHelper, viewerInput, mainColorTargetID);
+
+        this.renderHelper.debugThumbnails.pushPasses(builder, renderInstManager, ldrColorTargetID, viewerInput.mouseLocation);
+        this.renderHelper.antialiasingSupport.pushPasses(builder, viewerInput, ldrColorTargetID);
+        builder.resolveRenderTargetToExternalTexture(ldrColorTargetID, viewerInput.onscreenTexture);
 
         this.prepareToRender(device, viewerInput);
         builder.execute();
         this.renderInstListMain.reset();
+        this.renderInstListWater.reset();
     }
 
     public destroy(device: GfxDevice): void {
@@ -1142,3 +1250,4 @@ export class TheWitnessRenderer implements SceneGfx {
         this.globals.destroy(device);
     }
 }
+

--- a/src/TheWitness/Render.ts
+++ b/src/TheWitness/Render.ts
@@ -740,6 +740,7 @@ const ASSET_LOADS_PER_FRAME = 64;
 const scratchVec3a = vec3.create();
 const scratchVec3b = vec3.create();
 const scratchMatrix = mat4.create();
+const KEY_LIGHT_STRENGTH = 8.0;
 class Device_Material {
     public visible: boolean = true;
 
@@ -1097,7 +1098,10 @@ export class TheWitnessRenderer implements SceneGfx {
         vec3.set(scratchVec3a, misc.sun_x as number, misc.sun_y as number, misc.sun_z as number);
         vec3.normalize(scratchVec3a, scratchVec3a);
         offs += fillVec3v(d, offs, scratchVec3a, misc.wind_y as number);
-        offs += fillVec4(d, offs, 32, 32, 32, globals.scene_time);
+        // The game shadow-maps its sun; this doesn't, so a directional term at full strength
+        // lands on faces the sun can't reach and flattens the bake underneath it. Turned down,
+        // it still lifts the chunks whose lightmaps are dark without washing out the rest.
+        offs += fillVec4(d, offs, KEY_LIGHT_STRENGTH, KEY_LIGHT_STRENGTH, KEY_LIGHT_STRENGTH, globals.scene_time);
 
         const render_sky = globals.sky_variables['render/sky'];
         offs += fillVec4(d, offs, render_sky.fog_color_x as number, render_sky.fog_color_y as number, render_sky.fog_color_z as number, render_sky.fog_sky_blend as number);

--- a/src/TheWitness/Render.ts
+++ b/src/TheWitness/Render.ts
@@ -1,5 +1,5 @@
 
-import { mat4, quat, ReadonlyMat4, vec3 } from "gl-matrix";
+import { mat4, ReadonlyMat4, vec3 } from "gl-matrix";
 import { CameraController } from "../Camera.js";
 import { Color, colorCopy, colorNewCopy, colorNewFromRGBA, Red, White } from "../Color.js";
 import { AABB } from "../Geometry.js";
@@ -14,7 +14,7 @@ import { GfxRenderHelper } from "../gfx/render/GfxRenderHelper.js";
 import { GfxRendererLayer, GfxRenderInst, GfxRenderInstList, GfxRenderInstManager, makeSortKey, setSortKeyDepth } from "../gfx/render/GfxRenderInstManager.js";
 import { preprocessShader_GLSL } from "../gfx/shaderc/GfxShaderCompiler.js";
 import { hashCodeNumberUpdate, HashMap } from "../HashMap.js";
-import { setMatrixTranslation, Vec3NegY, Vec3UnitY, Vec3UnitZ } from "../MathHelpers.js";
+import { setMatrixTranslation, Vec3UnitY, Vec3UnitZ } from "../MathHelpers.js";
 import { DeviceProgram } from "../Program.js";
 import { UberShaderInstance, UberShaderTemplate } from "../SourceEngine/UberShader.js";
 import { TextureMapping } from "../TextureHolder.js";
@@ -940,21 +940,17 @@ export class TheWitnessRenderer implements SceneGfx {
     }
 
     public getDefaultWorldMatrix(dst: mat4): void {
-        // Start the camera where the game starts the player. Records we resynced past can be
-        // mistaken for the player -- several claim its portable_id of 0 -- but they carry a
-        // zeroed orientation, which a real one never does.
-        const player = this.globals.entity_manager.flat_entity_list.find((e) => {
-            return e.type_name === 'Entity_Type_Human' && Math.abs(quat.length(e.orientation) - 1.0) < 0.01;
-        });
-        if (player === undefined) {
+        // Start the camera where the game starts the player: a marker the world names ':start'.
+        const start = this.globals.entity_manager.flat_entity_list.find((e) => e.entity_name === ':start');
+        if (start === undefined) {
             mat4.identity(dst);
             return;
         }
 
-        // The world is Z-up, so lift the camera from the player's feet to about eye height and
-        // look along the direction they're facing, levelled off.
-        vec3.set(scratchVec3a, player.position[0], player.position[1], player.position[2] + 1.7);
-        vec3.transformQuat(scratchVec3b, Vec3NegY, player.orientation);
+        // The world is Z-up, so lift the camera from the marker on the ground to about eye
+        // height, and look the way it faces, levelled off.
+        vec3.set(scratchVec3a, start.position[0], start.position[1], start.position[2] + 1.7);
+        vec3.transformQuat(scratchVec3b, Vec3UnitY, start.orientation);
         scratchVec3b[2] = 0.0;
         if (vec3.squaredLength(scratchVec3b) < 0.0001)
             vec3.copy(scratchVec3b, Vec3UnitY);

--- a/src/TheWitness/Render.ts
+++ b/src/TheWitness/Render.ts
@@ -1059,7 +1059,7 @@ export class TheWitnessRenderer implements SceneGfx {
         // Work in The Witness's own space, where Z is up: lift the camera from the marker on the
         // ground to about eye height, and take the direction it faces with the vertical dropped,
         // which is what leaves the horizon level.
-        vec3.set(scratchVec3a, start.position[0], start.position[1], start.position[2] + 1.69);
+        vec3.set(scratchVec3a, start.position[0], start.position[1], start.position[2] + 1.2);
         vec3.transformQuat(scratchVec3b, Vec3UnitY, start.orientation);
         scratchVec3b[2] = 0.0;
         if (vec3.squaredLength(scratchVec3b) < 0.0001)
@@ -1118,6 +1118,19 @@ export class TheWitnessRenderer implements SceneGfx {
 
         globals.occlusion_manager.prepareToRender(globals, this.renderHelper.renderInstManager);
 
+        // Building an asset costs about a millisecond, and a world holds far more of them than a
+        // frame can afford, so the budget has to go somewhere. It goes to whatever covers the
+        // most of the screen: entities offer up how much of it they stand to fill, and anything
+        // under the floor waits. The floor rises while more is waiting than can be built and
+        // falls once the view has caught up, which keeps it tracking the camera by itself.
+        if (globals.asset_loads_remaining <= 0)
+            globals.asset_load_priority_floor = Math.max(globals.asset_load_priority_floor, 1e-7) * 1.5;
+        else if (globals.asset_loads_deferred === 0)
+            globals.asset_load_priority_floor = 0.0;
+        else
+            globals.asset_load_priority_floor *= 0.6;
+
+        globals.asset_loads_deferred = 0;
         globals.asset_loads_remaining = ASSET_LOADS_PER_FRAME;
 
         // Entities outside the cluster system -- the water among them -- come first. There are
@@ -1137,10 +1150,19 @@ export class TheWitnessRenderer implements SceneGfx {
             if (!viewpoint.frustum.containsSphere(cluster.bounding_center_world, cluster.bounding_radius_world))
                 continue;
 
-            // Brings in the cluster's package, which its elements load their assets out of.
-            cluster.ensure_assets_loaded(globals);
-            if (!cluster.assets_are_loaded())
-                continue;
+            // Brings in the cluster's package, which its elements load their assets out of. It
+            // waits its turn by the same measure as everything else.
+            if (!cluster.assets_are_loaded()) {
+                const squared_distance = vec3.squaredDistance(viewpoint.cameraPos, cluster.bounding_center_world);
+                if (cluster.asset_load_priority(squared_distance) < globals.asset_load_priority_floor) {
+                    globals.asset_loads_deferred++;
+                    continue;
+                }
+
+                cluster.ensure_assets_loaded(globals);
+                if (!cluster.assets_are_loaded())
+                    continue;
+            }
 
             for (let j = 0; j < cluster.elements.length; j++) {
                 const entity = globals.entity_manager.entity_list[cluster.elements[j]];

--- a/src/TheWitness/Render.ts
+++ b/src/TheWitness/Render.ts
@@ -14,7 +14,7 @@ import { GfxRenderHelper } from "../gfx/render/GfxRenderHelper.js";
 import { GfxRendererLayer, GfxRenderInst, GfxRenderInstList, GfxRenderInstManager, makeSortKey, setSortKeyDepth } from "../gfx/render/GfxRenderInstManager.js";
 import { preprocessShader_GLSL } from "../gfx/shaderc/GfxShaderCompiler.js";
 import { hashCodeNumberUpdate, HashMap } from "../HashMap.js";
-import { setMatrixTranslation, Vec3UnitY, Vec3UnitZ } from "../MathHelpers.js";
+import { setMatrixTranslation, Vec3UnitY } from "../MathHelpers.js";
 import { DeviceProgram } from "../Program.js";
 import { UberShaderInstance, UberShaderTemplate } from "../SourceEngine/UberShader.js";
 import { TextureMapping } from "../TextureHolder.js";
@@ -22,7 +22,7 @@ import { nArray } from "../util.js";
 import { SceneGfx, ViewerRenderInput } from "../viewer.js";
 import { Asset_Type, Material_Flags, Material_Type, Mesh_Asset, Render_Material, Texture_Asset } from "./Assets.js";
 import { Entity_World, Lightmap_Table } from "./Entity.js";
-import { TheWitnessGlobals } from "./Globals.js";
+import { noclipSpaceFromTheWitnessSpace, TheWitnessGlobals } from "./Globals.js";
 
 class DepthCopyProgram extends DeviceProgram {
     public override vert = GfxShaderLibrary.fullscreenVS;
@@ -947,8 +947,9 @@ export class TheWitnessRenderer implements SceneGfx {
             return;
         }
 
-        // The world is Z-up, so lift the camera from the marker on the ground to about eye
-        // height, and look the way it faces, levelled off.
+        // Work in The Witness's own space, where Z is up: lift the camera from the marker on the
+        // ground to about eye height, and take the direction it faces with the vertical dropped,
+        // which is what leaves the horizon level.
         vec3.set(scratchVec3a, start.position[0], start.position[1], start.position[2] + 1.7);
         vec3.transformQuat(scratchVec3b, Vec3UnitY, start.orientation);
         scratchVec3b[2] = 0.0;
@@ -957,7 +958,11 @@ export class TheWitnessRenderer implements SceneGfx {
         vec3.normalize(scratchVec3b, scratchVec3b);
         vec3.add(scratchVec3b, scratchVec3a, scratchVec3b);
 
-        mat4.targetTo(dst, scratchVec3a, scratchVec3b, Vec3UnitZ);
+        // The camera matrix is noclip's, so hand both points over to that space, where up is +Y.
+        vec3.transformMat4(scratchVec3a, scratchVec3a, noclipSpaceFromTheWitnessSpace);
+        vec3.transformMat4(scratchVec3b, scratchVec3b, noclipSpaceFromTheWitnessSpace);
+
+        mat4.targetTo(dst, scratchVec3a, scratchVec3b, Vec3UnitY);
     }
 
     private prepareToRender(device: GfxDevice, viewerInput: ViewerRenderInput): void {

--- a/src/TheWitness/Render.ts
+++ b/src/TheWitness/Render.ts
@@ -458,6 +458,57 @@ vec3 CalcSkyColor(in vec3 t_Direction) {
     return t_Color * u_SkyBrightness;
 }
 
+vec3 CalcWorldFromScreen(in vec2 t_ScreenUV, in float t_Depth) {
+    vec4 t_PosClip = vec4(t_ScreenUV.xy * 2.0 - 1.0, t_Depth, 1.0);
+#if !GFX_CLIPSPACE_NEAR_ZERO()
+    t_PosClip.z = t_PosClip.z * 2.0 - 1.0;
+#endif
+    vec4 t_PosWorld = UnpackMatrix(u_WorldFromClip) * t_PosClip;
+    return t_PosWorld.xyz / t_PosWorld.www;
+}
+
+// The island's lakes are mirrors, and what they mirror is standing right above them and already
+// drawn: the water pass runs after the rest of the scene and has its colour and depth to hand.
+// So the reflection is traced against those rather than by drawing the world a second time from
+// under the surface. The march is in world space, projecting each step, which keeps the test
+// below in metres instead of in the depth buffer's own crooked units. The water is not in that
+// depth buffer yet, so the ray cannot trip over the surface it started from.
+vec3 CalcScreenReflection(in vec3 t_Origin, in vec3 t_Direction, out float t_Confidence) {
+    t_Confidence = 0.0;
+
+    float t_Step = 0.4;
+    vec3 t_Position = t_Origin;
+
+    for (int i = 0; i < 20; i++) {
+        t_Position += t_Direction * t_Step;
+        t_Step *= 1.35;
+
+        vec4 t_Clip = UnpackMatrix(u_ViewProjection) * vec4(t_Position, 1.0);
+        if (t_Clip.w <= 0.0)
+            return vec3(0.0);
+
+        vec2 t_UV = (t_Clip.xy / t_Clip.w) * 0.5 + 0.5;
+        if (t_UV.x < 0.0 || t_UV.x > 1.0 || t_UV.y < 0.0 || t_UV.y > 1.0)
+            return vec3(0.0);
+
+        vec3 t_ScenePosition = CalcWorldFromScreen(t_UV, texture(SAMPLER_2D(u_SceneDepth), t_UV).r);
+
+        // Behind what was drawn there is a hit -- but only just behind it. Further back than the
+        // step that carried us there and the ray has passed clean through something thin and
+        // come out in front of scenery that has nothing to do with it.
+        float t_Behind = distance(t_Position, u_CameraPosWorld.xyz) - distance(t_ScenePosition, u_CameraPosWorld.xyz);
+        if (t_Behind > 0.0 && t_Behind < t_Step * 4.0) {
+            // Nothing traced across the screen can know what lies outside it, so let the answer
+            // fade out towards the borders rather than stop at one.
+            vec2 t_Fade = smoothstep(vec2(0.0), vec2(0.12), t_UV) * smoothstep(vec2(0.0), vec2(0.12), 1.0 - t_UV);
+            t_Confidence = t_Fade.x * t_Fade.y;
+            return texture(SAMPLER_2D(u_SceneColor), t_UV).rgb;
+        }
+    }
+
+    return vec3(0.0);
+}
+
 vec4 CalcAlbedo() {
     bool use_sky = ${this.is_type(m, Material_Type.Sky)};
     if (use_sky) {
@@ -615,29 +666,32 @@ void mainPS() {
 
         // Turn that depth back into a world position, so the distance down through the water is
         // just the drop from this surface to whatever lies under it.
-        vec4 t_PosClip = vec4(t_ScreenUV.xy * 2.0 - 1.0, t_SceneDepthSample, 1.0);
-#if !GFX_CLIPSPACE_NEAR_ZERO()
-        t_PosClip.z = t_PosClip.z * 2.0 - 1.0;
-#endif
-        vec4 t_PosWorld = UnpackMatrix(u_WorldFromClip) * t_PosClip;
-        vec3 t_BottomWorld = t_PosWorld.xyz / t_PosWorld.www;
+        vec3 t_BottomWorld = CalcWorldFromScreen(t_ScreenUV, t_SceneDepthSample);
         float t_WaterDepth = max(v_PositionWorld.z - t_BottomWorld.z, 0.0);
 
-        // Ripples: two slow wave trains crossing each other, tilting the surface a little. The
-        // amplitude is small on purpose -- the island's water is nearly a mirror.
-        vec2 t_WavePos = v_PositionWorld.xy;
-        float t_Wave0 = sin(dot(t_WavePos, vec2(0.21, 0.13)) + u_SceneTime * 0.8);
-        float t_Wave1 = sin(dot(t_WavePos, vec2(-0.09, 0.25)) + u_SceneTime * 0.55);
-        vec3 t_WaterNormal = normalize(vec3(0.02 * (t_Wave0 + 0.5 * t_Wave1), 0.02 * (t_Wave1 - 0.5 * t_Wave0), 1.0));
+        // The island's water is still. Not nearly still -- still: the lakes are mirrors, and the
+        // reflection puzzles are only readable because nothing disturbs them.
+        vec3 t_WaterNormal = vec3(0.0, 0.0, 1.0);
 
         // Grazing angles mirror the sky, straight down looks into the water: the Fresnel term
         // between the two is what gives the horizon its pale band and the foreground its blue.
         vec3 t_Reflected = reflect(-t_WorldDirectionToEye, t_WaterNormal);
-        t_Reflected.z = abs(t_Reflected.z);
-        vec3 t_SkyReflection = CalcSkyColor(t_Reflected);
+        vec3 t_SkyDirection = t_Reflected;
+        t_SkyDirection.z = abs(t_SkyDirection.z);
+        vec3 t_SkyReflection = CalcSkyColor(t_SkyDirection);
 
         float t_ViewDot = saturate(dot(t_WaterNormal, t_WorldDirectionToEye));
         float t_Fresnel = 0.02 + 0.98 * pow(1.0 - t_ViewDot, 5.0);
+
+        // The world's own reflection where the screen still holds it, the sky wherever it does
+        // not. Looking straight down the water barely reflects at all, and the march is much the
+        // most expensive thing here, so it is only worth walking when the answer will be seen.
+        vec3 t_Reflection = t_SkyReflection;
+        if (t_Fresnel > 0.06) {
+            float t_ReflectionConfidence;
+            vec3 t_TracedReflection = CalcScreenReflection(v_PositionWorld.xyz, t_Reflected, t_ReflectionConfidence);
+            t_Reflection = mix(t_SkyReflection, t_TracedReflection, t_ReflectionConfidence);
+        }
 
         // Looking into the water: the bottom, dimmed by however much water stands over it. A
         // metre of it barely tints the sand; ten metres of it is just blue. Light travelling
@@ -654,10 +708,10 @@ void mainPS() {
         vec3 t_DeepColor = vec3(0.048, 0.393, 1.0) * u_LightMapScale.rgb * 0.055;
         vec3 t_WaterColor = t_Bottom * t_Transmittance + t_DeepColor * (1.0 - t_Transmittance);
 
-        t_FinalColor = mix(t_WaterColor, t_SkyReflection, t_Fresnel);
+        t_FinalColor = mix(t_WaterColor, t_Reflection, t_Fresnel);
 
         // The sun's glint, tight enough to read as a highlight rather than a second sun.
-        float t_SunDot = saturate(dot(t_Reflected, u_KeyLightDir.xyz));
+        float t_SunDot = saturate(dot(t_SkyDirection, u_KeyLightDir.xyz));
         t_FinalColor += u_FogSunColor.rgb * pow(t_SunDot, 350.0) * 6.0;
     }
 

--- a/src/TheWitness/Render.ts
+++ b/src/TheWitness/Render.ts
@@ -414,20 +414,29 @@ vec3 CalcNormalMap() {
     return t_NormalMapSample;
 }
 
+// The sky along a direction, without the sun's disc. The skydome draws with this, and the water
+// reflects it, so the two always agree about what the sky looks like.
+vec3 CalcSkyColor(in vec3 t_Direction) {
+    vec3 t_Color = u_FogSkyColor.rgb;
+
+    float t_FogColorAmount = pow(saturate(1.0 - t_Direction.z), u_FogColor.a);
+    t_Color.rgb = mix(t_Color.rgb, u_FogColor.rgb, t_FogColorAmount);
+
+    float t_SunAmount = saturate(dot(t_Direction.xyz, u_KeyLightDir.xyz));
+    float t_FogSunColorAmount = pow(t_SunAmount, 8.0);
+    t_Color.rgb = mix(t_Color.rgb, u_FogSunColor.rgb, t_FogSunColorAmount);
+
+    return t_Color;
+}
+
 vec4 CalcAlbedo() {
     bool use_sky = ${this.is_type(m, Material_Type.Sky)};
     if (use_sky) {
         vec3 t_Normal = normalize(v_PositionWorld.xyz);
 
-        vec3 t_Color = u_FogSkyColor.rgb;
-
-        float t_FogColorAmount = pow(saturate(1.0 - t_Normal.z), u_FogColor.a);
-        t_Color.rgb = mix(t_Color.rgb, u_FogColor.rgb, t_FogColorAmount);
+        vec3 t_Color = CalcSkyColor(t_Normal);
 
         float t_SunAmount = saturate(dot(t_Normal.xyz, u_KeyLightDir.xyz));
-        float t_FogSunColorAmount = pow(t_SunAmount, 8.0);
-        t_Color.rgb = mix(t_Color.rgb, u_FogSunColor.rgb, t_FogSunColorAmount);
-
         vec3 t_SunColor = vec3(1.0, 0.8, 0.4) * 256.0;
         t_Color.rgb += t_SunColor * smoothstep(0.9985, 0.9989, t_SunAmount);
 
@@ -536,6 +545,36 @@ void mainPS() {
 
     vec3 t_FinalColor = vec3(0.0);
     t_FinalColor.rgb += t_DiffuseLight.rgb * t_Albedo.rgb;
+
+    bool use_lake = ${this.is_type(m, Material_Type.Lake)};
+    if (use_lake) {
+        // Ripples: two slow wave trains crossing each other, tilting the surface a little. The
+        // amplitude is small on purpose -- the island's water is nearly a mirror.
+        vec2 t_WavePos = v_PositionWorld.xy;
+        float t_Wave0 = sin(dot(t_WavePos, vec2(0.21, 0.13)) + u_SceneTime * 0.8);
+        float t_Wave1 = sin(dot(t_WavePos, vec2(-0.09, 0.25)) + u_SceneTime * 0.55);
+        vec3 t_WaterNormal = normalize(vec3(0.02 * (t_Wave0 + 0.5 * t_Wave1), 0.02 * (t_Wave1 - 0.5 * t_Wave0), 1.0));
+
+        // Grazing angles mirror the sky, straight down looks into the water: the Fresnel term
+        // between the two is what gives the horizon its pale band and the foreground its blue.
+        vec3 t_Reflected = reflect(-t_WorldDirectionToEye, t_WaterNormal);
+        t_Reflected.z = abs(t_Reflected.z);
+        vec3 t_SkyReflection = CalcSkyColor(t_Reflected);
+
+        float t_ViewDot = saturate(dot(t_WaterNormal, t_WorldDirectionToEye));
+        float t_Fresnel = 0.02 + 0.98 * pow(1.0 - t_ViewDot, 5.0);
+
+        // Looking into the water, from a shallow blue-green to the deep blue further out.
+        vec3 t_ShallowColor = vec3(0.014, 0.153, 0.216);
+        vec3 t_DeepColor = vec3(0.004, 0.032, 0.083);
+        vec3 t_WaterColor = mix(t_DeepColor, t_ShallowColor, t_ViewDot);
+
+        t_FinalColor = mix(t_WaterColor, t_SkyReflection, t_Fresnel);
+
+        // The sun's glint, tight enough to read as a highlight rather than a second sun.
+        float t_SunDot = saturate(dot(t_Reflected, u_KeyLightDir.xyz));
+        t_FinalColor += u_FogSunColor.rgb * pow(t_SunDot, 350.0) * 6.0;
+    }
 
     // TODO(jstpierre): Fog
 
@@ -666,7 +705,7 @@ export class Render_Material_Cache {
 
 const scratchColor = colorNewCopy(White);
 const scratchAABB = new AABB();
-const ASSET_LOADS_PER_FRAME = 16;
+const ASSET_LOADS_PER_FRAME = 64;
 
 const scratchVec3a = vec3.create();
 const scratchVec3b = vec3.create();
@@ -998,6 +1037,14 @@ export class TheWitnessRenderer implements SceneGfx {
 
         globals.asset_loads_remaining = ASSET_LOADS_PER_FRAME;
 
+        // Entities outside the cluster system -- the water among them -- come first. There are
+        // far fewer of them than there are cluster elements, and going second left them at the
+        // back of a queue the clusters never emptied, so the sea never arrived.
+        for (let i = 0; i < globals.entity_render_list.unclustered_entities.length; i++) {
+            const entity = globals.entity_render_list.unclustered_entities[i];
+            entity.prepareToRender(globals, this.renderHelper.renderInstManager);
+        }
+
         // Go through each entity cluster.
         for (let i = 0; i < globals.entity_render_list.clusters.length; i++) {
             const cluster = globals.entity_render_list.clusters[i];
@@ -1020,10 +1067,6 @@ export class TheWitnessRenderer implements SceneGfx {
             }
         }
 
-        for (let i = 0; i < globals.entity_render_list.unclustered_entities.length; i++) {
-            const entity = globals.entity_render_list.unclustered_entities[i];
-            entity.prepareToRender(globals, this.renderHelper.renderInstManager);
-        }
 
         this.skydome.prepareToRender(globals, this.renderHelper.renderInstManager);
 

--- a/src/TheWitness/Render.ts
+++ b/src/TheWitness/Render.ts
@@ -94,11 +94,18 @@ layout(std140) uniform ub_SceneParams {
     // xyz: what the sky says the baked light is worth (lightmap_color * lightmap_brightness).
     // w: the sky's own brightness.
     vec4 u_LightMapScale;
+    // xy: the world point the shadow map's first texel stands over, z: 1 / the world size it
+    // covers, w: the height its zero reads as.
+    vec4 u_ShadowMapParams;
+    // x: the height range its full scale spans, y: 1 once the map is there, z: depth bias,
+    // w: the height range the shadow edge is softened over.
+    vec4 u_ShadowMapDecode;
 };
 
 #define u_WindDirection (vec3(u_CameraPosWorld.w, u_KeyLightDir.w, 0.0))
 #define u_SceneTime (u_KeyLightColor.w)
 #define u_SkyBrightness (u_LightMapScale.w)
+#define u_ShadowMapEnabled (u_ShadowMapDecode.y)
 
 layout(std140) uniform ub_ObjectParams {
     Mat3x4 u_ModelMatrix;
@@ -134,6 +141,9 @@ uniform sampler2D u_LightMap0;
 uniform sampler2D u_LightMap1;
 
 uniform sampler2D u_TerrainColor;
+
+// The height at which the sun arrives, over every column of the world; see Shadow_Map.
+uniform sampler2D u_ShadowMap;
 
 // The scene as it stood before the water was drawn over it; see the 'Water' pass.
 uniform sampler2D u_SceneColor;
@@ -508,13 +518,17 @@ void mainPS() {
 
     bool use_lightmap = ${this.is_flag(m, Material_Flags.Lightmapped)};
 
-    // How much of the sky this surface can see, as the bake understands it. The game shadow-maps
-    // its sun; without that, a directional light reaches everywhere -- through a hillside and
-    // into a cave, which came out as brightly lit as the shore. The baked lighting already knows
-    // what is buried and what is open, so it stands in for the shadow: dark bakes take little
-    // sun, open ones take it all. The floor keeps surfaces whose lightmap is missing or has yet
-    // to stream in from going black.
+    // Whether the sun reaches this surface at all. The world ships a height field of itself,
+    // swept along the sun into the height at which its light arrives, so the question is just
+    // whether this point stands above that height -- which works for geometry that is nowhere
+    // near here, and for geometry that has yet to stream in.
     float t_SunVisibility = 1.0;
+    if (u_ShadowMapEnabled > 0.0) {
+        vec2 t_ShadowCoord = (u_ShadowMapParams.xy - v_PositionWorld.yx) * u_ShadowMapParams.z;
+        float t_SunReachesHeight = u_ShadowMapParams.w - texture(SAMPLER_2D(u_ShadowMap), t_ShadowCoord).r * u_ShadowMapDecode.x;
+        float t_AboveShadow = v_PositionWorld.z - t_SunReachesHeight + u_ShadowMapDecode.z;
+        t_SunVisibility = smoothstep(0.0, u_ShadowMapDecode.w, t_AboveShadow);
+    }
 
     vec3 t_LightMapSample = vec3(0.0);
     if (use_lightmap) {
@@ -526,8 +540,12 @@ void mainPS() {
             t_LightMapSample = CalcLightMapColor(v_LightMapData.xy);
         }
 
-        float t_BakedBrightness = dot(t_LightMapSample * u_LightMapScale.rgb, vec3(0.2126, 0.7152, 0.0722));
-        t_SunVisibility = clamp(t_BakedBrightness * 0.35, 0.15, 1.0);
+        // Without the map, the bake stands in for it: it already knows what is buried and what
+        // is open, so dark bakes take little sun and open ones take it all.
+        if (u_ShadowMapEnabled == 0.0) {
+            float t_BakedBrightness = dot(t_LightMapSample * u_LightMapScale.rgb, vec3(0.2126, 0.7152, 0.0722));
+            t_SunVisibility = clamp(t_BakedBrightness * 0.35, 0.15, 1.0);
+        }
     }
 
     // Add directional light.
@@ -754,14 +772,14 @@ const ASSET_LOADS_PER_FRAME = 64;
 const scratchVec3a = vec3.create();
 const scratchVec3b = vec3.create();
 const scratchMatrix = mat4.create();
-const KEY_LIGHT_STRENGTH = 8.0;
+const KEY_LIGHT_STRENGTH = 12.0;
 class Device_Material {
     public visible: boolean = true;
 
     private shader_instance: TheWitnessShaderInstance;
     private gfx_program: GfxProgram;
     private texture_map: (Texture_Asset | null)[] = nArray(3, () => null);
-    private texture_mapping_array: TextureMapping[] = nArray(12, () => new TextureMapping());
+    private texture_mapping_array: TextureMapping[] = nArray(13, () => new TextureMapping());
     public is_water: boolean = false;
 
     public sortKeyBase = 0;
@@ -808,6 +826,11 @@ class Device_Material {
         this.load_texture(globals, 9, 'white', clamp_sampler);
         this.load_texture(globals, 10, 'white', clamp_sampler);
 
+        if (globals.shadow_map !== null && globals.shadow_map.enabled)
+            this.texture_mapping_array[12].copy(globals.shadow_map.texture_mapping);
+        else
+            this.load_texture(globals, 12, 'white', clamp_sampler);
+
         this.shader_instance = globals.device_material_cache.create_shader_instance(this.render_material);
         this.gfx_program = this.shader_instance.getGfxProgram(globals.renderCache);
 
@@ -815,8 +838,8 @@ class Device_Material {
         this.is_water = material_type === Material_Type.Lake;
         if (this.is_water) {
             this.texture_mapping_array.push(new TextureMapping(), new TextureMapping());
-            this.texture_mapping_array[12].lateBinding = 'scene-color';
-            this.texture_mapping_array[13].lateBinding = 'scene-depth';
+            this.texture_mapping_array[13].lateBinding = 'scene-color';
+            this.texture_mapping_array[14].lateBinding = 'scene-depth';
         }
 
         // Disable invisible material types.
@@ -972,7 +995,7 @@ export class Mesh_Instance {
 // The scene depth the water reads is a depth texture, and the platform checks that the shader
 // says so; everything else here is an ordinary colour map.
 const samplerEntries: GfxBindingLayoutSamplerDescriptor[] = nArray(16, () => ({ dimension: GfxTextureDimension.n2D, formatKind: GfxSamplerFormatKind.Float }));
-samplerEntries[13] = { dimension: GfxTextureDimension.n2D, formatKind: GfxSamplerFormatKind.Depth, comparison: false };
+samplerEntries[14] = { dimension: GfxTextureDimension.n2D, formatKind: GfxSamplerFormatKind.Depth, comparison: false };
 
 const bindingLayouts: GfxBindingLayoutDescriptor[] = [
     { numUniformBuffers: 2, numSamplers: 16, samplerEntries, },
@@ -1001,32 +1024,12 @@ class Skydome {
     }
 }
 
-export class Cached_Shadow_Map {
-    public texture_mapping = nArray(1, () => new TextureMapping());
-    private shadow_map_size = 8192;
-
-    constructor(globals: TheWitnessGlobals, world: Entity_World) {
-        const texture_name = `${globals.entity_manager.universe_name}_shadow_map_${this.shadow_map_size}`;
-
-        const clamp_sampler = globals.renderCache.createSampler({
-            minFilter: GfxTexFilterMode.Bilinear,
-            magFilter: GfxTexFilterMode.Bilinear,
-            mipFilter: GfxMipFilterMode.Linear,
-            wrapS: GfxWrapMode.Clamp,
-            wrapT: GfxWrapMode.Clamp,
-        });
-
-        load_texture(globals, this.texture_mapping[0], texture_name, clamp_sampler);
-    }
-}
-
 export class TheWitnessRenderer implements SceneGfx {
     public renderHelper: GfxRenderHelper;
     private renderInstListMain = new GfxRenderInstList();
     private renderInstListWater = new GfxRenderInstList();
 
     private skydome: Skydome;
-    private cached_shadow_map: Cached_Shadow_Map | null = null;
 
     private post_process: Post_Process;
     private sceneColorSampler: GfxSampler;
@@ -1049,9 +1052,6 @@ export class TheWitnessRenderer implements SceneGfx {
             wrapT: GfxWrapMode.Clamp,
         });
         this.skydome = new Skydome(globals);
-
-        const world = this.globals.entity_manager.flat_entity_list.find((e) => e instanceof Entity_World) as Entity_World;
-        // this.cached_shadow_map = new Cached_Shadow_Map(globals, world);
 
         globals.debug_draw = this.renderHelper.debugDraw;
         globals.water_render_inst_list = this.renderInstListWater;
@@ -1102,7 +1102,7 @@ export class TheWitnessRenderer implements SceneGfx {
         viewpoint.setupFromCamera(viewerInput.camera);
         this.renderHelper.debugDraw.beginFrame(viewpoint.clipFromViewMatrix, viewpoint.viewFromWorldMatrix, viewerInput.backbufferWidth, viewerInput.backbufferHeight);
 
-        let offs = template.allocateUniformBuffer(TheWitnessShaderTemplate.ub_SceneParams, 64);
+        let offs = template.allocateUniformBuffer(TheWitnessShaderTemplate.ub_SceneParams, 72);
         const d = template.mapUniformBufferF32(TheWitnessShaderTemplate.ub_SceneParams);
         offs += fillMatrix4x4(d, offs, viewpoint.clipFromWorldMatrix);
         mat4.invert(scratchMatrix, viewpoint.clipFromWorldMatrix);
@@ -1112,9 +1112,10 @@ export class TheWitnessRenderer implements SceneGfx {
         vec3.set(scratchVec3a, misc.sun_x as number, misc.sun_y as number, misc.sun_z as number);
         vec3.normalize(scratchVec3a, scratchVec3a);
         offs += fillVec3v(d, offs, scratchVec3a, misc.wind_y as number);
-        // The game shadow-maps its sun; this doesn't, so a directional term at full strength
-        // lands on faces the sun can't reach and flattens the bake underneath it. Turned down,
-        // it still lifts the chunks whose lightmaps are dark without washing out the rest.
+        // The bakes in this build carry the sky and the bounce, not the sun, so the directional
+        // term is what separates a lit face from a shaded one. It could only be kept low while
+        // it reached everywhere; now that Shadow_Map holds it off what the sun cannot see, it
+        // can be turned up far enough to read as sunlight without washing the stone out.
         offs += fillVec4(d, offs, KEY_LIGHT_STRENGTH, KEY_LIGHT_STRENGTH, KEY_LIGHT_STRENGTH, globals.scene_time);
 
         const render_sky = globals.sky_variables['render/sky'];
@@ -1129,6 +1130,15 @@ export class TheWitnessRenderer implements SceneGfx {
             (render_sky.lightmap_color_y as number) * lightmap_brightness,
             (render_sky.lightmap_color_z as number) * lightmap_brightness,
             render_sky.brightness as number);
+
+        const shadow_map = globals.shadow_map;
+        if (shadow_map !== null && shadow_map.enabled) {
+            offs += fillVec4(d, offs, shadow_map.world_origin[0], shadow_map.world_origin[1], shadow_map.inv_world_size, shadow_map.z_max);
+            offs += fillVec4(d, offs, shadow_map.z_range, 1.0, shadow_map.depth_bias, shadow_map.penumbra);
+        } else {
+            offs += fillVec4(d, offs, 0.0, 0.0, 0.0, 0.0);
+            offs += fillVec4(d, offs, 1.0, 0.0, 0.0, 1.0);
+        }
 
         globals.occlusion_manager.prepareToRender(globals, this.renderHelper.renderInstManager);
 
@@ -1202,36 +1212,6 @@ export class TheWitnessRenderer implements SceneGfx {
         const builder = this.renderHelper.renderGraph.newGraphBuilder();
 
         globals.occlusion_manager.pushPasses(globals, builder, renderInstManager);
-
-        if (this.cached_shadow_map !== null) {
-            const shadowDepthDesc = new GfxrRenderTargetDescription(GfxFormat.D24);
-            shadowDepthDesc.setDimensions(1024, 1024, 1);
-
-            const shadowDepthTargetID = builder.createRenderTargetID(shadowDepthDesc, 'Main Depth');
-            builder.pushPass((pass) => {
-                pass.setDebugName('Cached Shadow Map');
-                pass.attachRenderTargetID(GfxrAttachmentSlot.DepthStencil, shadowDepthTargetID);
-
-                const renderHelper = this.renderHelper;
-                const renderInst = renderHelper.renderInstManager.newRenderInst();
-                renderInst.setUniformBuffer(renderHelper.uniformBuffer);
-                renderInst.setAllowSkippingIfPipelineNotReady(false);
-
-                renderInst.setMegaStateFlags(fullscreenMegaState);
-                renderInst.setBindingLayouts([{ numUniformBuffers: 0, numSamplers: 1 }]);
-                renderInst.setDrawCount(3);
-
-                const copyProgram = new DepthCopyProgram();
-                const gfxProgram = renderHelper.renderCache.createProgram(copyProgram);
-
-                renderInst.setGfxProgram(gfxProgram);
-
-                pass.exec((passRenderer) => {
-                    renderInst.setSamplerBindingsFromTextureMappings(this.cached_shadow_map!.texture_mapping);
-                    renderInst.drawOnPass(renderHelper.renderCache, passRenderer);
-                });
-            });
-        }
 
         // The scene is rendered in float, so the sun and sky keep their range until tone mapping.
         const mainColorDesc = makeBackbufferDescSimple(GfxrAttachmentSlot.Color0, viewerInput, standardFullClearRenderPassDescriptor);

--- a/src/TheWitness/Render.ts
+++ b/src/TheWitness/Render.ts
@@ -589,7 +589,10 @@ void mainPS() {
     vec3 t_FinalColor = vec3(0.0);
     t_FinalColor.rgb += t_DiffuseLight.rgb * t_Albedo.rgb;
 
-    bool use_lake = ${this.is_type(m, Material_Type.Lake)};
+    // Lake is the sea and the big open water; Pool is the small still water -- the cave
+    // pools, the cisterns. They are the same material to look at, and a Pool left out of
+    // this branch has no albedo and no lightmap to fall back on, so it came out black.
+    bool use_lake = ${this.is_type(m, Material_Type.Lake) || this.is_type(m, Material_Type.Pool)};
     if (use_lake) {
         // What the scene looked like where this pixel is, before the water went over it. The
         // fragment coordinate indexes the framebuffer directly, so it needs no flipping.
@@ -629,7 +632,12 @@ void mainPS() {
         vec3 t_Extinction = vec3(0.29, 0.086, 0.062);
         vec3 t_Transmittance = exp(-t_Extinction * (t_WaterDepth * 2.0));
 
-        vec3 t_DeepColor = vec3(0.004, 0.033, 0.084);
+        // What comes back out of deep water is skylight scattered by the column, so it belongs in
+        // the same units as everything else the sky lights. The fixed colour this replaces was a
+        // hundredth of what u_LightMapScale is worth, so deep water went to black wherever the
+        // bottom was too far down to show through. The tint is that old constant normalised;
+        // what it now multiplies is the sky's own brightness.
+        vec3 t_DeepColor = vec3(0.048, 0.393, 1.0) * u_LightMapScale.rgb * 0.055;
         vec3 t_WaterColor = t_Bottom * t_Transmittance + t_DeepColor * (1.0 - t_Transmittance);
 
         t_FinalColor = mix(t_WaterColor, t_SkyReflection, t_Fresnel);
@@ -835,7 +843,7 @@ class Device_Material {
         this.gfx_program = this.shader_instance.getGfxProgram(globals.renderCache);
 
         // Water draws in its own pass, once the rest of the scene is there to be seen through it.
-        this.is_water = material_type === Material_Type.Lake;
+        this.is_water = material_type === Material_Type.Lake || material_type === Material_Type.Pool;
         if (this.is_water) {
             this.texture_mapping_array.push(new TextureMapping(), new TextureMapping());
             this.texture_mapping_array[13].lateBinding = 'scene-color';

--- a/src/TheWitness/Render.ts
+++ b/src/TheWitness/Render.ts
@@ -506,20 +506,34 @@ void mainPS() {
 
     bool t_HasIncomingLight = false;
 
-    // Add directional light.
-    CalcLight(t_HasIncomingLight, t_DiffuseLight, u_KeyLightDir.xyz, u_KeyLightColor.rgb, t_NormalWorld.xyz, t_WorldDirectionToEye.xyz);
-
     bool use_lightmap = ${this.is_flag(m, Material_Flags.Lightmapped)};
+
+    // How much of the sky this surface can see, as the bake understands it. The game shadow-maps
+    // its sun; without that, a directional light reaches everywhere -- through a hillside and
+    // into a cave, which came out as brightly lit as the shore. The baked lighting already knows
+    // what is buried and what is open, so it stands in for the shadow: dark bakes take little
+    // sun, open ones take it all. The floor keeps surfaces whose lightmap is missing or has yet
+    // to stream in from going black.
+    float t_SunVisibility = 1.0;
+
+    vec3 t_LightMapSample = vec3(0.0);
     if (use_lightmap) {
         bool use_vertex_lightmap = ${this.is_flag(m, Material_Flags.Vertex_Lightmap | Material_Flags.Vertex_Lightmap_Auto)};
 
-        vec3 t_LightMapSample;
         if (use_vertex_lightmap) {
             t_LightMapSample = v_LightMapData.xyz;
         } else {
             t_LightMapSample = CalcLightMapColor(v_LightMapData.xy);
         }
 
+        float t_BakedBrightness = dot(t_LightMapSample * u_LightMapScale.rgb, vec3(0.2126, 0.7152, 0.0722));
+        t_SunVisibility = clamp(t_BakedBrightness * 0.35, 0.15, 1.0);
+    }
+
+    // Add directional light.
+    CalcLight(t_HasIncomingLight, t_DiffuseLight, u_KeyLightDir.xyz, u_KeyLightColor.rgb * t_SunVisibility, t_NormalWorld.xyz, t_WorldDirectionToEye.xyz);
+
+    if (use_lightmap) {
         bool use_vegetation = ${this.is_type(m, Material_Type.Vegetation)};
         if (use_vegetation) {
             // Kill some of the existing light.

--- a/src/TheWitness/Scenes_TheWitness.ts
+++ b/src/TheWitness/Scenes_TheWitness.ts
@@ -6,6 +6,8 @@ import * as ZipFile from '../ZipFile.js';
 import { Asset_Manager } from "./Assets.js";
 import { TheWitnessGlobals } from "./Globals.js";
 import { TheWitnessRenderer } from "./Render.js";
+import { Shadow_Map } from "./Shadow_Map.js";
+import { Entity_World } from "./Entity.js";
 
 const pathBase = `TheWitness`;
 
@@ -24,6 +26,11 @@ class TheWitnessSceneDesc implements SceneDesc {
 
         const globals = new TheWitnessGlobals(device, asset_manager);
         globals.entity_manager.load_world(globals);
+
+        // Before anything builds a material: every one of them samples the sun's shadow.
+        const world = globals.entity_manager.flat_entity_list.find((e) => e instanceof Entity_World) as Entity_World | undefined;
+        if (world !== undefined)
+            globals.shadow_map = new Shadow_Map(globals, world);
 
         return new TheWitnessRenderer(device, globals);
     }

--- a/src/TheWitness/Shadow_Map.ts
+++ b/src/TheWitness/Shadow_Map.ts
@@ -1,0 +1,151 @@
+import { GfxDevice, GfxFormat, GfxTexture, GfxTextureDimension, GfxTextureUsage, GfxTexFilterMode, GfxMipFilterMode, GfxWrapMode } from "../gfx/platform/GfxPlatform.js";
+import { TextureMapping } from "../TextureHolder.js";
+import { Asset_Type } from "./Assets.js";
+import { TheWitnessGlobals } from "./Globals.js";
+import { Entity_World } from "./Entity.js";
+
+// What the game calls its shadow map is a height field: for every column of the world, the height
+// of the tallest thing standing in it, top-down, over the whole island. It is the only description
+// of the world's shape that is available all at once, which is what shadowing the sun needs -- a
+// surface has to know about geometry that is nowhere near it, and may not even be loaded.
+//
+// The rectangle it covers is not written down anywhere in the data. These numbers come from fitting
+// the field against the bounding boxes of the world-space meshes: the height it reports over a mesh
+// has to be the height of that mesh. The 2048 and 4096 maps were fitted separately and agreed on
+// the same rectangle to within half a percent, which is what says the fit is real.
+const WORLD_X_AT_ROW_0 = 515.0;
+const WORLD_Y_AT_COLUMN_0 = 518.4;
+const WORLD_SIZE = 1082.8;
+
+// A texel holds the tallest point in its footprint, so the ground reads as very slightly above
+// itself and every lit surface would otherwise shadow-acne. Half a metre of slack clears it.
+const DEPTH_BIAS = 0.5;
+// The sun has an angular size, and the field is a metre or so per texel in any case; softening the
+// comparison over a small height range stands in for a penumbra and hides the texel grid.
+const PENUMBRA = 1.5;
+
+const HEIGHT_MAP_SIZE = 2048;
+
+export class Shadow_Map {
+    public texture_mapping = new TextureMapping();
+    public enabled = false;
+
+    // The transform into the map, and back out of its 16-bit heights, as the shader wants them.
+    public world_origin: [number, number] = [WORLD_Y_AT_COLUMN_0, WORLD_X_AT_ROW_0];
+    public inv_world_size = 1.0 / WORLD_SIZE;
+    public z_max = 0.0;
+    public z_range = 1.0;
+    public depth_bias = DEPTH_BIAS;
+    public penumbra = PENUMBRA;
+
+    private texture: GfxTexture | null = null;
+
+    constructor(globals: TheWitnessGlobals, world: Entity_World) {
+        const name = `${globals.entity_manager.universe_name}_shadow_map_${HEIGHT_MAP_SIZE}`;
+        const bytes = globals.asset_manager.load_asset_bytes(Asset_Type.Texture, name);
+        if (bytes === null) {
+            console.warn(`TheWitness: no ${name}; the sun will not cast shadows`);
+            return;
+        }
+
+        const view = bytes.createDataView();
+        const width = view.getUint16(0x00, true), height = view.getUint16(0x02, true);
+        const d3d_format = view.getUint32(0x1C, true);
+        if (d3d_format !== 0x51) {
+            console.warn(`TheWitness: ${name} is not the 16-bit height field we expect (format 0x${d3d_format.toString(16)})`);
+            return;
+        }
+
+        // The field's own encoding: 0 is the top of the world, full scale is the bottom, so that
+        // a column with nothing in it saturates.
+        this.z_max = world.world_z_max;
+        this.z_range = world.world_z_max - world.world_z_min;
+
+        const heights = bytes.createTypedArray(Uint16Array, 0x20, width * height);
+        const shadow = this.sweep(globals, heights, width, height);
+
+        this.texture = globals.device.createTexture({
+            dimension: GfxTextureDimension.n2D,
+            width, height, depthOrArrayLayers: 1, numLevels: 1,
+            pixelFormat: GfxFormat.U16_R_NORM,
+            usage: GfxTextureUsage.Sampled,
+        });
+        globals.device.setResourceName(this.texture, `${name} (swept)`);
+        globals.device.uploadTextureData(this.texture, 0, [shadow]);
+
+        this.texture_mapping.gfxTexture = this.texture;
+        this.texture_mapping.gfxSampler = globals.renderCache.createSampler({
+            minFilter: GfxTexFilterMode.Bilinear,
+            magFilter: GfxTexFilterMode.Bilinear,
+            mipFilter: GfxMipFilterMode.Nearest,
+            wrapS: GfxWrapMode.Clamp,
+            wrapT: GfxWrapMode.Clamp,
+        });
+        this.enabled = true;
+    }
+
+    // Turn the height field into the height at which the sun arrives. Marching toward the sun per
+    // fragment would answer the same question and cost a dozen taps to do it; sweeping the field
+    // once along the sun instead answers it everywhere, and leaves the shader a single lookup.
+    //
+    // Reading along the sun's own direction, the shadow cast forward from everything behind falls
+    // away at exactly the sun's slope, so each texel only has to look at the one upstream of it:
+    //     shadow(p) = max(height(p), shadow(p - sun_step) - slope * step)
+    private sweep(globals: TheWitnessGlobals, heights: Uint16Array, width: number, height: number): Uint16Array {
+        const misc = globals.all_variables.misc;
+        const sun_x = misc.sun_x as number, sun_y = misc.sun_y as number, sun_z = misc.sun_z as number;
+        const sun_horizontal = Math.hypot(sun_x, sun_y);
+        const slope = sun_z / sun_horizontal;
+
+        // World +x runs along -row and world +y along -column, so the shadows travel this way.
+        const du = sun_y / sun_horizontal, dv = sun_x / sun_horizontal;
+        const units_per_texel = WORLD_SIZE / width;
+
+        // Step along whichever axis the sun leans on, so that every texel is written exactly once
+        // and reads a predecessor that has already been written.
+        const along_rows = Math.abs(dv) >= Math.abs(du);
+        const steps = along_rows ? height : width;
+        const lanes = along_rows ? width : height;
+        const lane_drift = along_rows ? du / dv : dv / du;
+        const forward = (along_rows ? dv : du) > 0;
+        const index = along_rows ? (s: number, l: number) => s * width + l : (s: number, l: number) => l * width + s;
+
+        const fall = Math.hypot(1.0, lane_drift) * units_per_texel * slope;
+        // Heights are stored top-down, so the sun eating into a shadow *raises* the stored value.
+        const fall_encoded = (fall / this.z_range) * 65535.0;
+
+        const shadow = new Uint16Array(width * height);
+        const first = forward ? 0 : steps - 1;
+        for (let l = 0; l < lanes; l++)
+            shadow[index(first, l)] = heights[index(first, l)];
+
+        const direction = forward ? 1 : -1;
+        for (let k = 1; k < steps; k++) {
+            const s = forward ? k : steps - 1 - k;
+            const previous = s - direction;
+            // The predecessor along the sun sits a fraction of a texel to the side; take it linearly.
+            const drift = -direction * lane_drift;
+            for (let l = 0; l < lanes; l++) {
+                const source = l + drift;
+                const l0 = Math.floor(source), t = source - l0, l1 = l0 + 1;
+                let carried = 65535.0;
+                if (l0 >= 0 && l1 < lanes)
+                    carried = shadow[index(previous, l0)] * (1.0 - t) + shadow[index(previous, l1)] * t;
+                else if (l0 >= 0 && l0 < lanes)
+                    carried = shadow[index(previous, l0)];
+
+                // min, because a smaller stored value is a greater height.
+                const here = heights[index(s, l)];
+                const decayed = carried + fall_encoded;
+                shadow[index(s, l)] = Math.min(here, decayed < 65535.0 ? decayed : 65535.0);
+            }
+        }
+
+        return shadow;
+    }
+
+    public destroy(device: GfxDevice): void {
+        if (this.texture !== null)
+            device.destroyTexture(this.texture);
+    }
+}

--- a/src/TheWitness/Stream.ts
+++ b/src/TheWitness/Stream.ts
@@ -4,11 +4,15 @@ import { colorNewFromRGBA, Color } from "../Color.js";
 import { vec2, vec3, quat, vec4 } from "gl-matrix";
 
 export class Stream {
-    private offset: number = 0;
+    public offset: number = 0;
     private view: DataView;
 
     constructor(private buffer: ArrayBufferSlice) {
         this.view = buffer.createDataView();
+    }
+
+    public get byteLength(): number {
+        return this.buffer.byteLength;
     }
 
     public readUint8(): number {

--- a/src/gfx/platform/GfxPlatformWebGL2.ts
+++ b/src/gfx/platform/GfxPlatformWebGL2.ts
@@ -555,6 +555,9 @@ class GfxImplP_GL implements GfxSwapChain, GfxDevice {
         this._EXT_texture_filter_anisotropic = gl.getExtension('EXT_texture_filter_anisotropic');
         this._EXT_texture_norm16 = gl.getExtension('EXT_texture_norm16');
         this._KHR_parallel_shader_compile = gl.getExtension('KHR_parallel_shader_compile');
+        // Float colour targets aren't renderable in WebGL2 without this; asking for it costs
+        // nothing where it isn't used, and a scene that renders in HDR can't work without it.
+        gl.getExtension('EXT_color_buffer_float');
         this._OES_texture_float_linear = gl.getExtension('OES_texture_float_linear');
         this._OES_texture_half_float_linear = gl.getExtension('OES_texture_half_float_linear');
         this._OES_draw_buffers_indexed = gl.getExtension('OES_draw_buffers_indexed');

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,9 +1,21 @@
 
 import ArrayBufferSlice from './ArrayBufferSlice.js';
 
+let assertLogStacks = true;
+
+// Speculative parsers (see TheWitness/Entity_Types.ts) trip asserts by the thousand while
+// probing a stream for a record boundary; capturing a stack for each one costs far more than
+// the parse itself. Returns the previous setting, so callers can restore it when they're done.
+export function setAssertLogStacks(v: boolean): boolean {
+    const old = assertLogStacks;
+    assertLogStacks = v;
+    return old;
+}
+
 export function assert(b: boolean, message: string = ""): asserts b {
     if (!b) {
-        console.error(new Error().stack);
+        if (assertLogStacks)
+            console.error(new Error().stack);
         throw new Error(`Assert fail: ${message}`);
     }
 }


### PR DESCRIPTION
The Witness importer was written against an older build than the one that ships today, and nothing in it loaded — the mesh mismatch alone took the renderer process down at ~7.4GB. This gets the current build loading, and brings the picture up close to the game's own.

**Formats.** Meshes 0x31, lightmaps 0x13, textures 0x16, plus D3DFMT_A8 and A8L8. Entity records carry no length prefix, so a type whose revision is newer — or that has no implementation — desyncs everything after it; records resync by probing forward for the next clean boundary, and five types turned out to have gained a field. 48,939 of 49,485 load.

**Streaming.** ~48,000 entities is more than a renderer process can hold, so assets are built on first draw, a cluster at a time, under a per-frame budget prioritised by how much of the screen an entity stands to cover — the foreground arrives first. LOD now uses the levels a mesh actually has.

**Look.** The scene renders to F16_RGBA through the game's own chain, reading sky.variables, tone_mapping.variables and bloom.variables (the last two ship as their own files and were never loaded). The sun is shadowed by sweeping the height field the game ships, which keeps daylight out of the caves. Lakes and cave pools shade as still water, with depth extinction and a screen-space reflection.

Outside src/TheWitness/: GfxPlatformWebGL2.ts asks for EXT_color_buffer_float, without which a float target silently draws nothing; util.ts gains setAssertLogStacks(), since the boundary probe trips asserts by the thousand by design.


<img width="3840" height="2160" alt="HRVfyUzbYAA1Nk2" src="https://github.com/user-attachments/assets/b757b759-8ef3-4fe9-8afb-8a6b49f4e9ce" />
<img width="3696" height="1996" alt="screenshot-2026-09-13_12-59-22" src="https://github.com/user-attachments/assets/49a47e43-9924-42d3-935f-70930a0875d1" />
<img width="3687" height="1981" alt="screenshot-2026-09-13_13-00-00" src="https://github.com/user-attachments/assets/62445424-0177-4f80-9e7c-8a5cf7cced86" />
<img width="3840" height="2160" alt="screenshot-2026-09-13_13-02-37" src="https://github.com/user-attachments/assets/7eb8e91e-0a1c-4bfc-9af1-4225428489f8" />
<img width="3840" height="2160" alt="screenshot-2026-09-13_13-00-56" src="https://github.com/user-attachments/assets/f1ec07f0-fa81-45d1-8cda-0bdf6999cbf1" />
<img width="3168" height="1962" alt="screenshot-2026-09-13_12-58-40" src="https://github.com/user-attachments/assets/27d2e4b9-ae15-472a-94ef-db1074efa88f" />


## Pull Request Checklist

Please check one of the boxes below:
- [X] Generative AI was used in the creation of this PR (for any part, including but not limited to coding, reverse engineering, or debugging). I have read [AI Contributions Policy](https://github.com/magcius/noclip.website/blob/main/README.md#ai-contributions-policy). 
- [ ] Generative AI was not used in the creation of this PR.

Note: Not all comments are human-authored.